### PR TITLE
Fix afd_endpoint::ioctl_connect

### DIFF
--- a/src/windows-emulator/devices/afd_endpoint.hpp
+++ b/src/windows-emulator/devices/afd_endpoint.hpp
@@ -2,3 +2,4 @@
 #include "../io_device.hpp"
 
 std::unique_ptr<io_device> create_afd_endpoint();
+std::unique_ptr<io_device> create_afd_async_connect_hlp();

--- a/src/windows-emulator/io_device.cpp
+++ b/src/windows-emulator/io_device.cpp
@@ -32,6 +32,11 @@ std::unique_ptr<io_device> create_device(const std::u16string_view device)
         return create_afd_endpoint();
     }
 
+    if (device == u"Afd\\AsyncConnectHlp")
+    {
+        return create_afd_async_connect_hlp();
+    }
+
     if (device == u"MountPointManager")
     {
         return create_mount_point_manager();

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -415,6 +415,11 @@ namespace syscalls
         return handle_NtCreateEvent(c, event_handle, desired_access, object_attributes, NotificationEvent, FALSE);
     }
 
+    NTSTATUS handle_NtSetIoCompletion()
+    {
+        return STATUS_NOT_SUPPORTED;
+    }
+
     NTSTATUS handle_NtCreateWaitCompletionPacket(
         const syscall_context& c, const emulator_object<handle> event_handle, const ACCESS_MASK desired_access,
         const emulator_object<OBJECT_ATTRIBUTES<EmulatorTraits<Emu64>>> object_attributes)
@@ -940,6 +945,7 @@ void syscall_dispatcher::add_handlers(std::map<std::string, syscall_handler>& ha
     add_handler(NtTraceEvent);
     add_handler(NtAllocateVirtualMemoryEx);
     add_handler(NtCreateIoCompletion);
+    add_handler(NtSetIoCompletion);
     add_handler(NtCreateWaitCompletionPacket);
     add_handler(NtCreateWorkerFactory);
     add_handler(NtManageHotPatch);

--- a/src/windows-emulator/syscalls/file.cpp
+++ b/src/windows-emulator/syscalls/file.cpp
@@ -25,6 +25,12 @@ namespace syscalls
         const auto* f = c.proc.files.get(file_handle);
         if (!f)
         {
+            if (c.proc.devices.get(file_handle))
+            {
+                c.win_emu.log.error("Unsupported set device info class: %X\n", info_class);
+                return STATUS_SUCCESS;
+            }
+
             return STATUS_INVALID_HANDLE;
         }
 


### PR DESCRIPTION
This PR aims to fix both blocking and non-blocking socket connect operations inside the emulator.  
The previous implementation of `ioctl_connect` was a bit wrong, and the `afd_async_connect_hlp` device is necessary for non-blocking sockets.

![image](https://github.com/user-attachments/assets/e48a6934-7276-4b0e-a179-9f93f17810b7)
