### PR TITLE
Fix NtCallbackReturn result marshaling and GDI shared-block 4GB ceiling for native processes

### DIFF
--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -378,7 +378,7 @@ namespace sogen
                     return 0;
                 }
 
-                if (base > std::numeric_limits<uint32_t>::max())
+                if (c.proc.is_wow64_process && base > std::numeric_limits<uint32_t>::max())
                 {
                     c.win_emu.memory.release_memory(base, 0);
                     return 0;

--- a/src/windows-emulator/syscalls/thread.cpp
+++ b/src/windows-emulator/syscalls/thread.cpp
@@ -988,13 +988,18 @@ namespace sogen
             uint64_t callback_result = t.callback_return_rax.value_or(c.emu.reg<uint64_t>(x86_register::rax));
             t.callback_return_rax.reset();
 
-            if (callback_result_ptr != 0 && callback_result_length != 0 && callback_result_length <= sizeof(callback_result))
+            if (callback_result_ptr != 0 && callback_result_length != 0)
             {
+                // user32's SFI-table-driven dispatch stubs (the __guard_xfg_dispatch_icall_fptr family
+                // used for e.g. NtUserMessageCall completions) always pass a real result pointer with
+                // ResultLength=0x18 - a 24-byte structure whose first 8 bytes are the actual LRESULT the
+                // callback computed.
+                const auto read_length = std::min<ULONG>(callback_result_length, sizeof(callback_result));
                 std::array<std::byte, sizeof(callback_result)> result_bytes{};
-                if (c.win_emu.memory.try_read_memory(callback_result_ptr, result_bytes.data(), callback_result_length))
+                if (c.win_emu.memory.try_read_memory(callback_result_ptr, result_bytes.data(), read_length))
                 {
                     callback_result = 0;
-                    memcpy(&callback_result, result_bytes.data(), callback_result_length);
+                    memcpy(&callback_result, result_bytes.data(), read_length);
                 }
             }
 


### PR DESCRIPTION
Two small, independent, backend-agnostic fixes found while bringing up an out-of-tree macOS FEX backend, split out so they can land ahead of and independently from that work — neither touches FEX-specific code, and neither is specific to any single execution backend.

**This is a prerequisite for the upcoming macOS FEX backend addition.** Its CI crashes on process init (`STATUS_DLL_INIT_FAILED`, see below) without both fixes here; that PR will depend on this one merging first.

- **`NtCallbackReturn`: honor result buffers larger than 8 bytes** — the handler rejected any callback result whose `ResultLength` exceeded `sizeof(callback_result)` (8 bytes) and silently fell back to reading the guest's raw `RAX` register instead. user32's SFI-table-driven dispatch stubs (the `__guard_xfg_dispatch_icall_fptr` family used for `NtUserMessageCall` completions) always pass a real result pointer with `ResultLength=0x18` — a 24-byte structure whose first 8 bytes are the actual `LRESULT` the callback computed — so the old check rejected every one of these and depended on `RAX` coincidentally already holding the right value at the syscall boundary. That coincidence holds under some execution backends and not others, since it depends on backend-specific register-state timing around the syscall boundary rather than anything in the actual NT semantics. Fixed by clamping and reading (`min(ResultLength, sizeof(callback_result))`) instead of outright rejecting.
- **`allocate_gdi_user_block`: only enforce the 4GB ceiling for WoW64 processes** — the GDI shared-block allocator rejected any allocation landing above the 4GB boundary unconditionally. That check exists so 32-bit WoW64 guests, whose pointers can't address above 4GB, never receive a block they can't reach — but it also rejected every allocation for native 64-bit processes, whose GDI shared handle table and DC-attribute blocks routinely land above 4GB. Depending on the host allocator's layout, that can silently fail `allocate_gdi_user_block` right around `NtGdiInit2`'s setup path and take down process init. Narrowed the check to WoW64 processes only, since native 64-bit processes have no such addressing constraint.

Both were bisected against a real crash (`STATUS_DLL_INIT_FAILED` via `NtRaiseHardError`, immediately after `NtGdiInit2`) and confirmed as the minimal pair needed to resolve it — neither alone is sufficient, both together are.

## Verification

Builds clean; `windows-emulator-test` 27/27 passing; the exact `NtCallbackReturn` + `allocate_gdi_user_block` combination in this PR was also confirmed, via the macOS FEX backend branch's own CI, to resolve the `STATUS_DLL_INIT_FAILED` crash that branch otherwise hits on every run.
