### PR TITLE
Add new tests and some syscall fixes

### DIFF
--- a/src/common/platform/process.hpp
+++ b/src/common/platform/process.hpp
@@ -770,6 +770,12 @@ struct TOKEN_USER64
     SID_AND_ATTRIBUTES64 User;
 };
 
+struct TOKEN_GROUPS64
+{
+    ULONG GroupCount;
+    SID_AND_ATTRIBUTES64 Groups[1];
+};
+
 struct TOKEN_OWNER64
 {
     EMULATOR_CAST(EmulatorTraits<Emu64>::PVOID, PSID) Owner;

--- a/src/tools/create-root.bat
+++ b/src/tools/create-root.bat
@@ -130,6 +130,7 @@ CALL :collect msacm32.dll
 CALL :collect locale.nls
 CALL :collect c_1252.nls
 CALL :collect c_850.nls
+CALL :collect c_437.nls
 
 EXIT /B 0
 

--- a/src/windows-emulator/registry/registry_manager.cpp
+++ b/src/windows-emulator/registry/registry_manager.cpp
@@ -110,12 +110,12 @@ std::optional<registry_key> registry_manager::get_key(const utils::path_key& key
 
     if (!entry)
     {
-        constexpr std::wstring_view wowPrefix = L"wow6432node\\";
+        constexpr std::wstring_view wowPrefix = L"wow6432node";
 
         const auto pathStr = path.wstring();
         if (pathStr.starts_with(wowPrefix))
         {
-            path = pathStr.substr(wowPrefix.size());
+            path = pathStr.substr(wowPrefix.size() + 1);
             reg_key.path = path;
             entry = iterator->second->get_sub_key(path);
         }

--- a/src/windows-emulator/syscalls/system.cpp
+++ b/src/windows-emulator/syscalls/system.cpp
@@ -105,6 +105,7 @@ namespace syscalls
         case SystemFeatureConfigurationInformation:
         case SystemSupportedProcessorArchitectures2:
         case SystemFeatureConfigurationSectionInformation:
+        case SystemFirmwareTableInformation:
             return STATUS_NOT_SUPPORTED;
 
         case SystemControlFlowTransition:

--- a/src/windows-emulator/syscalls/token.cpp
+++ b/src/windows-emulator/syscalls/token.cpp
@@ -75,6 +75,26 @@ namespace syscalls
             return STATUS_SUCCESS;
         }
 
+        if (token_information_class == TokenGroups)
+        {
+            constexpr auto required_size = sizeof(TOKEN_GROUPS64) + sizeof(sid);
+            return_length.write(required_size);
+
+            if (required_size > token_information_length)
+            {
+                return STATUS_BUFFER_TOO_SMALL;
+            }
+
+            TOKEN_GROUPS64 groups{};
+            groups.GroupCount = 1;
+            groups.Groups[0].Attributes = SE_GROUP_ENABLED | SE_GROUP_ENABLED_BY_DEFAULT | SE_GROUP_MANDATORY;
+            groups.Groups[0].Sid = token_information + sizeof(TOKEN_GROUPS64);
+
+            emulator_object<TOKEN_GROUPS64>{c.emu, token_information}.write(groups);
+            c.emu.write_memory(token_information + sizeof(TOKEN_GROUPS64), sid, sizeof(sid));
+            return STATUS_SUCCESS;
+        }
+
         if (token_information_class == TokenOwner)
         {
             constexpr auto required_size = sizeof(sid) + sizeof(TOKEN_OWNER64);

--- a/src/windows-emulator/syscalls/token.cpp
+++ b/src/windows-emulator/syscalls/token.cpp
@@ -87,7 +87,7 @@ namespace syscalls
 
             TOKEN_GROUPS64 groups{};
             groups.GroupCount = 1;
-            groups.Groups[0].Attributes = SE_GROUP_ENABLED | SE_GROUP_ENABLED_BY_DEFAULT | SE_GROUP_MANDATORY;
+            groups.Groups[0].Attributes = 0;
             groups.Groups[0].Sid = token_information + sizeof(TOKEN_GROUPS64);
 
             emulator_object<TOKEN_GROUPS64>{c.emu, token_information}.write(groups);


### PR DESCRIPTION
This PR aims to:
- [Add new tests](https://github.com/momo5502/sogen/commit/9d0de32cde149a492c771dd7db8d523f0c82a4ab), specifically tests for the new registry features were added, as well as a check for the GetSystemDirectory (this breaks if the SharedSection is incorrectly configured). This already helped me [fix a bug](https://github.com/momo5502/sogen/commit/0474eef3737455e00dd890c41c88dc55bca80569) in the `WOW6432Node` redirection under Linux!
- [Handle TokenGroups in NtQueryInformationToken](https://github.com/momo5502/sogen/commit/7fef4ebc24f6fc831fe86f785d7130ea7346c3d2), [Stub SystemFirmwareTableInformation in NtQuerySystemInformation](https://github.com/momo5502/sogen/commit/3b918f2d5cd867d05b7dd1bc9633ed4b88efe84b). These two changes allow executables protected with Themida to reach their OEP while running on the emulator.
- [Add c_437.nls to create-root.bat](https://github.com/momo5502/sogen/commit/21af0de2c8272e353c3ee81ee4e9cf3aa7b0893f), because looks like 850 was my system's code page but the playground emulator uses 437.