### PR TITLE
Improvements to NtQueryDirectoryFileEx

### DIFF
--- a/src/common/utils/container.hpp
+++ b/src/common/utils/container.hpp
@@ -41,9 +41,7 @@ namespace utils
 
         bool operator()(const std::string_view lhs, const std::string_view rhs) const
         {
-            return std::ranges::equal(lhs, rhs, [](const char c1, const char c2) {
-                return string::char_to_lower(c1) == string::char_to_lower(c2);
-            });
+            return string::equals_ignore_case(lhs, rhs);
         }
     };
 

--- a/src/common/utils/string.hpp
+++ b/src/common/utils/string.hpp
@@ -149,4 +149,20 @@ namespace utils::string
 
         return data;
     }
+
+    template <class Elem, class Traits, class Alloc>
+    bool equals_ignore_case(const std::basic_string<Elem, Traits, Alloc>& lhs,
+                            const std::basic_string<Elem, Traits, Alloc>& rhs)
+    {
+        return std::ranges::equal(lhs, rhs,
+                                  [](const auto c1, const auto c2) { return char_to_lower(c1) == char_to_lower(c2); });
+    }
+
+    template <class Elem, class Traits>
+    bool equals_ignore_case(const std::basic_string_view<Elem, Traits>& lhs,
+                            const std::basic_string_view<Elem, Traits>& rhs)
+    {
+        return std::ranges::equal(lhs, rhs,
+                                  [](const auto c1, const auto c2) { return char_to_lower(c1) == char_to_lower(c2); });
+    }
 }

--- a/src/common/utils/wildcard.hpp
+++ b/src/common/utils/wildcard.hpp
@@ -1,0 +1,99 @@
+#pragma once
+#include <string>
+
+namespace utils::wildcard
+{
+    inline bool is_wildcard(char16_t c)
+    {
+        return c == '*' || c == '?' || c == '>' || c == '<' || c == '\"';
+    }
+
+    inline bool has_wildcard(const std::u16string_view mask)
+    {
+        return std::ranges::any_of(mask, is_wildcard);
+    }
+
+    inline bool match_filename(std::u16string_view name, std::u16string_view mask)
+    {
+        if (mask.empty() || mask == u"*" || mask == u"*.*")
+        {
+            return true;
+        }
+
+        size_t name_pos = 0;
+        size_t mask_pos = 0;
+
+        size_t star_mask_pos = std::u16string_view::npos;
+        size_t star_name_pos = 0;
+
+        while (name_pos < name.size())
+        {
+            if (mask_pos < mask.size())
+            {
+                char16_t mask_char = mask[mask_pos];
+                char16_t name_char = name[name_pos];
+
+                bool char_matches;
+                if (mask_char == u'?' || mask_char == u'>')
+                {
+                    char_matches = true;
+                }
+                else if (mask_char == u'"')
+                {
+                    char_matches = name_char == u'.';
+                }
+                else
+                {
+                    char_matches = string::char_to_lower(name_char) == string::char_to_lower(mask_char);
+                }
+
+                // Advance if current characters match
+                if (char_matches)
+                {
+                    name_pos++;
+                    mask_pos++;
+                    continue;
+                }
+
+                // If this is a wildcard, skip all consecutive wildcards and save position for backtracking
+                if (mask[mask_pos] == u'*' || mask[mask_pos] == u'<')
+                {
+                    mask_pos++;
+                    while (mask_pos < mask.size() && (mask[mask_pos] == u'*' || mask[mask_pos] == u'<'))
+                    {
+                        mask_pos++;
+                    }
+
+                    if (mask_pos == mask.size())
+                    {
+                        // There is no need to continue because all that remained were star masks.
+                        return true;
+                    }
+
+                    star_mask_pos = mask_pos;
+                    star_name_pos = name_pos;
+                    continue;
+                }
+            }
+
+            // The current characters didn't match...
+            // If we had a wildcard earlier, backtrack to it and try to match at the next position
+            if (star_mask_pos != std::u16string_view::npos)
+            {
+                mask_pos = star_mask_pos;
+                name_pos = ++star_name_pos;
+                continue;
+            }
+
+            return false;
+        }
+
+        // Skip any remaining wildcards in the mask
+        while (mask_pos < mask.size() && (mask[mask_pos] == u'*' || mask[mask_pos] == u'<'))
+        {
+            mask_pos++;
+        }
+
+        return mask_pos == mask.size();
+    }
+}

