### PR TITLE
Various fixes, update to create-root.bat and a new syscall

### DIFF
--- a/src/tools/create-root.bat
+++ b/src/tools/create-root.bat
@@ -26,6 +26,7 @@ COPY /B /Y C:\Users\Default\NTUSER.DAT "%EMU_REGDIR%\NTUSER.DAT"
 
 CALL :collect advapi32.dll
 CALL :collect bcrypt.dll
+CALL :collect bcryptprimitives.dll
 CALL :collect cfgmgr32.dll
 CALL :collect ci.dll
 CALL :collect combase.dll
@@ -118,8 +119,18 @@ CALL :collect wintypes.dll
 CALL :collect slwga.dll
 CALL :collect sppc.dll
 CALL :collect kernel.appcore.dll
+CALL :collect winnlsres.dll
+CALL :collect nlsbres.dll
+CALL :collect netutils.dll
+CALL :collect dinput8.dll
+CALL :collect d3d10.dll
+CALL :collect d3d10core.dll
+CALL :collect cabinet.dll
+CALL :collect msacm32.dll
 
 CALL :collect locale.nls
+CALL :collect c_1252.nls
+CALL :collect c_850.nls
 
 EXIT /B 0
 

--- a/src/tools/create-root.bat
+++ b/src/tools/create-root.bat
@@ -26,7 +26,6 @@ COPY /B /Y C:\Users\Default\NTUSER.DAT "%EMU_REGDIR%\NTUSER.DAT"
 
 CALL :collect advapi32.dll
 CALL :collect bcrypt.dll
-CALL :collect bcryptprimitives.dll
 CALL :collect cfgmgr32.dll
 CALL :collect ci.dll
 CALL :collect combase.dll

--- a/src/windows-emulator/registry/registry_manager.cpp
+++ b/src/windows-emulator/registry/registry_manager.cpp
@@ -105,7 +105,22 @@ std::optional<registry_key> registry_manager::get_key(const utils::path_key& key
         return {std::move(reg_key)};
     }
 
