### PR TITLE
Load environment variables from registry and other fixes

### DIFF
--- a/src/common/platform/kernel_mapped.hpp
+++ b/src/common/platform/kernel_mapped.hpp
@@ -863,28 +863,26 @@ typedef struct _SYSTEM_TIMEOFDAY_INFORMATION64
     ULONGLONG SleepTimeBias;
 } SYSTEM_TIMEOFDAY_INFORMATION64, *PSYSTEM_TIMEOFDAY_INFORMATION64;
 
-#ifndef OS_WINDOWS
-typedef struct _SYSTEMTIME
+typedef struct _SYSTEMTIME64
 {
     WORD wYear;
     WORD wMonth;
-    WORD wDayOfWeek;
     WORD wDay;
     WORD wHour;
     WORD wMinute;
     WORD wSecond;
     WORD wMilliseconds;
-} SYSTEMTIME, *PSYSTEMTIME, *LPSYSTEMTIME;
-#endif
+    WORD wDayOfWeek;
+} SYSTEMTIME64, *PSYSTEMTIME64, *LPSYSTEMTIME64;
 
 typedef struct _SYSTEM_TIMEZONE_INFORMATION
 {
     LONG Bias;
     ARRAY_CONTAINER<char16_t, 32> StandardName;
-    SYSTEMTIME StandardDate;
+    SYSTEMTIME64 StandardDate;
     LONG StandardBias;
     ARRAY_CONTAINER<char16_t, 32> DaylightName;
-    SYSTEMTIME DaylightDate;
+    SYSTEMTIME64 DaylightDate;
     LONG DaylightBias;
 } SYSTEM_TIMEZONE_INFORMATION, *PSYSTEM_TIMEZONE_INFORMATION;
 
@@ -892,10 +890,10 @@ typedef struct _SYSTEM_DYNAMIC_TIMEZONE_INFORMATION
 {
     LONG Bias;
     ARRAY_CONTAINER<char16_t, 32> StandardName;
-    SYSTEMTIME StandardDate;
+    SYSTEMTIME64 StandardDate;
     LONG StandardBias;
     ARRAY_CONTAINER<char16_t, 32> DaylightName;
-    SYSTEMTIME DaylightDate;
+    SYSTEMTIME64 DaylightDate;
     LONG DaylightBias;
     ARRAY_CONTAINER<char16_t, 128> TimeZoneKeyName;
     BOOLEAN DynamicDaylightTimeDisabled;

--- a/src/common/utils/container.hpp
+++ b/src/common/utils/container.hpp
@@ -8,26 +8,28 @@
 
 namespace utils
 {
-    struct string_hash
+    template <typename Elem, typename Traits>
+    struct basic_string_hash
     {
         using is_transparent = void;
 
-        size_t operator()(const std::string_view str) const
+        size_t operator()(const std::basic_string_view<Elem, Traits> str) const
         {
-            constexpr std::hash<std::string_view> hasher{};
+            constexpr std::hash<std::basic_string_view<Elem, Traits>> hasher{};
             return hasher(str);
         }
     };
 
-    struct insensitive_string_hash
+    template <typename Elem, typename Traits>
+    struct basic_insensitive_string_hash
     {
         using is_transparent = void;
 
-        size_t operator()(const std::string_view str) const
+        size_t operator()(const std::basic_string_view<Elem, Traits> str) const
         {
             size_t hash = 0;
             constexpr std::hash<int> hasher{};
-            for (const char c : str)
+            for (const auto c : str)
             {
                 hash ^= hasher(string::char_to_lower(c)) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
             }
@@ -35,22 +37,39 @@ namespace utils
         }
     };
 
-    struct insensitive_string_equal
+    template <typename Elem, typename Traits>
+    struct basic_insensitive_string_equal
     {
         using is_transparent = void;
 
-        bool operator()(const std::string_view lhs, const std::string_view rhs) const
+        bool operator()(const std::basic_string_view<Elem, Traits> lhs,
+                        const std::basic_string_view<Elem, Traits> rhs) const
         {
             return string::equals_ignore_case(lhs, rhs);
         }
     };
 
+    using string_hash = basic_string_hash<char, std::char_traits<char>>;
+    using u16string_hash = basic_string_hash<char16_t, std::char_traits<char16_t>>;
+
+    using insensitive_string_hash = basic_insensitive_string_hash<char, std::char_traits<char>>;
+    using insensitive_u16string_hash = basic_insensitive_string_hash<char16_t, std::char_traits<char16_t>>;
+
+    using insensitive_string_equal = basic_insensitive_string_equal<char, std::char_traits<char>>;
+    using insensitive_u16string_equal = basic_insensitive_string_equal<char16_t, std::char_traits<char16_t>>;
+
     template <typename T>
     using unordered_string_map = std::unordered_map<std::string, T, string_hash, std::equal_to<>>;
+    template <typename T>
+    using unordered_u16string_map = std::unordered_map<std::u16string, T, u16string_hash, std::equal_to<>>;
 
     template <typename T>
     using unordered_insensitive_string_map =
         std::unordered_map<std::string, T, insensitive_string_hash, insensitive_string_equal>;
+    template <typename T>
+    using unordered_insensitive_u16string_map =
+        std::unordered_map<std::u16string, T, insensitive_u16string_hash, insensitive_u16string_equal>;
 
     using unordered_string_set = std::unordered_set<std::string, string_hash, std::equal_to<>>;
+    using unordered_u16string_set = std::unordered_set<std::u16string, u16string_hash, std::equal_to<>>;
 }

--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -458,6 +458,48 @@ namespace
         return true;
     }
 
