### PR TITLE
fix(scheduler): serialize quantum-timer preemption against the scheduler

### DIFF
--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -1331,6 +1331,15 @@ namespace sogen
 
                     if (!this->should_stop)
                     {
+                        // Under the kernel lock so this switch_thread/stop() pair can't straddle a vCPU's
+                        // own scheduling step: perform_thread_switch consumes switch_thread (exchange to
+                        // false) under the lock, and a preemption whose switch request lands before that
+                        // consume while its stop() only lands inside the next quantum surfaces there as a
+                        // stop with no pending switch - the exact shape of a fatal wind-down, tearing the
+                        // whole run off at a random parked rip. Serialized against the scheduler, the pair
+                        // lands either fully before the consume (plain early switch) or fully inside the
+                        // running quantum (ordinary preemption), never split across it.
+                        const std::scoped_lock kernel_lock(this->kernel_lock_);
                         for (uint32_t i = 0; i < this->vcpu_count_; ++i)
                         {
                             auto& v = this->vcpu(i);


### PR DESCRIPTION
Extracted from #1239 at momo5502's request, so this fix can merge and be relied on independently of the FEX backend PR.

The software-quantum timer preempts a vCPU in two unsynchronized steps: set `switch_thread`, then `cpu.stop()`. `perform_thread_switch` consumes `switch_thread` (exchange to `false`) before entering the next quantum, so a timer iteration descheduled between its two steps can have its switch request consumed by that switch while its `stop()` only lands inside the fresh quantum. The vCPU loop then sees `cpu.start()` return with no pending switch and no violation — the exact shape of a fatal wind-down — and tears the whole run off at whatever RIP the current thread was parked at (`Emulation failed at <rip> - Emulation terminated without status`, no error logged, no exit status).

This is backend-agnostic and pre-existing on `main` — it doesn't depend on any FEX code. It's just rare to hit: the watchdog only exists when `!uses_instruction_precision() && is_stop_thread_safe()`, so it never fires under Unicorn, and needs enough scheduling pressure to land the race window. It reproduces reliably under FEX's cooperative page-protect stop, which is how it was originally found.

Fix: take the kernel lock around the timer's `switch_thread`/`stop()` pair. The scheduler's consume step runs under that same lock, so the pair now lands either fully before it (a plain early switch) or fully inside the running quantum (an ordinary preemption), never split across the boundary. A pair landing exactly at quantum entry can still be erased by `start()`'s `stop_requested` reset — a benignly missed tick, retried 20ms later — or unwind with the switch request still pending, which the vCPU loop already treats as a normal thread switch.

## Verification

Reproduced directly by artificially widening the race window (a sleep between the two steps): unfixed, 2 of 5 runs failed with the exact reported symptom; fixed, 0 of 8. Stress-tested for a new deadlock by holding the lock 100x longer than normal for 8 full emulation runs — zero stalls. Builds clean; `windows-emulator-test` 27/27; `analyzer -s test-sample.exe` smoke test passes; `clang-format --dry-run` clean.
