### PR TITLE
Fix exception when NtTerminateThread is called on the active thread.

### DIFF
--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -52,6 +52,7 @@ namespace
     void perform_context_switch_work(windows_emulator& win_emu)
     {
         auto& threads = win_emu.process.threads;
+        auto*& active = win_emu.process.active_thread;
 
         for (auto it = threads.begin(); it != threads.end();)
         {
@@ -59,6 +60,11 @@ namespace
             {
                 ++it;
                 continue;
+            }
+
+            if (active == &it->second)
+            {
+                active = nullptr;
             }
 
             const auto [new_it, deleted] = threads.erase(it);


### PR DESCRIPTION
Fixes a bug where `perform_context_switch_work` method erases the thread from the threads list and call its destructor but doesn't invalidate the `active_thread` property causing the following switch_to_thread call to call `active_thread->save(emu);` when `active_thread` is already destroyed and thus throws an exception when assigning to `last_registers`.