+    bool test_time_zone()
+    {
+        DYNAMIC_TIME_ZONE_INFORMATION current_dtzi = {};
+        DWORD result = GetDynamicTimeZoneInformation(&current_dtzi);
+
+        if (result == TIME_ZONE_ID_INVALID)
+        {
+            return false;
+        }
+
+        if (current_dtzi.Bias != -60 || current_dtzi.StandardBias != 0 || current_dtzi.DaylightBias != -60 ||
+            current_dtzi.DynamicDaylightTimeDisabled != FALSE)
+        {
+            return false;
+        }
+
+        if (wcscmp(current_dtzi.StandardName, L"W. Europe Standard Time") != 0 ||
+            wcscmp(current_dtzi.DaylightName, L"W. Europe Daylight Time") != 0 ||
+            wcscmp(current_dtzi.TimeZoneKeyName, L"W. Europe Standard Time") != 0)
+        {
+            return false;
+        }
+
+        if (current_dtzi.StandardDate.wYear != 0 || current_dtzi.StandardDate.wMonth != 10 ||
+            current_dtzi.StandardDate.wDayOfWeek != 0 || current_dtzi.StandardDate.wDay != 5 ||
+            current_dtzi.StandardDate.wHour != 3 || current_dtzi.StandardDate.wMinute != 0 ||
+            current_dtzi.StandardDate.wSecond != 0 || current_dtzi.StandardDate.wMilliseconds != 0)
+        {
+            return false;
+        }
+
+        if (current_dtzi.DaylightDate.wYear != 0 || current_dtzi.DaylightDate.wMonth != 3 ||
+            current_dtzi.DaylightDate.wDayOfWeek != 0 || current_dtzi.DaylightDate.wDay != 5 ||
+            current_dtzi.DaylightDate.wHour != 2 || current_dtzi.DaylightDate.wMinute != 0 ||
+            current_dtzi.DaylightDate.wSecond != 0 || current_dtzi.DaylightDate.wMilliseconds != 0)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
     void throw_exception()
     {
         if (do_the_task)
@@ -651,6 +693,7 @@ int main(const int argc, const char* argv[])
     RUN_TEST(test_working_directory, "Working Directory")
     RUN_TEST(test_registry, "Registry")
     RUN_TEST(test_system_info, "System Info")
+    RUN_TEST(test_time_zone, "Time Zone")
     RUN_TEST(test_threads, "Threads")
     RUN_TEST(test_env, "Environment")
     RUN_TEST(test_exceptions, "Exceptions")

--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -729,7 +729,10 @@ int main(const int argc, const char* argv[])
     RUN_TEST(test_env, "Environment")
     RUN_TEST(test_exceptions, "Exceptions")
     RUN_TEST(test_native_exceptions, "Native Exceptions")
-    RUN_TEST(test_interrupts, "Interrupts")
+    if (!getenv("EMULATOR_ICICLE"))
+    {
+        RUN_TEST(test_interrupts, "Interrupts")
+    }
     RUN_TEST(test_tls, "TLS")
     RUN_TEST(test_socket, "Socket")
     RUN_TEST(test_apc, "APC")

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -108,6 +108,13 @@ namespace
         }
 
         env_map[u"EMULATOR"] = u"1";
+
+        const auto* env = getenv("EMULATOR_ICICLE");
+        if (env && (env == "1"sv || env == "true"sv))
+        {
+            env_map[u"EMULATOR_ICICLE"] = u"1";
+        }
+
         env_map[u"COMPUTERNAME"] = u"momo";
         env_map[u"USERNAME"] = u"momo";
         env_map[u"SystemDrive"] = u"C:";

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -59,8 +59,9 @@ struct process_context
     {
     }
 
-    void setup(x86_64_emulator& emu, memory_manager& memory, const application_settings& app_settings,
-               const mapped_module& executable, const mapped_module& ntdll, const apiset::container& apiset_container);
+    void setup(x86_64_emulator& emu, memory_manager& memory, registry_manager& registry,
+               const application_settings& app_settings, const mapped_module& executable, const mapped_module& ntdll,
+               const apiset::container& apiset_container);
 
     handle create_thread(memory_manager& memory, uint64_t start_address, uint64_t argument, uint64_t stack_size,
                          bool suspended);

--- a/src/windows-emulator/registry/registry_manager.hpp
+++ b/src/windows-emulator/registry/registry_manager.hpp
@@ -5,6 +5,25 @@
 #include "serialization_helper.hpp"
 #include "../handles.hpp"
 
+#ifndef OS_WINDOWS
+#define REG_NONE (0ul) // No value type
+#define REG_SZ   (1ul) // Unicode nul terminated string
+#define REG_EXPAND_SZ \
+    (2ul)                                    // Unicode nul terminated string
+                                             // (with environment variable references)
+#define REG_BINARY                     (3ul) // Free form binary
+#define REG_DWORD                      (4ul) // 32-bit number
+#define REG_DWORD_LITTLE_ENDIAN        (4ul) // 32-bit number (same as REG_DWORD)
+#define REG_DWORD_BIG_ENDIAN           (5ul) // 32-bit number
+#define REG_LINK                       (6ul) // Symbolic Link (unicode)
+#define REG_MULTI_SZ                   (7ul) // Multiple Unicode strings
+#define REG_RESOURCE_LIST              (8ul) // Resource list in the resource map
+#define REG_FULL_RESOURCE_DESCRIPTOR   (9ul) // Resource list in the hardware description
+#define REG_RESOURCE_REQUIREMENTS_LIST (10ul)
+#define REG_QWORD                      (11ul) // 64-bit number
+#define REG_QWORD_LITTLE_ENDIAN        (11ul) // 64-bit number (same as REG_QWORD)
+#endif
+
 struct registry_key : ref_counted_object
 {
     utils::path_key hive{};

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -215,6 +215,7 @@ namespace syscalls
                                               emulator_object<uint32_t> return_length);
     NTSTATUS handle_NtSetInformationProcess(const syscall_context& c, handle process_handle, uint32_t info_class,
                                             uint64_t process_information, uint32_t process_information_length);
+    NTSTATUS handle_NtOpenProcess();
     NTSTATUS handle_NtOpenProcessToken(const syscall_context&, handle process_handle, ACCESS_MASK /*desired_access*/,
                                        emulator_object<handle> token_handle);
     NTSTATUS handle_NtOpenProcessTokenEx(const syscall_context& c, handle process_handle, ACCESS_MASK desired_access,
@@ -769,6 +770,7 @@ void syscall_dispatcher::add_handlers(std::map<std::string, syscall_handler>& ha
     add_handler(NtCreateFile);
     add_handler(NtDeviceIoControlFile);
     add_handler(NtQueryWnfStateData);
+    add_handler(NtOpenProcess);
     add_handler(NtOpenProcessToken);
     add_handler(NtOpenProcessTokenEx);
     add_handler(NtQuerySecurityAttributesToken);

--- a/src/windows-emulator/syscalls/process.cpp
+++ b/src/windows-emulator/syscalls/process.cpp
@@ -348,6 +348,11 @@ namespace syscalls
         return STATUS_NOT_SUPPORTED;
     }
 
+    NTSTATUS handle_NtOpenProcess()
+    {
+        return STATUS_NOT_SUPPORTED;
+    }
+
     NTSTATUS handle_NtOpenProcessToken(const syscall_context&, const handle process_handle,
                                        const ACCESS_MASK /*desired_access*/, const emulator_object<handle> token_handle)
     {

--- a/src/windows-emulator/syscalls/section.cpp
+++ b/src/windows-emulator/syscalls/section.cpp
@@ -171,6 +171,9 @@ namespace syscalls
 
             c.emu.write_memory(obj_address + 0x9C8, 0xFFFFFFFF); // TIME_ZONE_ID_INVALID
 
+            // Windows 2019 offset!
+            c.emu.write_memory(obj_address + 0xA70, 0xFFFFFFFF); // TIME_ZONE_ID_INVALID
+
             if (view_size)
             {
                 view_size.write(shared_section_size);

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -345,7 +345,7 @@ void windows_emulator::setup_process(const application_settings& app_settings)
 
     const auto apiset_data = apiset::obtain(this->emulation_root);
 
-    this->process.setup(this->emu(), this->memory, app_settings, *executable, *ntdll, apiset_data);
+    this->process.setup(this->emu(), this->memory, this->registry, app_settings, *executable, *ntdll, apiset_data);
 
     const auto ntdll_data = emu.read_memory(ntdll->image_base, static_cast<size_t>(ntdll->size_of_image));
     const auto win32u_data = emu.read_memory(win32u->image_base, static_cast<size_t>(win32u->size_of_image));


### PR DESCRIPTION
This PR aims to:
- [Fix TimeZoneInformation](https://github.com/momo5502/sogen/commit/496fbd3a407e66a191e8cfa73fea77def2c6bdc6) by moving `wDayOfWeek` to the end of the `SYSTEMTIME` structure. This goes against the public definitions of the `SYSTEMTIME` struct but I can confirm that this yields correct values when `GetTimeZoneInformation` is called.
- [Load environment variables from registry](https://github.com/momo5502/sogen/commit/9d5338b1680a7b0e25b2547895c6cac934e02eeb).
- [Miscellaneous fixes](https://github.com/momo5502/sogen/commit/a629f77e31ef4a40ebe8e8b845d398478ecc6bdd), to be more specific:
  - Add `NtOpenProcess` syscall stub.
  - Add logging to `handle_file_enumeration`.
  - Fix `FILE_ATTRIBUTE_NORMAL` being together with `FILE_ATTRIBUTE_DIRECTORY` (`FILE_ATTRIBUTE_NORMAL` means "no attributes are set").
  - Properly handle relative filenames in `NtQueryFullAttributesFile`.
  - Properly handle "trap flag".
  - Handle "DbgPrint" interrupt.