### PR TITLE
Add stub for NtReleaseWorkerFactoryWorker, skeleton implementation for NtCreateNamedPipeFile

### DIFF
--- a/src/windows-emulator/devices/named_pipe.hpp
+++ b/src/windows-emulator/devices/named_pipe.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include "../io_device.hpp"
+
+class named_pipe : public io_device_container {
+public:
+    std::u16string name;
+    ULONG pipe_type;
+    ULONG read_mode;
+    ULONG completion_mode;
+    ULONG max_instances;
+    ULONG inbound_quota;
+    ULONG outbound_quota;
+    LARGE_INTEGER default_timeout;
+
+    void create(windows_emulator&, const io_device_creation_data&) override {}
+    void work(windows_emulator&) override {}
+    NTSTATUS io_control(windows_emulator&, const io_device_context&) override { return STATUS_NOT_SUPPORTED; }
+
+    void serialize_object(utils::buffer_serializer&) const override {}
+    void deserialize_object(utils::buffer_deserializer&) override {}
+};

--- a/src/windows-emulator/io_device.cpp
+++ b/src/windows-emulator/io_device.cpp
@@ -4,6 +4,7 @@
 #include "devices/afd_endpoint.hpp"
 #include "devices/mount_point_manager.hpp"
 #include "devices/security_support_provider.hpp"
+#include "devices/named_pipe.hpp"
 
 namespace
 {
@@ -47,6 +48,11 @@ std::unique_ptr<io_device> create_device(const std::u16string_view device)
     if (device == u"KsecDD")
     {
         return create_security_support_provider();
+    }
+
+    if (device == u"NamedPipe")
+    {
+        return std::make_unique<named_pipe>();
     }
 
     throw std::runtime_error("Unsupported device: " + u16_to_u8(device));

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -436,6 +436,11 @@ namespace syscalls
         return STATUS_SUCCESS;
     }
 
+    NTSTATUS handle_NtReleaseWorkerFactoryWorker()
+    {
+        return STATUS_SUCCESS;
+    }
+
     NTSTATUS handle_NtCreateIoCompletion(
         const syscall_context& c, const emulator_object<handle> event_handle, const ACCESS_MASK desired_access,
         const emulator_object<OBJECT_ATTRIBUTES<EmulatorTraits<Emu64>>> object_attributes,
@@ -1185,6 +1190,7 @@ void syscall_dispatcher::add_handlers(std::map<std::string, syscall_handler>& ha
     add_handler(NtQueryEvent);
     add_handler(NtRemoveIoCompletionEx);
     add_handler(NtCreateDebugObject);
+    add_handler(NtReleaseWorkerFactoryWorker);
 
 #undef add_handler
 }


### PR DESCRIPTION
Added a stub implementation for NtReleaseWorkerFactoryWorker.

Introduced initial skeleton logic for NtCreateNamedPipeFile with device creation and registration, object attribute parse for pipe naming, basic parameters to named_pipe structure, IOSB and handle writing.