--- a/src/common/utils/wildcard.hpp
+++ b/src/common/utils/wildcard.hpp
@@ -33,7 +33,7 @@ namespace utils::wildcard
                 char16_t mask_char = mask[mask_pos];
                 char16_t name_char = name[name_pos];
 
-                bool char_matches;
+                bool char_matches = false;
                 if (mask_char == u'?' || mask_char == u'>')
                 {
                     char_matches = true;

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -55,7 +55,14 @@ namespace syscalls
                                            emulator_object<IO_STATUS_BLOCK<EmulatorTraits<Emu64>>> io_status_block,
                                            uint64_t file_information, uint32_t length, uint32_t info_class,
                                            ULONG query_flags,
-                                           emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> /*file_name*/);
+                                           emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> file_name);
+    NTSTATUS handle_NtQueryDirectoryFile(const syscall_context& c, handle file_handle, handle event_handle,
+                                         emulator_pointer /*PIO_APC_ROUTINE*/ apc_routine, emulator_pointer apc_context,
+                                         emulator_object<IO_STATUS_BLOCK<EmulatorTraits<Emu64>>> io_status_block,
+                                         uint64_t file_information, uint32_t length, uint32_t info_class,
+                                         BOOLEAN return_single_entry,
+                                         emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> file_name,
+                                         BOOLEAN restart_scan);
     NTSTATUS handle_NtQueryInformationFile(const syscall_context& c, handle file_handle,
                                            emulator_object<IO_STATUS_BLOCK<EmulatorTraits<Emu64>>> io_status_block,
                                            uint64_t file_information, uint32_t length, uint32_t info_class);
@@ -831,6 +838,7 @@ void syscall_dispatcher::add_handlers(std::map<std::string, syscall_handler>& ha
     add_handler(NtSetInformationKey);
     add_handler(NtUserGetKeyboardLayout);
     add_handler(NtQueryDirectoryFileEx);
+    add_handler(NtQueryDirectoryFile);
     add_handler(NtUserSystemParametersInfo);
     add_handler(NtGetContextThread);
     add_handler(NtYieldExecution);

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -21,6 +21,11 @@ namespace syscalls
             return STATUS_INVALID_HANDLE;
         }
 
+        if (info_class == FileBasicInformation)
+        {
+            return STATUS_NOT_SUPPORTED;
+        }
+
         if (info_class == FilePositionInformation)
         {
             if (!f->handle)

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -268,9 +268,13 @@ namespace syscalls
     {
         ULONG query_flags = 0;
         if (return_single_entry)
+        {
             query_flags |= SL_RETURN_SINGLE_ENTRY;
+        }
         if (restart_scan)
-            query_flags |= SL_RETURN_SINGLE_ENTRY;
+        {
+            query_flags |= SL_RESTART_SCAN;
+        }
         return handle_NtQueryDirectoryFileEx(c, file_handle, event_handle, apc_routine, apc_context, io_status_block,
                                              file_information, length, info_class, query_flags, file_name);
     }

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -94,15 +94,21 @@ struct mutant : ref_counted_object
 struct file_entry
 {
     std::filesystem::path file_path{};
+    uint64_t file_size{};
+    bool is_directory{};
 
     void serialize(utils::buffer_serializer& buffer) const
     {
         buffer.write(this->file_path);
+        buffer.write(this->file_size);
+        buffer.write(this->is_directory);
     }
 
     void deserialize(utils::buffer_deserializer& buffer)
     {
         buffer.read(this->file_path);
+        buffer.read(this->file_size);
+        buffer.read(this->is_directory);
     }
 };
 

--- a/src/windows-emulator/windows_path.hpp
+++ b/src/windows-emulator/windows_path.hpp
@@ -117,6 +117,11 @@ class windows_path
             path.append(folder);
         }
 
+        if (this->is_absolute() && this->folders_.empty())
+        {
+            path.push_back(u'\\');
+        }
+
         return path;
     }
 


### PR DESCRIPTION
This PR aims to:
- [Stub FileBasicInformation in NtSetInformationFile](https://github.com/momo5502/sogen/commit/6d0ad1dd61454bacdc41ad869d5b82c17540dc9d)
- [Make sure a root `windows_path` have slash at the end](https://github.com/momo5502/sogen/commit/02ed4fbb033135844ec0986fb4ca6fac73b45a3e), this was necessary because `directory_iterator` fails when the path is `C:` (without slash)..
- [Improve NtQueryDirectoryFileEx](https://github.com/momo5502/sogen/commit/f6ec1fc9cca448fc8de031cba1a5dd492e530087) by adding filename filtering support, including more basic file information in the struct, and fixing an issue that prevented the last chunk of files from being enumerated correctly.