-    const auto* entry = iterator->second->get_sub_key(reg_key.path.get());
+    auto path = reg_key.path.get();
+    const auto* entry = iterator->second->get_sub_key(path);
+
+    if (!entry)
+    {
+        constexpr std::wstring_view wowPrefix = L"wow6432node\\";
+
+        const auto pathStr = path.wstring();
+        if (pathStr.starts_with(wowPrefix))
+        {
+            path = pathStr.substr(wowPrefix.size());
+            reg_key.path = path;
+            entry = iterator->second->get_sub_key(path);
+        }
+    }
+
     if (!entry)
     {
         return std::nullopt;

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -259,6 +259,8 @@ namespace syscalls
     NTSTATUS handle_NtUnmapViewOfSection(const syscall_context& c, handle process_handle, uint64_t base_address);
     NTSTATUS handle_NtUnmapViewOfSectionEx(const syscall_context& c, handle process_handle, uint64_t base_address,
                                            ULONG /*flags*/);
+    NTSTATUS handle_NtAreMappedFilesTheSame(const syscall_context& c, emulator_pointer address1,
+                                            emulator_pointer address2);
 
     // syscalls/semaphore.cpp:
     NTSTATUS handle_NtOpenSemaphore(const syscall_context& c, emulator_object<handle> semaphore_handle,
@@ -866,6 +868,7 @@ void syscall_dispatcher::add_handlers(std::map<std::string, syscall_handler>& ha
     add_handler(NtFsControlFile);
     add_handler(NtQueryFullAttributesFile);
     add_handler(NtFlushBuffersFile);
+    add_handler(NtAreMappedFilesTheSame);
     add_handler(NtUserGetProcessWindowStation);
     add_handler(NtUserRegisterClassExWOW);
     add_handler(NtUserUnregisterClass);

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -259,8 +259,7 @@ namespace syscalls
     NTSTATUS handle_NtUnmapViewOfSection(const syscall_context& c, handle process_handle, uint64_t base_address);
     NTSTATUS handle_NtUnmapViewOfSectionEx(const syscall_context& c, handle process_handle, uint64_t base_address,
                                            ULONG /*flags*/);
-    NTSTATUS handle_NtAreMappedFilesTheSame(const syscall_context& c, emulator_pointer address1,
-                                            emulator_pointer address2);
+    NTSTATUS handle_NtAreMappedFilesTheSame();
 
     // syscalls/semaphore.cpp:
     NTSTATUS handle_NtOpenSemaphore(const syscall_context& c, emulator_object<handle> semaphore_handle,

--- a/src/windows-emulator/syscalls/process.cpp
+++ b/src/windows-emulator/syscalls/process.cpp
@@ -309,6 +309,11 @@ namespace syscalls
                     const auto tls_vector = teb.ThreadLocalStoragePointer;
                     constexpr auto ptr_size = sizeof(EmulatorTraits<Emu64>::PVOID);
 
+                    if (!tls_vector)
+                    {
+                        return;
+                    }
+
                     if (tls_info.TlsRequest == ProcessTlsReplaceIndex)
                     {
                         const auto tls_entry_ptr = tls_vector + (tls_info.TlsIndex * ptr_size);

--- a/src/windows-emulator/syscalls/registry.cpp
+++ b/src/windows-emulator/syscalls/registry.cpp
@@ -239,7 +239,7 @@ namespace syscalls
 
     NTSTATUS handle_NtSetInformationKey()
     {
-        return STATUS_NOT_SUPPORTED;
+        return STATUS_SUCCESS;
     }
 
     NTSTATUS handle_NtEnumerateKey(const syscall_context& c, const handle key_handle, const ULONG index,

--- a/src/windows-emulator/syscalls/section.cpp
+++ b/src/windows-emulator/syscalls/section.cpp
@@ -304,4 +304,10 @@ namespace syscalls
     {
         return handle_NtUnmapViewOfSection(c, process_handle, base_address);
     }
+
+    NTSTATUS handle_NtAreMappedFilesTheSame(const syscall_context& c, const emulator_pointer address1,
+                                            const emulator_pointer address2)
+    {
+        return STATUS_NOT_SUPPORTED;
+    }
 }

--- a/src/windows-emulator/syscalls/section.cpp
+++ b/src/windows-emulator/syscalls/section.cpp
@@ -143,6 +143,7 @@ namespace syscalls
             constexpr auto windows_dir_offset = 0x10;
             c.emu.write_memory(address + 8, windows_dir_offset);
 
+            // aka. BaseStaticServerData (BASE_STATIC_SERVER_DATA)
             const auto obj_address = address + windows_dir_offset;
 
             const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> windir_obj{c.emu, obj_address};
@@ -167,6 +168,8 @@ namespace syscalls
                 c.proc.base_allocator.make_unicode_string(ucs, u"\\Sessions\\1\\BaseNamedObjects");
                 ucs.Buffer = ucs.Buffer - obj_address;
             });
+
+            c.emu.write_memory(obj_address + 0x9C8, 0xFFFFFFFF); // TIME_ZONE_ID_INVALID
 
             if (view_size)
             {

--- a/src/windows-emulator/syscalls/section.cpp
+++ b/src/windows-emulator/syscalls/section.cpp
@@ -308,8 +308,7 @@ namespace syscalls
         return handle_NtUnmapViewOfSection(c, process_handle, base_address);
     }
 
-    NTSTATUS handle_NtAreMappedFilesTheSame(const syscall_context& c, const emulator_pointer address1,
-                                            const emulator_pointer address2)
+    NTSTATUS handle_NtAreMappedFilesTheSame()
     {
         return STATUS_NOT_SUPPORTED;
     }


### PR DESCRIPTION
This PR aims to:
- [Update `create-root.bat`](https://github.com/momo5502/sogen/commit/21fc460db83192464ce0f8773a92ecedb5acbe4f) with more dlls and NLS-related files.
- [Retry loading using normal path when wow6432node path is not found](https://github.com/momo5502/sogen/commit/16e7cac48af4e88c3ee3710a6e3a335e1486adb5), I'm not sure if this is the right thing to do, but I guess Windows does something like this behind the scenes because the saved `wow6432node` doesn't contain all the keys that exist when you look at it in regedit.
- [Add stub for NtAreMappedFilesTheSame and modify NtSetInformationKey to return success](https://github.com/momo5502/sogen/commit/8dfcf2755c3fca1da36a2334ad40c4e55728a048).
- [Simplify the TimeZone query fix](https://github.com/momo5502/sogen/commit/39d40a7f2f588fdba9d3292d1faa1357789b72da), this was necessary because... turns out all the stuff I wrote in NtConnectPort was unnecessary and caused some regressions, all I needed to change was `NtMapViewOfSection`.
- [Fix vm crash when teb.ThreadLocalStoragePointer is null](https://github.com/momo5502/sogen/commit/134b45d1e8107ad1637531c7d084fa22b1143ad3), but I'm not sure if this was a small oversight or something more fundamentally wrong.