### PR TITLE
VKD3D bring-up

### DIFF
--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -181,9 +181,13 @@ namespace sogen::gpu_bridge
         cmd_draw_indirect_count = 0x88E,
         cmd_next_subpass = 0x88F,
         free_descriptor_sets = 0x890,
-        get_shader_module_identifier = 0x891,
-        get_shader_module_create_info_identifier = 0x892,
         get_descriptor_set_layout_support = 0x893,
+        cmd_write_timestamp2 = 0x89A,
+        get_physical_device_cooperative_matrix_properties = 0x89B,
+        get_physical_device_fragment_shading_rates = 0x89C,
+        get_physical_device_calibrateable_time_domains = 0x89D,
+        get_device_memory_commitment = 0x8A2,
+        get_calibrated_timestamps = 0x8A3,
     };
 
     // Discriminator for cmd_set_dynamic_u32: the family of extended-dynamic-state setters that all take a
@@ -257,9 +261,6 @@ namespace sogen::gpu_bridge
     inline constexpr uint32_t ioctl_queue_present = make_ioctl(static_cast<uint32_t>(command::queue_present));
     inline constexpr uint32_t ioctl_create_shader_module = make_ioctl(static_cast<uint32_t>(command::create_shader_module));
     inline constexpr uint32_t ioctl_destroy_shader_module = make_ioctl(static_cast<uint32_t>(command::destroy_shader_module));
-    inline constexpr uint32_t ioctl_get_shader_module_identifier = make_ioctl(static_cast<uint32_t>(command::get_shader_module_identifier));
-    inline constexpr uint32_t ioctl_get_shader_module_create_info_identifier =
-        make_ioctl(static_cast<uint32_t>(command::get_shader_module_create_info_identifier));
     inline constexpr uint32_t ioctl_create_image_view = make_ioctl(static_cast<uint32_t>(command::create_image_view));
     inline constexpr uint32_t ioctl_destroy_image_view = make_ioctl(static_cast<uint32_t>(command::destroy_image_view));
     inline constexpr uint32_t ioctl_create_buffer_view = make_ioctl(static_cast<uint32_t>(command::create_buffer_view));
@@ -329,6 +330,14 @@ namespace sogen::gpu_bridge
         make_ioctl(static_cast<uint32_t>(command::invalidate_mapped_memory_direct));
     inline constexpr uint32_t ioctl_get_physical_device_memory_budget =
         make_ioctl(static_cast<uint32_t>(command::get_physical_device_memory_budget));
+    inline constexpr uint32_t ioctl_get_physical_device_cooperative_matrix_properties =
+        make_ioctl(static_cast<uint32_t>(command::get_physical_device_cooperative_matrix_properties));
+    inline constexpr uint32_t ioctl_get_physical_device_fragment_shading_rates =
+        make_ioctl(static_cast<uint32_t>(command::get_physical_device_fragment_shading_rates));
+    inline constexpr uint32_t ioctl_get_physical_device_calibrateable_time_domains =
+        make_ioctl(static_cast<uint32_t>(command::get_physical_device_calibrateable_time_domains));
+    inline constexpr uint32_t ioctl_get_device_memory_commitment = make_ioctl(static_cast<uint32_t>(command::get_device_memory_commitment));
+    inline constexpr uint32_t ioctl_get_calibrated_timestamps = make_ioctl(static_cast<uint32_t>(command::get_calibrated_timestamps));
 
     // Opaque identifier handed to the guest in place of a host Vulkan handle. The host keeps the
     // real VkInstance / VkPhysicalDevice / ... in a table and the guest only ever sees this id, so
@@ -372,6 +381,39 @@ namespace sogen::gpu_bridge
         int32_t vk_result;
         uint32_t count; // number of physical devices reported by the host
         // object_id devices[count];
+    };
+
+    struct physical_device_enumeration_request
+    {
+        object_id physical_device;
+        uint32_t max_count;
+        uint32_t has_entries;
+    };
+
+    struct physical_device_enumeration_response
+    {
+        int32_t vk_result;
+        uint32_t count;
+    };
+
+    struct cooperative_matrix_property
+    {
+        uint32_t m_size;
+        uint32_t n_size;
+        uint32_t k_size;
+        uint32_t a_type;
+        uint32_t b_type;
+        uint32_t c_type;
+        uint32_t result_type;
+        uint32_t saturating_accumulation;
+        uint32_t scope;
+    };
+
+    struct fragment_shading_rate
+    {
+        uint32_t sample_counts;
+        uint32_t width;
+        uint32_t height;
     };
 
     // ioctl_get_physical_device_properties: in (out = raw VkPhysicalDeviceProperties bytes)
@@ -846,6 +888,19 @@ namespace sogen::gpu_bridge
         object_id memory;
     };
 
+    struct get_device_memory_commitment_request
+    {
+        object_id device;
+        object_id memory;
+    };
+
+    struct get_device_memory_commitment_response
+    {
+        int32_t vk_result;
+        uint32_t reserved;
+        uint64_t committed_bytes;
+    };
+
     struct create_buffer_request
     {
         object_id device;
@@ -1296,24 +1351,14 @@ namespace sogen::gpu_bridge
         object_id object;
     };
 
-    // ioctl_create_shader_module / ioctl_get_shader_module_create_info_identifier: header immediately
-    // followed by `code_size` bytes of SPIR-V. The create command returns object_response; the identifier
-    // command returns shader_module_identifier_response.
+    // ioctl_create_shader_module: in header immediately followed by `code_size` bytes of SPIR-V;
+    // out = object_response
     struct create_shader_module_request
     {
         object_id device;
         uint32_t code_size; // bytes (multiple of 4)
-        uint32_t flags;     // VkShaderModuleCreateFlags
+        uint32_t reserved;
         // uint8_t code[code_size];
-    };
-
-    inline constexpr uint32_t max_shader_module_identifier_size = 32;
-
-    struct shader_module_identifier_response
-    {
-        int32_t vk_result;
-        uint32_t identifier_size;
-        std::array<uint8_t, max_shader_module_identifier_size> identifier;
     };
 
     struct create_image_view_request
@@ -1431,6 +1476,15 @@ namespace sogen::gpu_bridge
         object_id query_pool;
         uint32_t query;
         uint32_t pipeline_stage; // VkPipelineStageFlagBits
+    };
+
+    struct cmd_write_timestamp2_request
+    {
+        object_id command_buffer;
+        object_id query_pool;
+        uint32_t query;
+        uint32_t reserved;
+        uint64_t pipeline_stage; // VkPipelineStageFlags2
     };
 
     struct cmd_copy_query_pool_results_request
@@ -1586,14 +1640,20 @@ namespace sogen::gpu_bridge
         uint32_t color_write_mask;       // VkColorComponentFlags
     };
 
-    // A pipeline shader stage is backed either by a bridge shader-module object or by an EXT shader-module
-    // identifier. Exactly one of module and identifier_size must be non-zero.
-    struct shader_stage_source
+    struct get_calibrated_timestamps_request
     {
-        object_id module;
-        uint32_t identifier_size;
+        object_id device;
+        uint32_t timestamp_count;
         uint32_t reserved;
-        std::array<uint8_t, max_shader_module_identifier_size> identifier{};
+        // uint32_t time_domains[timestamp_count];
+    };
+
+    struct get_calibrated_timestamps_response
+    {
+        int32_t vk_result;
+        uint32_t reserved;
+        uint64_t max_deviation;
+        // uint64_t timestamps[timestamp_count];
     };
 
     struct create_graphics_pipeline_request
@@ -1601,8 +1661,8 @@ namespace sogen::gpu_bridge
         object_id device;
         object_id render_pass; // 0 => dynamic rendering: use the attachment formats below, and viewport/scissor are dynamic
         object_id pipeline_layout;
-        shader_stage_source vertex_shader;
-        shader_stage_source fragment_shader;
+        object_id vertex_shader;
+        object_id fragment_shader;
         uint32_t flags; // VkPipelineCreateFlags
         uint32_t width;
         uint32_t height;
@@ -1646,7 +1706,7 @@ namespace sogen::gpu_bridge
     {
         object_id device;
         object_id pipeline_layout;
-        shader_stage_source shader;
+        object_id shader_module;
         uint32_t flags; // VkPipelineCreateFlags
         uint32_t reserved;
     };
@@ -2108,11 +2168,9 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(get_image_subresource_layout_response) == 48, "wire layout drift");
     static_assert(sizeof(create_buffer_view_request) == 40, "wire layout drift");
     static_assert(sizeof(create_shader_module_request) == 16, "wire layout drift");
-    static_assert(sizeof(shader_module_identifier_response) == 40, "wire layout drift");
-    static_assert(sizeof(shader_stage_source) == 48, "wire layout drift");
     static_assert(sizeof(vertex_input_divisor) == 8, "wire layout drift");
-    static_assert(sizeof(create_compute_pipeline_request) == 72, "wire layout drift");
-    static_assert(sizeof(create_graphics_pipeline_request) == 496, "wire layout drift");
+    static_assert(sizeof(create_compute_pipeline_request) == 32, "wire layout drift");
+    static_assert(sizeof(create_graphics_pipeline_request) == 416, "wire layout drift");
     static_assert(sizeof(buffer_copy_region) == 24, "wire layout drift");
     static_assert(sizeof(cmd_copy_buffer_request) == 32, "wire layout drift");
     static_assert(sizeof(create_query_pool_request) == 24, "wire layout drift");
@@ -2121,6 +2179,7 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(cmd_reset_query_pool_request) == 24, "wire layout drift");
     static_assert(sizeof(cmd_begin_query_request) == 24, "wire layout drift");
     static_assert(sizeof(cmd_end_query_request) == 24, "wire layout drift");
+    static_assert(sizeof(cmd_write_timestamp2_request) == 32, "wire layout drift");
     static_assert(sizeof(cmd_write_timestamp_request) == 24, "wire layout drift");
     static_assert(sizeof(cmd_copy_query_pool_results_request) == 56, "wire layout drift");
     static_assert(sizeof(cmd_draw_indexed_indirect_request) == 32, "wire layout drift");
@@ -2173,4 +2232,12 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(get_physical_device_image_format_properties_request) == 32, "wire layout drift");
     static_assert(sizeof(get_physical_device_image_format_properties_response) == 40, "wire layout drift");
     static_assert(sizeof(reset_descriptor_pool_request) == 24, "wire layout drift");
+    static_assert(sizeof(physical_device_enumeration_request) == 16, "wire layout drift");
+    static_assert(sizeof(physical_device_enumeration_response) == 8, "wire layout drift");
+    static_assert(sizeof(cooperative_matrix_property) == 36, "wire layout drift");
+    static_assert(sizeof(fragment_shading_rate) == 12, "wire layout drift");
+    static_assert(sizeof(get_device_memory_commitment_request) == 16, "wire layout drift");
+    static_assert(sizeof(get_device_memory_commitment_response) == 16, "wire layout drift");
+    static_assert(sizeof(get_calibrated_timestamps_request) == 16, "wire layout drift");
+    static_assert(sizeof(get_calibrated_timestamps_response) == 16, "wire layout drift");
 }

--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -16,7 +16,7 @@ namespace sogen::gpu_bridge
     // Identifies a valid bridge and lets the guest detect a host that speaks a different
     // protocol revision before issuing any further commands.
     inline constexpr uint32_t protocol_magic = 0x55504753; // 'SGPU'
-    inline constexpr uint32_t protocol_version = 27;
+    inline constexpr uint32_t protocol_version = 28;
 
     // Windows IOCTL encoding: CTL_CODE(DeviceType, Function, Method, Access).
     //   value = (DeviceType << 16) | (Access << 14) | (Function << 2) | Method
@@ -174,6 +174,14 @@ namespace sogen::gpu_bridge
         cmd_blit_image = 0x887,
         reset_descriptor_pool = 0x888,
         cmd_clear_attachments = 0x889,
+        cmd_copy_query_pool_results = 0x88A,
+        cmd_draw_indexed_indirect = 0x88B,
+        cmd_draw_indexed_indirect_count = 0x88C,
+        cmd_draw_indirect = 0x88D,
+        cmd_draw_indirect_count = 0x88E,
+        cmd_next_subpass = 0x88F,
+        free_descriptor_sets = 0x890,
+        get_shader_module_identifier = 0x891,
     };
 
     // Discriminator for cmd_set_dynamic_u32: the family of extended-dynamic-state setters that all take a
@@ -247,6 +255,7 @@ namespace sogen::gpu_bridge
     inline constexpr uint32_t ioctl_queue_present = make_ioctl(static_cast<uint32_t>(command::queue_present));
     inline constexpr uint32_t ioctl_create_shader_module = make_ioctl(static_cast<uint32_t>(command::create_shader_module));
     inline constexpr uint32_t ioctl_destroy_shader_module = make_ioctl(static_cast<uint32_t>(command::destroy_shader_module));
+    inline constexpr uint32_t ioctl_get_shader_module_identifier = make_ioctl(static_cast<uint32_t>(command::get_shader_module_identifier));
     inline constexpr uint32_t ioctl_create_image_view = make_ioctl(static_cast<uint32_t>(command::create_image_view));
     inline constexpr uint32_t ioctl_destroy_image_view = make_ioctl(static_cast<uint32_t>(command::destroy_image_view));
     inline constexpr uint32_t ioctl_create_buffer_view = make_ioctl(static_cast<uint32_t>(command::create_buffer_view));
@@ -272,6 +281,7 @@ namespace sogen::gpu_bridge
     inline constexpr uint32_t ioctl_destroy_descriptor_pool = make_ioctl(static_cast<uint32_t>(command::destroy_descriptor_pool));
     inline constexpr uint32_t ioctl_reset_descriptor_pool = make_ioctl(static_cast<uint32_t>(command::reset_descriptor_pool));
     inline constexpr uint32_t ioctl_allocate_descriptor_sets = make_ioctl(static_cast<uint32_t>(command::allocate_descriptor_sets));
+    inline constexpr uint32_t ioctl_free_descriptor_sets = make_ioctl(static_cast<uint32_t>(command::free_descriptor_sets));
     inline constexpr uint32_t ioctl_update_descriptor_sets = make_ioctl(static_cast<uint32_t>(command::update_descriptor_sets));
     inline constexpr uint32_t ioctl_update_descriptor_sets_batch = make_ioctl(static_cast<uint32_t>(command::update_descriptor_sets_batch));
     inline constexpr uint32_t ioctl_create_sampler = make_ioctl(static_cast<uint32_t>(command::create_sampler));
@@ -1290,6 +1300,13 @@ namespace sogen::gpu_bridge
         // uint8_t code[code_size];
     };
 
+    struct shader_module_identifier_response
+    {
+        int32_t vk_result;
+        uint32_t identifier_size;
+        std::array<uint8_t, 32> identifier;
+    };
+
     struct create_image_view_request
     {
         object_id device;
@@ -1405,6 +1422,66 @@ namespace sogen::gpu_bridge
         object_id query_pool;
         uint32_t query;
         uint32_t pipeline_stage; // VkPipelineStageFlagBits
+    };
+
+    struct cmd_copy_query_pool_results_request
+    {
+        object_id command_buffer;
+        object_id query_pool;
+        uint32_t first_query;
+        uint32_t query_count;
+        object_id destination_buffer;
+        uint64_t destination_offset;
+        uint64_t stride;
+        uint32_t flags;
+        uint32_t reserved;
+    };
+
+    struct cmd_draw_indexed_indirect_request
+    {
+        object_id command_buffer;
+        object_id buffer;
+        uint64_t offset;
+        uint32_t draw_count;
+        uint32_t stride;
+    };
+
+    struct cmd_draw_indexed_indirect_count_request
+    {
+        object_id command_buffer;
+        object_id buffer;
+        uint64_t offset;
+        object_id count_buffer;
+        uint64_t count_buffer_offset;
+        uint32_t max_draw_count;
+        uint32_t stride;
+    };
+
+    struct cmd_draw_indirect_request
+    {
+        object_id command_buffer;
+        object_id buffer;
+        uint64_t offset;
+        uint32_t draw_count;
+        uint32_t stride;
+    };
+
+    struct cmd_draw_indirect_count_request
+    {
+        object_id command_buffer;
+        object_id buffer;
+        uint64_t offset;
+        object_id count_buffer;
+        uint64_t count_buffer_offset;
+        uint32_t max_draw_count;
+        uint32_t stride;
+    };
+
+    struct cmd_next_subpass_request
+    {
+        object_id command_buffer;
+        uint32_t contents;
+        uint32_t reserved;
     };
 
     // out = object_response
@@ -1891,6 +1968,14 @@ namespace sogen::gpu_bridge
         // object_id sets[count];
     };
 
+    struct free_descriptor_sets_request
+    {
+        object_id device;
+        object_id descriptor_pool;
+        uint32_t set_count;
+        uint32_t reserved;
+    };
+
     // One descriptor write (trailing-array element of update_descriptor_sets). Models a single buffer or
     // image descriptor per write (descriptor_count == 1). For buffer types the buffer/offset/range fields
     // apply; for image types (combined image sampler) the sampler/image_view/image_layout fields apply.
@@ -1901,7 +1986,7 @@ namespace sogen::gpu_bridge
         uint32_t dst_array_element;
         uint32_t descriptor_type; // VkDescriptorType
         uint32_t reserved;
-        object_id buffer;      // VK_DESCRIPTOR_TYPE_*_BUFFER: the bound buffer (else null_object)
+        object_id buffer_or_view;
         uint64_t offset;       // buffer offset
         uint64_t range;        // buffer range (VK_WHOLE_SIZE allowed)
         object_id sampler;     // image types: the sampler (else null_object)
@@ -1975,6 +2060,7 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(get_image_subresource_layout_request) == 32, "wire layout drift");
     static_assert(sizeof(get_image_subresource_layout_response) == 48, "wire layout drift");
     static_assert(sizeof(create_buffer_view_request) == 40, "wire layout drift");
+    static_assert(sizeof(shader_module_identifier_response) == 40, "wire layout drift");
     static_assert(sizeof(buffer_copy_region) == 24, "wire layout drift");
     static_assert(sizeof(cmd_copy_buffer_request) == 32, "wire layout drift");
     static_assert(sizeof(create_query_pool_request) == 24, "wire layout drift");
@@ -1984,6 +2070,13 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(cmd_begin_query_request) == 24, "wire layout drift");
     static_assert(sizeof(cmd_end_query_request) == 24, "wire layout drift");
     static_assert(sizeof(cmd_write_timestamp_request) == 24, "wire layout drift");
+    static_assert(sizeof(cmd_copy_query_pool_results_request) == 56, "wire layout drift");
+    static_assert(sizeof(cmd_draw_indexed_indirect_request) == 32, "wire layout drift");
+    static_assert(sizeof(cmd_draw_indexed_indirect_count_request) == 48, "wire layout drift");
+    static_assert(sizeof(cmd_draw_indirect_request) == 32, "wire layout drift");
+    static_assert(sizeof(cmd_draw_indirect_count_request) == 48, "wire layout drift");
+    static_assert(sizeof(cmd_next_subpass_request) == 16, "wire layout drift");
+    static_assert(sizeof(free_descriptor_sets_request) == 24, "wire layout drift");
     static_assert(sizeof(reset_query_pool_request) == 24, "wire layout drift");
     static_assert(sizeof(vertex_buffer_binding) == 16, "wire layout drift");
     static_assert(sizeof(vertex_buffer_binding2) == 32, "wire layout drift");

--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -182,6 +182,7 @@ namespace sogen::gpu_bridge
         cmd_next_subpass = 0x88F,
         free_descriptor_sets = 0x890,
         get_shader_module_identifier = 0x891,
+        get_shader_module_create_info_identifier = 0x892,
     };
 
     // Discriminator for cmd_set_dynamic_u32: the family of extended-dynamic-state setters that all take a
@@ -256,6 +257,8 @@ namespace sogen::gpu_bridge
     inline constexpr uint32_t ioctl_create_shader_module = make_ioctl(static_cast<uint32_t>(command::create_shader_module));
     inline constexpr uint32_t ioctl_destroy_shader_module = make_ioctl(static_cast<uint32_t>(command::destroy_shader_module));
     inline constexpr uint32_t ioctl_get_shader_module_identifier = make_ioctl(static_cast<uint32_t>(command::get_shader_module_identifier));
+    inline constexpr uint32_t ioctl_get_shader_module_create_info_identifier =
+        make_ioctl(static_cast<uint32_t>(command::get_shader_module_create_info_identifier));
     inline constexpr uint32_t ioctl_create_image_view = make_ioctl(static_cast<uint32_t>(command::create_image_view));
     inline constexpr uint32_t ioctl_destroy_image_view = make_ioctl(static_cast<uint32_t>(command::destroy_image_view));
     inline constexpr uint32_t ioctl_create_buffer_view = make_ioctl(static_cast<uint32_t>(command::create_buffer_view));
@@ -1290,21 +1293,24 @@ namespace sogen::gpu_bridge
         object_id object;
     };
 
-    // ioctl_create_shader_module: in header immediately followed by `code_size` bytes of SPIR-V;
-    // out = object_response
+    // ioctl_create_shader_module / ioctl_get_shader_module_create_info_identifier: header immediately
+    // followed by `code_size` bytes of SPIR-V. The create command returns object_response; the identifier
+    // command returns shader_module_identifier_response.
     struct create_shader_module_request
     {
         object_id device;
         uint32_t code_size; // bytes (multiple of 4)
-        uint32_t reserved;
+        uint32_t flags;     // VkShaderModuleCreateFlags
         // uint8_t code[code_size];
     };
+
+    inline constexpr uint32_t max_shader_module_identifier_size = 32;
 
     struct shader_module_identifier_response
     {
         int32_t vk_result;
         uint32_t identifier_size;
-        std::array<uint8_t, 32> identifier;
+        std::array<uint8_t, max_shader_module_identifier_size> identifier;
     };
 
     struct create_image_view_request
@@ -1537,6 +1543,13 @@ namespace sogen::gpu_bridge
         uint32_t offset;
     };
 
+    // A VkVertexInputBindingDivisorDescription flattened to plain integers.
+    struct vertex_input_divisor
+    {
+        uint32_t binding;
+        uint32_t divisor;
+    };
+
     // A VkSpecializationMapEntry flattened (size is size_t in Vulkan; the wire keeps it 32-bit because the
     // guest is 32-bit and DXVK's spec constants are all 4 bytes). DXVK bakes d3d9 render state -- notably
     // SpecAlphaCompareOp (a VkCompareOp) -- into shaders via specialization constants; dropping them defaults
@@ -1549,9 +1562,9 @@ namespace sogen::gpu_bridge
         uint32_t size;
     };
 
-    // color attachment). The vertex input state is variable-length: the input buffer is this header
-    // immediately followed by `binding_count` vertex_input_binding entries and then `attribute_count`
-    // vertex_input_attribute entries. Both counts 0 => no vertex input (vertices baked into the shader).
+    // color attachment). The vertex input state is variable-length: the input buffer is this header,
+    // followed by binding_count vertex_input_binding entries, attribute_count vertex_input_attribute entries,
+    // and divisor_count vertex_input_divisor entries. Zero counts mean the corresponding state is absent.
     // out = object_response
     inline constexpr uint32_t max_color_attachments = 8;
 
@@ -1570,13 +1583,24 @@ namespace sogen::gpu_bridge
         uint32_t color_write_mask;       // VkColorComponentFlags
     };
 
+    // A pipeline shader stage is backed either by a bridge shader-module object or by an EXT shader-module
+    // identifier. Exactly one of module and identifier_size must be non-zero.
+    struct shader_stage_source
+    {
+        object_id module;
+        uint32_t identifier_size;
+        uint32_t reserved;
+        std::array<uint8_t, max_shader_module_identifier_size> identifier{};
+    };
+
     struct create_graphics_pipeline_request
     {
         object_id device;
         object_id render_pass; // 0 => dynamic rendering: use the attachment formats below, and viewport/scissor are dynamic
         object_id pipeline_layout;
-        object_id vertex_shader;
-        object_id fragment_shader;
+        shader_stage_source vertex_shader;
+        shader_stage_source fragment_shader;
+        uint32_t flags; // VkPipelineCreateFlags
         uint32_t width;
         uint32_t height;
         uint32_t depth_test_enable;  // VkBool32 (0 => no depth-stencil state, as before)
@@ -1603,10 +1627,11 @@ namespace sogen::gpu_bridge
         // Per-color-attachment blend state (DXVK bakes D3D9 alpha blending statically). blend_attachment_count
         // entries are valid; the rest are zero. When blend_attachment_count == 0 the host disables blending.
         uint32_t blend_attachment_count;
-        uint32_t reserved_blend;
+        uint32_t divisor_count; // number of vertex_input_divisor entries trailing the attributes
         std::array<pipeline_blend_attachment, max_color_attachments> blend_attachments{};
         // vertex_input_binding bindings[binding_count];
         // vertex_input_attribute attributes[attribute_count];
+        // vertex_input_divisor divisors[divisor_count];
         // uint32_t dynamic_states[dynamic_state_count]; // VkDynamicState values DXVK declared on the pipeline
         // specialization_map_entry vs_spec_entries[vs_spec_entry_count];
         // uint8_t vs_spec_data[vs_spec_data_size];
@@ -1618,7 +1643,9 @@ namespace sogen::gpu_bridge
     {
         object_id device;
         object_id pipeline_layout;
-        object_id shader_module;
+        shader_stage_source shader;
+        uint32_t flags; // VkPipelineCreateFlags
+        uint32_t reserved;
     };
 
     struct create_compute_pipeline_response
@@ -2060,7 +2087,12 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(get_image_subresource_layout_request) == 32, "wire layout drift");
     static_assert(sizeof(get_image_subresource_layout_response) == 48, "wire layout drift");
     static_assert(sizeof(create_buffer_view_request) == 40, "wire layout drift");
+    static_assert(sizeof(create_shader_module_request) == 16, "wire layout drift");
     static_assert(sizeof(shader_module_identifier_response) == 40, "wire layout drift");
+    static_assert(sizeof(shader_stage_source) == 48, "wire layout drift");
+    static_assert(sizeof(vertex_input_divisor) == 8, "wire layout drift");
+    static_assert(sizeof(create_compute_pipeline_request) == 72, "wire layout drift");
+    static_assert(sizeof(create_graphics_pipeline_request) == 496, "wire layout drift");
     static_assert(sizeof(buffer_copy_region) == 24, "wire layout drift");
     static_assert(sizeof(cmd_copy_buffer_request) == 32, "wire layout drift");
     static_assert(sizeof(create_query_pool_request) == 24, "wire layout drift");

--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -183,6 +183,7 @@ namespace sogen::gpu_bridge
         free_descriptor_sets = 0x890,
         get_shader_module_identifier = 0x891,
         get_shader_module_create_info_identifier = 0x892,
+        get_descriptor_set_layout_support = 0x893,
     };
 
     // Discriminator for cmd_set_dynamic_u32: the family of extended-dynamic-state setters that all take a
@@ -278,6 +279,8 @@ namespace sogen::gpu_bridge
     inline constexpr uint32_t ioctl_get_surface_capabilities = make_ioctl(static_cast<uint32_t>(command::get_surface_capabilities));
     inline constexpr uint32_t ioctl_record_commands = make_ioctl(static_cast<uint32_t>(command::record_commands));
     inline constexpr uint32_t ioctl_create_descriptor_set_layout = make_ioctl(static_cast<uint32_t>(command::create_descriptor_set_layout));
+    inline constexpr uint32_t ioctl_get_descriptor_set_layout_support =
+        make_ioctl(static_cast<uint32_t>(command::get_descriptor_set_layout_support));
     inline constexpr uint32_t ioctl_destroy_descriptor_set_layout =
         make_ioctl(static_cast<uint32_t>(command::destroy_descriptor_set_layout));
     inline constexpr uint32_t ioctl_create_descriptor_pool = make_ioctl(static_cast<uint32_t>(command::create_descriptor_pool));
@@ -1950,6 +1953,23 @@ namespace sogen::gpu_bridge
         // descriptor_set_layout_binding bindings[binding_count];
     };
 
+    // A separate query payload deliberately preserves the existing create-layout wire format. The bridge
+    // only evaluates the subset it can also create faithfully: flags == 0, no input pNext structures, and
+    // no immutable samplers. More advanced layouts are rejected conservatively by the guest shim.
+    struct get_descriptor_set_layout_support_request
+    {
+        object_id device;
+        uint32_t binding_count;
+        uint32_t reserved;
+        // descriptor_set_layout_binding bindings[binding_count];
+    };
+
+    struct descriptor_set_layout_support_response
+    {
+        int32_t vk_result;
+        uint32_t supported; // VkBool32
+    };
+
     // One pool size (trailing-array element of create_descriptor_pool).
     struct descriptor_pool_size
     {
@@ -2132,6 +2152,8 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(cmd_set_stencil_op_request) == 32, "wire layout drift");
     static_assert(sizeof(cmd_set_dynamic_u32_request) == 16, "wire layout drift");
     static_assert(sizeof(descriptor_set_layout_binding) == 16, "wire layout drift");
+    static_assert(sizeof(get_descriptor_set_layout_support_request) == 16, "wire layout drift");
+    static_assert(sizeof(descriptor_set_layout_support_response) == 8, "wire layout drift");
     static_assert(sizeof(cmd_bind_descriptor_sets_request) == 32, "wire layout drift");
     static_assert(sizeof(create_sampler_request) == 64, "wire layout drift");
     static_assert(sizeof(enumerate_device_extension_properties_request) == 16, "wire layout drift");

--- a/src/gpu-bridge-protocol/vk_feature_chain.hpp
+++ b/src/gpu-bridge-protocol/vk_feature_chain.hpp
@@ -50,8 +50,6 @@ namespace sogen::gpu_bridge
             return sizeof(VkPhysicalDeviceMaintenance9FeaturesKHR);
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES:
             return sizeof(VkPhysicalDeviceVertexAttributeDivisorFeatures);
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT:
-            return sizeof(VkPhysicalDeviceTransformFeedbackFeaturesEXT);
         default:
             return 0;
         }
@@ -97,8 +95,6 @@ namespace sogen::gpu_bridge
             return sizeof(VkPhysicalDeviceVertexAttributeDivisorProperties);
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT:
             return sizeof(VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT);
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT:
-            return sizeof(VkPhysicalDeviceTransformFeedbackPropertiesEXT);
         default:
             return 0;
         }

--- a/src/gpu-bridge-protocol/vk_feature_chain.hpp
+++ b/src/gpu-bridge-protocol/vk_feature_chain.hpp
@@ -48,6 +48,10 @@ namespace sogen::gpu_bridge
             return sizeof(VkPhysicalDeviceMaintenance8FeaturesKHR);
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_9_FEATURES_KHR:
             return sizeof(VkPhysicalDeviceMaintenance9FeaturesKHR);
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES:
+            return sizeof(VkPhysicalDeviceVertexAttributeDivisorFeatures);
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT:
+            return sizeof(VkPhysicalDeviceTransformFeedbackFeaturesEXT);
         default:
             return 0;
         }
@@ -89,6 +93,12 @@ namespace sogen::gpu_bridge
             return sizeof(VkPhysicalDeviceMaintenance7PropertiesKHR);
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_9_PROPERTIES_KHR:
             return sizeof(VkPhysicalDeviceMaintenance9PropertiesKHR);
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES:
+            return sizeof(VkPhysicalDeviceVertexAttributeDivisorProperties);
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT:
+            return sizeof(VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT);
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT:
+            return sizeof(VkPhysicalDeviceTransformFeedbackPropertiesEXT);
         default:
             return 0;
         }

--- a/src/samples/vulkan-shim-test/vulkan-shim-test.cpp
+++ b/src/samples/vulkan-shim-test/vulkan-shim-test.cpp
@@ -5,7 +5,9 @@
 
 #include <windows.h>
 
+#include <array>
 #include <cstdio>
+#include <cstring>
 #include <vector>
 
 #define VK_NO_PROTOTYPES
@@ -84,6 +86,120 @@ namespace
 
         destroy_fence(device, fence, nullptr);
         destroy_command_pool(device, pool, nullptr);
+    }
+
+    // Records both promoted spellings with synchronization2-only stage bits. Ending the command buffer
+    // flushes the shim command stream, so this catches any truncation or legacy-stage substitution.
+    bool test_write_timestamp2(PFN_vkGetInstanceProcAddr get_instance_proc, VkInstance instance, VkDevice device, uint32_t queue_family,
+                               PFN_vkCmdWriteTimestamp2 write_timestamp2, PFN_vkCmdWriteTimestamp2KHR write_timestamp2_khr)
+    {
+        const auto create_command_pool = reinterpret_cast<PFN_vkCreateCommandPool>(get_instance_proc(instance, "vkCreateCommandPool"));
+        const auto destroy_command_pool = reinterpret_cast<PFN_vkDestroyCommandPool>(get_instance_proc(instance, "vkDestroyCommandPool"));
+        const auto allocate_command_buffers =
+            reinterpret_cast<PFN_vkAllocateCommandBuffers>(get_instance_proc(instance, "vkAllocateCommandBuffers"));
+        const auto begin_command_buffer = reinterpret_cast<PFN_vkBeginCommandBuffer>(get_instance_proc(instance, "vkBeginCommandBuffer"));
+        const auto end_command_buffer = reinterpret_cast<PFN_vkEndCommandBuffer>(get_instance_proc(instance, "vkEndCommandBuffer"));
+        const auto create_query_pool = reinterpret_cast<PFN_vkCreateQueryPool>(get_instance_proc(instance, "vkCreateQueryPool"));
+        const auto destroy_query_pool = reinterpret_cast<PFN_vkDestroyQueryPool>(get_instance_proc(instance, "vkDestroyQueryPool"));
+        if (!create_command_pool || !destroy_command_pool || !allocate_command_buffers || !begin_command_buffer || !end_command_buffer ||
+            !create_query_pool || !destroy_query_pool)
+        {
+            std::printf("[shim-test] timestamp2 support entry point missing\n");
+            return false;
+        }
+
+        VkCommandPoolCreateInfo pool_info{};
+        pool_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+        pool_info.queueFamilyIndex = queue_family;
+
+        VkCommandPool pool = VK_NULL_HANDLE;
+        if (create_command_pool(device, &pool_info, nullptr, &pool) != VK_SUCCESS)
+        {
+            std::printf("[shim-test] timestamp2 vkCreateCommandPool failed\n");
+            return false;
+        }
+
+        VkCommandBufferAllocateInfo alloc_info{};
+        alloc_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+        alloc_info.commandPool = pool;
+        alloc_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        alloc_info.commandBufferCount = 1;
+
+        VkCommandBuffer command_buffer = VK_NULL_HANDLE;
+        const VkResult allocate_result = allocate_command_buffers(device, &alloc_info, &command_buffer);
+
+        VkQueryPoolCreateInfo query_info{};
+        query_info.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+        query_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
+        query_info.queryCount = 2;
+
+        VkQueryPool query_pool = VK_NULL_HANDLE;
+        const VkResult query_result = create_query_pool(device, &query_info, nullptr, &query_pool);
+
+        VkResult begin_result = VK_ERROR_INITIALIZATION_FAILED;
+        VkResult end_result = VK_ERROR_INITIALIZATION_FAILED;
+        if (allocate_result == VK_SUCCESS && query_result == VK_SUCCESS)
+        {
+            VkCommandBufferBeginInfo begin_info{};
+            begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+            begin_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+            begin_result = begin_command_buffer(command_buffer, &begin_info);
+            if (begin_result == VK_SUCCESS)
+            {
+                write_timestamp2(command_buffer, VK_PIPELINE_STAGE_2_COPY_BIT, query_pool, 0);
+                write_timestamp2_khr(command_buffer, VK_PIPELINE_STAGE_2_RESOLVE_BIT, query_pool, 1);
+                end_result = end_command_buffer(command_buffer);
+            }
+        }
+
+        const bool ok =
+            allocate_result == VK_SUCCESS && query_result == VK_SUCCESS && begin_result == VK_SUCCESS && end_result == VK_SUCCESS;
+        std::printf("[shim-test] timestamp2 stage2-only recording -> %s\n", ok ? "PASS" : "FAIL");
+
+        if (query_pool != VK_NULL_HANDLE)
+        {
+            destroy_query_pool(device, query_pool, nullptr);
+        }
+        destroy_command_pool(device, pool, nullptr);
+        return ok;
+    }
+
+    bool test_calibrated_timestamps(PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsKHR get_time_domains_khr,
+                                    PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT get_time_domains_ext,
+                                    PFN_vkGetCalibratedTimestampsKHR get_timestamps_khr,
+                                    PFN_vkGetCalibratedTimestampsEXT get_timestamps_ext, VkPhysicalDevice physical_device, VkDevice device)
+    {
+        uint32_t khr_count = 0;
+        uint32_t ext_count = 0;
+        const VkResult khr_count_result = get_time_domains_khr(physical_device, &khr_count, nullptr);
+        const VkResult ext_count_result = get_time_domains_ext(physical_device, &ext_count, nullptr);
+        if (khr_count_result != VK_SUCCESS || ext_count_result != VK_SUCCESS || khr_count == 0 || ext_count == 0)
+        {
+            std::printf("[shim-test] calibrated timestamp domains KHR=%d/%u EXT=%d/%u -> FAIL\n", khr_count_result, khr_count,
+                        ext_count_result, ext_count);
+            return false;
+        }
+
+        std::vector<VkTimeDomainKHR> khr_domains(khr_count);
+        std::vector<VkTimeDomainKHR> ext_domains(ext_count);
+        const VkResult khr_domains_result = get_time_domains_khr(physical_device, &khr_count, khr_domains.data());
+        const VkResult ext_domains_result = get_time_domains_ext(physical_device, &ext_count, ext_domains.data());
+
+        VkCalibratedTimestampInfoKHR timestamp_info{};
+        timestamp_info.sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR;
+        timestamp_info.timeDomain = khr_domains.front();
+        uint64_t khr_timestamp = 0;
+        uint64_t ext_timestamp = 0;
+        uint64_t khr_deviation = 0;
+        uint64_t ext_deviation = 0;
+        const VkResult khr_result = get_timestamps_khr(device, 1, &timestamp_info, &khr_timestamp, &khr_deviation);
+        const VkResult ext_result = get_timestamps_ext(device, 1, &timestamp_info, &ext_timestamp, &ext_deviation);
+        const bool ok =
+            khr_domains_result == VK_SUCCESS && ext_domains_result == VK_SUCCESS && khr_result == VK_SUCCESS && ext_result == VK_SUCCESS;
+        std::printf("[shim-test] calibrated timestamps KHR=%d/%llu EXT=%d/%llu -> %s\n", khr_result,
+                    static_cast<unsigned long long>(khr_deviation), ext_result, static_cast<unsigned long long>(ext_deviation),
+                    ok ? "PASS" : "FAIL");
+        return ok;
     }
 
     // Picks the first memory type that is set in `type_bits` and carries all of `required` property
@@ -492,11 +608,27 @@ int main(int argc, char** argv)
 
     const auto write_timestamp2 = reinterpret_cast<PFN_vkCmdWriteTimestamp2>(get_instance_proc(nullptr, "vkCmdWriteTimestamp2"));
     const auto write_timestamp2_khr = reinterpret_cast<PFN_vkCmdWriteTimestamp2KHR>(get_instance_proc(nullptr, "vkCmdWriteTimestamp2KHR"));
-    if (!write_timestamp2 || !write_timestamp2_khr)
+    const auto draw_indirect_count_khr =
+        reinterpret_cast<PFN_vkCmdDrawIndirectCountKHR>(get_instance_proc(nullptr, "vkCmdDrawIndirectCountKHR"));
+    const auto draw_indexed_indirect_count_khr =
+        reinterpret_cast<PFN_vkCmdDrawIndexedIndirectCountKHR>(get_instance_proc(nullptr, "vkCmdDrawIndexedIndirectCountKHR"));
+    const auto get_time_domains_khr = reinterpret_cast<PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsKHR>(
+        get_instance_proc(nullptr, "vkGetPhysicalDeviceCalibrateableTimeDomainsKHR"));
+    const auto get_time_domains_ext = reinterpret_cast<PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT>(
+        get_instance_proc(nullptr, "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT"));
+    const auto get_calibrated_timestamps_khr =
+        reinterpret_cast<PFN_vkGetCalibratedTimestampsKHR>(get_instance_proc(nullptr, "vkGetCalibratedTimestampsKHR"));
+    const auto get_calibrated_timestamps_ext =
+        reinterpret_cast<PFN_vkGetCalibratedTimestampsEXT>(get_instance_proc(nullptr, "vkGetCalibratedTimestampsEXT"));
+    if (!write_timestamp2 || !write_timestamp2_khr || !draw_indirect_count_khr || !draw_indexed_indirect_count_khr ||
+        !get_time_domains_khr || !get_time_domains_ext || !get_calibrated_timestamps_khr || !get_calibrated_timestamps_ext)
     {
-        std::printf("[shim-test] no vkCmdWriteTimestamp2 entry point\n");
+        std::printf("[shim-test] promoted command alias missing\n");
         return 3;
     }
+
+    bool timestamp2_test_ok = true;
+    bool calibrated_timestamps_test_ok = true;
 
     const auto create_instance = reinterpret_cast<PFN_vkCreateInstance>(get_instance_proc(nullptr, "vkCreateInstance"));
     if (!create_instance)
@@ -547,9 +679,50 @@ int main(int argc, char** argv)
         // Create a logical device on the first physical device, using a graphics-capable queue family.
         const auto get_queue_families = reinterpret_cast<PFN_vkGetPhysicalDeviceQueueFamilyProperties>(
             get_instance_proc(instance, "vkGetPhysicalDeviceQueueFamilyProperties"));
+        const auto enumerate_device_extensions =
+            reinterpret_cast<PFN_vkEnumerateDeviceExtensionProperties>(get_instance_proc(instance, "vkEnumerateDeviceExtensionProperties"));
+        const auto get_features2 =
+            reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2>(get_instance_proc(instance, "vkGetPhysicalDeviceFeatures2"));
         const auto create_device = reinterpret_cast<PFN_vkCreateDevice>(get_instance_proc(instance, "vkCreateDevice"));
         const auto get_device_queue = reinterpret_cast<PFN_vkGetDeviceQueue>(get_instance_proc(instance, "vkGetDeviceQueue"));
         const auto destroy_device = reinterpret_cast<PFN_vkDestroyDevice>(get_instance_proc(instance, "vkDestroyDevice"));
+
+        const char* calibrated_timestamps_extension = nullptr;
+        if (enumerate_device_extensions)
+        {
+            uint32_t extension_count = 0;
+            if (enumerate_device_extensions(devices[0], nullptr, &extension_count, nullptr) == VK_SUCCESS)
+            {
+                std::vector<VkExtensionProperties> extensions(extension_count);
+                if (enumerate_device_extensions(devices[0], nullptr, &extension_count, extensions.data()) == VK_SUCCESS)
+                {
+                    for (const VkExtensionProperties& extension : extensions)
+                    {
+                        if (std::strcmp(extension.extensionName, VK_KHR_CALIBRATED_TIMESTAMPS_EXTENSION_NAME) == 0)
+                        {
+                            calibrated_timestamps_extension = VK_KHR_CALIBRATED_TIMESTAMPS_EXTENSION_NAME;
+                            break;
+                        }
+                        if (std::strcmp(extension.extensionName, VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME) == 0)
+                        {
+                            calibrated_timestamps_extension = VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME;
+                        }
+                    }
+                }
+            }
+        }
+
+        bool synchronization2_supported = false;
+        if (get_features2)
+        {
+            VkPhysicalDeviceVulkan13Features vulkan13_features{};
+            vulkan13_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;
+            VkPhysicalDeviceFeatures2 features2{};
+            features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+            features2.pNext = &vulkan13_features;
+            get_features2(devices[0], &features2);
+            synchronization2_supported = vulkan13_features.synchronization2 == VK_TRUE;
+        }
 
         uint32_t family_count = 0;
         get_queue_families(devices[0], &family_count, nullptr);
@@ -557,29 +730,56 @@ int main(int argc, char** argv)
         get_queue_families(devices[0], &family_count, families.data());
 
         uint32_t graphics_family = UINT32_MAX;
+        uint32_t timestamp_family = UINT32_MAX;
         for (uint32_t i = 0; i < family_count; ++i)
         {
-            if (families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT)
+            if ((families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) && graphics_family == UINT32_MAX)
             {
                 graphics_family = i;
-                break;
+            }
+            if ((families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) && families[i].timestampValidBits != 0 && timestamp_family == UINT32_MAX)
+            {
+                timestamp_family = i;
             }
         }
-        std::printf("[shim-test] queue families=%u, graphics family=%u\n", family_count, graphics_family);
+        const bool timestamp2_test_supported = synchronization2_supported && timestamp_family != UINT32_MAX;
+        std::printf("[shim-test] queue families=%u, graphics family=%u, timestamp family=%u\n", family_count, graphics_family,
+                    timestamp_family);
 
         if (graphics_family != UINT32_MAX)
         {
             const float priority = 1.0f;
-            VkDeviceQueueCreateInfo queue_info{};
-            queue_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-            queue_info.queueFamilyIndex = graphics_family;
-            queue_info.queueCount = 1;
-            queue_info.pQueuePriorities = &priority;
+            std::array<VkDeviceQueueCreateInfo, 2> queue_infos{};
+            queue_infos[0].sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+            queue_infos[0].queueFamilyIndex = graphics_family;
+            queue_infos[0].queueCount = 1;
+            queue_infos[0].pQueuePriorities = &priority;
+            uint32_t queue_info_count = 1;
+            if (timestamp2_test_supported && timestamp_family != graphics_family)
+            {
+                queue_infos[1].sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+                queue_infos[1].queueFamilyIndex = timestamp_family;
+                queue_infos[1].queueCount = 1;
+                queue_infos[1].pQueuePriorities = &priority;
+                queue_info_count = 2;
+            }
+
+            VkPhysicalDeviceVulkan13Features enabled_vulkan13_features{};
+            enabled_vulkan13_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;
+            enabled_vulkan13_features.synchronization2 = timestamp2_test_supported ? VK_TRUE : VK_FALSE;
 
             VkDeviceCreateInfo device_info{};
             device_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-            device_info.queueCreateInfoCount = 1;
-            device_info.pQueueCreateInfos = &queue_info;
+            device_info.queueCreateInfoCount = queue_info_count;
+            device_info.pQueueCreateInfos = queue_infos.data();
+            device_info.pNext = timestamp2_test_supported ? &enabled_vulkan13_features : nullptr;
+            std::vector<const char*> enabled_extensions;
+            if (calibrated_timestamps_extension)
+            {
+                enabled_extensions.push_back(calibrated_timestamps_extension);
+            }
+            device_info.enabledExtensionCount = static_cast<uint32_t>(enabled_extensions.size());
+            device_info.ppEnabledExtensionNames = enabled_extensions.data();
 
             VkDevice device = VK_NULL_HANDLE;
             const VkResult device_result = create_device(devices[0], &device_info, nullptr, &device);
@@ -590,6 +790,26 @@ int main(int argc, char** argv)
                 VkQueue queue = VK_NULL_HANDLE;
                 get_device_queue(device, graphics_family, 0, &queue);
                 std::printf("[shim-test] vkGetDeviceQueue -> queue=%p\n", static_cast<void*>(queue));
+
+                if (timestamp2_test_supported)
+                {
+                    timestamp2_test_ok = test_write_timestamp2(get_instance_proc, instance, device, timestamp_family, write_timestamp2,
+                                                               write_timestamp2_khr);
+                }
+                else
+                {
+                    std::printf("[shim-test] timestamp2 stage2-only recording -> SKIP (synchronization2 or timestamps unavailable)\n");
+                }
+                if (calibrated_timestamps_extension)
+                {
+                    calibrated_timestamps_test_ok =
+                        test_calibrated_timestamps(get_time_domains_khr, get_time_domains_ext, get_calibrated_timestamps_khr,
+                                                   get_calibrated_timestamps_ext, devices[0], device);
+                }
+                else
+                {
+                    std::printf("[shim-test] calibrated timestamps -> SKIP (extension unavailable)\n");
+                }
 
                 submit_and_wait(get_instance_proc, instance, device, queue, graphics_family);
                 fill_buffer_and_readback(get_instance_proc, instance, devices[0], device, queue, graphics_family);
@@ -605,6 +825,7 @@ int main(int argc, char** argv)
         destroy_instance(instance, nullptr);
     }
 
-    std::printf("[shim-test] ok\n");
-    return 0;
+    const bool all_ok = timestamp2_test_ok && calibrated_timestamps_test_ok;
+    std::printf("[shim-test] %s\n", all_ok ? "ok" : "FAILED");
+    return all_ok ? 0 : 6;
 }

--- a/src/samples/vulkan-shim-test/vulkan-shim-test.cpp
+++ b/src/samples/vulkan-shim-test/vulkan-shim-test.cpp
@@ -490,6 +490,14 @@ int main(int argc, char** argv)
         return 2;
     }
 
+    const auto write_timestamp2 = reinterpret_cast<PFN_vkCmdWriteTimestamp2>(get_instance_proc(nullptr, "vkCmdWriteTimestamp2"));
+    const auto write_timestamp2_khr = reinterpret_cast<PFN_vkCmdWriteTimestamp2KHR>(get_instance_proc(nullptr, "vkCmdWriteTimestamp2KHR"));
+    if (!write_timestamp2 || !write_timestamp2_khr)
+    {
+        std::printf("[shim-test] no vkCmdWriteTimestamp2 entry point\n");
+        return 3;
+    }
+
     const auto create_instance = reinterpret_cast<PFN_vkCreateInstance>(get_instance_proc(nullptr, "vkCreateInstance"));
     if (!create_instance)
     {

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -4403,18 +4403,33 @@ extern "C"
                 height = static_cast<uint32_t>(ci.pViewportState->pViewports[0].height);
             }
 
-            // Vertex input state (variable-length): flatten the binding/attribute descriptions after the
-            // request header. Empty state (vertices baked into the shader) just sends counts of 0.
+            // Vertex input state (variable-length): flatten bindings, attributes, and the optional
+            // VkPipelineVertexInputDivisorStateCreateInfo pNext payload after the request header.
             uint32_t binding_count = 0;
             uint32_t attribute_count = 0;
+            uint32_t divisor_count = 0;
             const VkVertexInputBindingDescription* vk_bindings = nullptr;
             const VkVertexInputAttributeDescription* vk_attributes = nullptr;
+            const VkVertexInputBindingDivisorDescription* vk_divisors = nullptr;
             if (ci.pVertexInputState)
             {
                 binding_count = ci.pVertexInputState->vertexBindingDescriptionCount;
                 attribute_count = ci.pVertexInputState->vertexAttributeDescriptionCount;
                 vk_bindings = ci.pVertexInputState->pVertexBindingDescriptions;
                 vk_attributes = ci.pVertexInputState->pVertexAttributeDescriptions;
+
+                for (const auto* base = static_cast<const VkBaseInStructure*>(ci.pVertexInputState->pNext); base != nullptr;
+                     base = base->pNext)
+                {
+                    if (base->sType != VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO)
+                    {
+                        continue;
+                    }
+                    const auto* divisor_state = reinterpret_cast<const VkPipelineVertexInputDivisorStateCreateInfo*>(base);
+                    divisor_count = divisor_state->vertexBindingDivisorCount;
+                    vk_divisors = divisor_state->pVertexBindingDivisors;
+                    break;
+                }
             }
 
             gb::create_graphics_pipeline_request request{};
@@ -4433,6 +4448,7 @@ extern "C"
             }
             request.binding_count = binding_count;
             request.attribute_count = attribute_count;
+            request.divisor_count = divisor_count;
             request.rasterization_samples = ci.pMultisampleState ? static_cast<uint32_t>(ci.pMultisampleState->rasterizationSamples) : 1u;
 
             request.primitive_topology = static_cast<uint32_t>(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST);
@@ -4506,6 +4522,7 @@ extern "C"
             };
             std::vector<uint8_t> message(sizeof(request) + static_cast<size_t>(binding_count) * sizeof(gb::vertex_input_binding) +
                                          static_cast<size_t>(attribute_count) * sizeof(gb::vertex_input_attribute) +
+                                         static_cast<size_t>(divisor_count) * sizeof(gb::vertex_input_divisor) +
                                          static_cast<size_t>(dynamic_state_count) * sizeof(uint32_t) +
                                          spec_block_bytes(vs_spec_entries, vs_spec_bytes) +
                                          spec_block_bytes(fs_spec_entries, fs_spec_bytes));
@@ -4527,6 +4544,14 @@ extern "C"
                 wire.binding = vk_attributes[a].binding;
                 wire.format = static_cast<uint32_t>(vk_attributes[a].format);
                 wire.offset = vk_attributes[a].offset;
+                std::memcpy(message.data() + cursor, &wire, sizeof(wire));
+                cursor += sizeof(wire);
+            }
+            for (uint32_t d = 0; d < divisor_count; ++d)
+            {
+                gb::vertex_input_divisor wire{};
+                wire.binding = vk_divisors[d].binding;
+                wire.divisor = vk_divisors[d].divisor;
                 std::memcpy(message.data() + cursor, &wire, sizeof(wire));
                 cursor += sizeof(wire);
             }

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -256,8 +256,6 @@ namespace
     // lock. Each record is a gb::command_record_header followed by that command's request payload.
     std::unordered_map<gb::object_id, std::vector<uint8_t>> g_command_streams;
 
-    uint64_t g_next_pipeline_cache = UINT64_C(0xF000000000000000);
-
     // Pending coalesced vkUpdateDescriptorSets blobs (the hottest bridge call - DXVK updates per draw).
     // Unlike the per-command-buffer streams (each synchronised to one thread by Vulkan), this global is
     // touched by every DXVK thread, and the preemptive time-slice can interrupt a thread mid-append, so the
@@ -1808,17 +1806,12 @@ extern "C"
                                                                           VkPipelineStageFlags2 pipelineStage, VkQueryPool queryPool,
                                                                           uint32_t query)
     {
-        VkPipelineStageFlagBits legacy_stage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-        if (pipelineStage == VK_PIPELINE_STAGE_2_NONE)
-        {
-            // NONE has an empty first synchronization scope, matching legacy TOP_OF_PIPE.
-            legacy_stage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-        }
-        else if (pipelineStage <= UINT32_MAX)
-        {
-            legacy_stage = static_cast<VkPipelineStageFlagBits>(pipelineStage);
-        }
-        vkCmdWriteTimestamp(commandBuffer, legacy_stage, queryPool, query);
+        gb::cmd_write_timestamp2_request request{};
+        request.command_buffer = to_object_id(commandBuffer);
+        request.query_pool = to_object_id(queryPool);
+        request.query = query;
+        request.pipeline_stage = static_cast<uint64_t>(pipelineStage);
+        record_command(request.command_buffer, gb::command::cmd_write_timestamp2, &request, sizeof(request));
     }
 
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer,
@@ -3391,42 +3384,195 @@ extern "C"
         }
     }
 
-    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL
-    vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR(VkPhysicalDevice, uint32_t* pPropertyCount, VkCooperativeMatrixPropertiesKHR*)
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR(
+        VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount, VkCooperativeMatrixPropertiesKHR* pProperties)
     {
         if (!pPropertyCount)
         {
-            return VK_INCOMPLETE;
+            return VK_ERROR_INITIALIZATION_FAILED;
         }
 
-        *pPropertyCount = 0;
-        return VK_SUCCESS;
+        gb::physical_device_enumeration_request request{};
+        request.physical_device = to_object_id(physicalDevice);
+        request.max_count = pProperties ? *pPropertyCount : 0;
+        request.has_entries = pProperties != nullptr;
+
+        const size_t capacity = request.max_count;
+        if (capacity > (SIZE_MAX - sizeof(gb::physical_device_enumeration_response)) / sizeof(gb::cooperative_matrix_property))
+        {
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+        const size_t buffer_size = sizeof(gb::physical_device_enumeration_response) + capacity * sizeof(gb::cooperative_matrix_property);
+        if (buffer_size > MAXDWORD)
+        {
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+        std::vector<std::byte> buffer(buffer_size);
+        if (!bridge_call(gb::ioctl_get_physical_device_cooperative_matrix_properties, &request, sizeof(request), buffer.data(),
+                         static_cast<DWORD>(buffer.size())))
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        const auto* response = reinterpret_cast<const gb::physical_device_enumeration_response*>(buffer.data());
+        const uint32_t written = std::min<uint32_t>(response->count, request.max_count);
+        const auto* entries =
+            reinterpret_cast<const gb::cooperative_matrix_property*>(buffer.data() + sizeof(gb::physical_device_enumeration_response));
+        for (uint32_t i = 0; i < written; ++i)
+        {
+            pProperties[i].sType = VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_KHR;
+            pProperties[i].MSize = entries[i].m_size;
+            pProperties[i].NSize = entries[i].n_size;
+            pProperties[i].KSize = entries[i].k_size;
+            pProperties[i].AType = static_cast<VkComponentTypeKHR>(entries[i].a_type);
+            pProperties[i].BType = static_cast<VkComponentTypeKHR>(entries[i].b_type);
+            pProperties[i].CType = static_cast<VkComponentTypeKHR>(entries[i].c_type);
+            pProperties[i].ResultType = static_cast<VkComponentTypeKHR>(entries[i].result_type);
+            pProperties[i].saturatingAccumulation = entries[i].saturating_accumulation;
+            pProperties[i].scope = static_cast<VkScopeKHR>(entries[i].scope);
+        }
+        *pPropertyCount = response->count;
+        return static_cast<VkResult>(response->vk_result);
     }
 
-    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceFragmentShadingRatesKHR(VkPhysicalDevice,
-                                                                                                    uint32_t* pFragmentShadingRateCount,
-                                                                                                    VkPhysicalDeviceFragmentShadingRateKHR*)
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceFragmentShadingRatesKHR(
+        VkPhysicalDevice physicalDevice, uint32_t* pFragmentShadingRateCount, VkPhysicalDeviceFragmentShadingRateKHR* pFragmentShadingRates)
     {
         if (!pFragmentShadingRateCount)
         {
-            return VK_INCOMPLETE;
+            return VK_ERROR_INITIALIZATION_FAILED;
         }
 
-        *pFragmentShadingRateCount = 0;
-        return VK_SUCCESS;
+        gb::physical_device_enumeration_request request{};
+        request.physical_device = to_object_id(physicalDevice);
+        request.max_count = pFragmentShadingRates ? *pFragmentShadingRateCount : 0;
+        request.has_entries = pFragmentShadingRates != nullptr;
+
+        const size_t capacity = request.max_count;
+        if (capacity > (SIZE_MAX - sizeof(gb::physical_device_enumeration_response)) / sizeof(gb::fragment_shading_rate))
+        {
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+        const size_t buffer_size = sizeof(gb::physical_device_enumeration_response) + capacity * sizeof(gb::fragment_shading_rate);
+        if (buffer_size > MAXDWORD)
+        {
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+        std::vector<std::byte> buffer(buffer_size);
+        if (!bridge_call(gb::ioctl_get_physical_device_fragment_shading_rates, &request, sizeof(request), buffer.data(),
+                         static_cast<DWORD>(buffer.size())))
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        const auto* response = reinterpret_cast<const gb::physical_device_enumeration_response*>(buffer.data());
+        const uint32_t written = std::min<uint32_t>(response->count, request.max_count);
+        const auto* entries =
+            reinterpret_cast<const gb::fragment_shading_rate*>(buffer.data() + sizeof(gb::physical_device_enumeration_response));
+        for (uint32_t i = 0; i < written; ++i)
+        {
+            pFragmentShadingRates[i].sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_KHR;
+            pFragmentShadingRates[i].sampleCounts = entries[i].sample_counts;
+            pFragmentShadingRates[i].fragmentSize = {.width = entries[i].width, .height = entries[i].height};
+        }
+        *pFragmentShadingRateCount = response->count;
+        return static_cast<VkResult>(response->vk_result);
     }
 
-    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceCalibrateableTimeDomainsKHR(VkPhysicalDevice,
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceCalibrateableTimeDomainsKHR(VkPhysicalDevice physicalDevice,
                                                                                                         uint32_t* pTimeDomainCount,
-                                                                                                        VkTimeDomainKHR*)
+                                                                                                        VkTimeDomainKHR* pTimeDomains)
     {
         if (!pTimeDomainCount)
         {
-            return VK_INCOMPLETE;
+            return VK_ERROR_INITIALIZATION_FAILED;
         }
 
-        *pTimeDomainCount = 0;
-        return VK_SUCCESS;
+        gb::physical_device_enumeration_request request{};
+        request.physical_device = to_object_id(physicalDevice);
+        request.max_count = pTimeDomains ? *pTimeDomainCount : 0;
+        request.has_entries = pTimeDomains != nullptr;
+
+        const size_t capacity = request.max_count;
+        if (capacity > (SIZE_MAX - sizeof(gb::physical_device_enumeration_response)) / sizeof(uint32_t))
+        {
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+        const size_t buffer_size = sizeof(gb::physical_device_enumeration_response) + capacity * sizeof(uint32_t);
+        if (buffer_size > MAXDWORD)
+        {
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+        std::vector<std::byte> buffer(buffer_size);
+        if (!bridge_call(gb::ioctl_get_physical_device_calibrateable_time_domains, &request, sizeof(request), buffer.data(),
+                         static_cast<DWORD>(buffer.size())))
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        const auto* response = reinterpret_cast<const gb::physical_device_enumeration_response*>(buffer.data());
+        const uint32_t written = std::min<uint32_t>(response->count, request.max_count);
+        const auto* entries = reinterpret_cast<const uint32_t*>(buffer.data() + sizeof(gb::physical_device_enumeration_response));
+        for (uint32_t i = 0; i < written; ++i)
+        {
+            pTimeDomains[i] = static_cast<VkTimeDomainKHR>(entries[i]);
+        }
+        *pTimeDomainCount = response->count;
+        return static_cast<VkResult>(response->vk_result);
+    }
+
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(VkPhysicalDevice physicalDevice,
+                                                                                                        uint32_t* pTimeDomainCount,
+                                                                                                        VkTimeDomainKHR* pTimeDomains)
+    {
+        return vkGetPhysicalDeviceCalibrateableTimeDomainsKHR(physicalDevice, pTimeDomainCount, pTimeDomains);
+    }
+
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkGetCalibratedTimestampsKHR(VkDevice device, uint32_t timestampCount,
+                                                                                      const VkCalibratedTimestampInfoKHR* pTimestampInfos,
+                                                                                      uint64_t* pTimestamps, uint64_t* pMaxDeviation)
+    {
+        if (timestampCount == 0 || !pTimestampInfos || !pTimestamps || !pMaxDeviation)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        if (timestampCount > (MAXDWORD - sizeof(gb::get_calibrated_timestamps_response)) / sizeof(uint64_t))
+        {
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+
+        gb::get_calibrated_timestamps_request request{};
+        request.device = to_object_id(device);
+        request.timestamp_count = timestampCount;
+
+        const size_t input_size = sizeof(request) + static_cast<size_t>(timestampCount) * sizeof(uint32_t);
+        std::vector<std::byte> input(input_size);
+        std::memcpy(input.data(), &request, sizeof(request));
+        for (uint32_t i = 0; i < timestampCount; ++i)
+        {
+            const auto time_domain = static_cast<uint32_t>(pTimestampInfos[i].timeDomain);
+            std::memcpy(input.data() + sizeof(request) + static_cast<size_t>(i) * sizeof(time_domain), &time_domain, sizeof(time_domain));
+        }
+
+        const size_t output_size = sizeof(gb::get_calibrated_timestamps_response) + static_cast<size_t>(timestampCount) * sizeof(uint64_t);
+        std::vector<std::byte> output(output_size);
+        if (!bridge_call(gb::ioctl_get_calibrated_timestamps, input.data(), static_cast<DWORD>(input.size()), output.data(),
+                         static_cast<DWORD>(output.size())))
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        const auto* response = reinterpret_cast<const gb::get_calibrated_timestamps_response*>(output.data());
+        *pMaxDeviation = response->max_deviation;
+        std::memcpy(pTimestamps, output.data() + sizeof(*response), static_cast<size_t>(timestampCount) * sizeof(uint64_t));
+        return static_cast<VkResult>(response->vk_result);
+    }
+
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkGetCalibratedTimestampsEXT(VkDevice device, uint32_t timestampCount,
+                                                                                      const VkCalibratedTimestampInfoKHR* pTimestampInfos,
+                                                                                      uint64_t* pTimestamps, uint64_t* pMaxDeviation)
+    {
+        return vkGetCalibratedTimestampsKHR(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation);
     }
 
     // VK_KHR_get_surface_capabilities2 / VK_EXT_surface_maintenance1: delegate to the KHR queries.
@@ -3720,25 +3866,6 @@ extern "C"
                                                                            const VkAllocationCallbacks*)
     {
         destroy_device_child(gb::ioctl_destroy_shader_module, device, shaderModule);
-    }
-
-    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetShaderModuleIdentifierEXT(VkDevice device, VkShaderModule shaderModule,
-                                                                                    VkShaderModuleIdentifierEXT* pIdentifier)
-    {
-        gb::device_child_request request{};
-        request.device = to_object_id(device);
-        request.object = to_object_id(shaderModule);
-
-        gb::shader_module_identifier_response response{};
-        if (!bridge_call(gb::ioctl_get_shader_module_identifier, &request, sizeof(request), &response, sizeof(response)) ||
-            response.vk_result != VK_SUCCESS)
-        {
-            pIdentifier->identifierSize = 0;
-            return;
-        }
-
-        pIdentifier->identifierSize = std::min<uint32_t>(response.identifier_size, VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT);
-        std::memcpy(pIdentifier->identifier, response.identifier.data(), pIdentifier->identifierSize);
     }
 
     __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
@@ -4267,8 +4394,9 @@ extern "C"
         return static_cast<VkResult>(response.vk_result);
     }
 
-    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetDescriptorSetLayoutSupport(
-        VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo, VkDescriptorSetLayoutSupport* pSupport)
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetDescriptorSetLayoutSupport(VkDevice device,
+                                                                                     const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+                                                                                     VkDescriptorSetLayoutSupport* pSupport)
     {
         if (!pSupport)
         {
@@ -4293,8 +4421,7 @@ extern "C"
             }
         }
 
-        if (unsupported_output_chain || !pCreateInfo ||
-            (pCreateInfo->bindingCount != 0 && !pCreateInfo->pBindings))
+        if (unsupported_output_chain || !pCreateInfo || (pCreateInfo->bindingCount != 0 && !pCreateInfo->pBindings))
         {
             return;
         }
@@ -4317,8 +4444,7 @@ extern "C"
         gb::get_descriptor_set_layout_support_request header{};
         header.device = to_object_id(device);
         header.binding_count = pCreateInfo->bindingCount;
-        if (header.binding_count >
-            (static_cast<size_t>(UINT32_MAX) - sizeof(header)) / sizeof(gb::descriptor_set_layout_binding))
+        if (header.binding_count > (static_cast<size_t>(UINT32_MAX) - sizeof(header)) / sizeof(gb::descriptor_set_layout_binding))
         {
             return;
         }
@@ -4349,8 +4475,9 @@ extern "C"
         pSupport->supported = response.supported ? VK_TRUE : VK_FALSE;
     }
 
-    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetDescriptorSetLayoutSupportKHR(
-        VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo, VkDescriptorSetLayoutSupport* pSupport)
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetDescriptorSetLayoutSupportKHR(VkDevice device,
+                                                                                        const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+                                                                                        VkDescriptorSetLayoutSupport* pSupport)
     {
         vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport);
     }
@@ -4366,12 +4493,24 @@ extern "C"
         }
     }
 
-    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetDeviceMemoryCommitment(VkDevice, VkDeviceMemory,
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetDeviceMemoryCommitment(VkDevice device, VkDeviceMemory memory,
                                                                                  VkDeviceSize* pCommittedMemoryInBytes)
     {
-        if (pCommittedMemoryInBytes)
+        if (!pCommittedMemoryInBytes)
         {
-            *pCommittedMemoryInBytes = 0;
+            return;
+        }
+
+        *pCommittedMemoryInBytes = 0;
+        gb::get_device_memory_commitment_request request{};
+        request.device = to_object_id(device);
+        request.memory = to_object_id(memory);
+
+        gb::get_device_memory_commitment_response response{};
+        if (bridge_call(gb::ioctl_get_device_memory_commitment, &request, sizeof(request), &response, sizeof(response)) &&
+            response.vk_result == VK_SUCCESS)
+        {
+            *pCommittedMemoryInBytes = response.committed_bytes;
         }
     }
 
@@ -4442,37 +4581,6 @@ extern "C"
             }
             return VK_NULL_HANDLE;
         }
-    }
-
-    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkCreatePipelineCache(VkDevice, const VkPipelineCacheCreateInfo*,
-                                                                               const VkAllocationCallbacks*,
-                                                                               VkPipelineCache* pPipelineCache)
-    {
-        if (!pPipelineCache)
-        {
-            return VK_ERROR_INITIALIZATION_FAILED;
-        }
-        *pPipelineCache = to_handle<VkPipelineCache>(g_next_pipeline_cache++);
-        return VK_SUCCESS;
-    }
-
-    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkDestroyPipelineCache(VkDevice, VkPipelineCache, const VkAllocationCallbacks*)
-    {
-    }
-
-    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkGetPipelineCacheData(VkDevice, VkPipelineCache, size_t* pDataSize, void*)
-    {
-        if (!pDataSize)
-        {
-            return VK_ERROR_INITIALIZATION_FAILED;
-        }
-        *pDataSize = 0;
-        return VK_SUCCESS;
-    }
-
-    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkMergePipelineCaches(VkDevice, VkPipelineCache, uint32_t, const VkPipelineCache*)
-    {
-        return VK_SUCCESS;
     }
 
     __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkCreateGraphicsPipelines(VkDevice device, VkPipelineCache,
@@ -4558,6 +4666,7 @@ extern "C"
             request.pipeline_layout = to_object_id(ci.layout);
             request.vertex_shader = vertex_shader;
             request.fragment_shader = fragment_shader;
+            request.flags = static_cast<uint32_t>(ci.flags & ~VK_PIPELINE_CREATE_DERIVATIVE_BIT);
             request.width = width;
             request.height = height;
             if (ci.pDepthStencilState && ci.pDepthStencilState->depthTestEnable)
@@ -4738,6 +4847,7 @@ extern "C"
             request.device = to_object_id(device);
             request.pipeline_layout = to_object_id(ci.layout);
             request.shader_module = to_object_id(module);
+            request.flags = static_cast<uint32_t>(ci.flags & ~VK_PIPELINE_CREATE_DERIVATIVE_BIT);
 
             gb::create_compute_pipeline_response response{};
             const bool ok = bridge_call(gb::ioctl_create_compute_pipeline, &request, sizeof(request), &response, sizeof(response));
@@ -4948,6 +5058,14 @@ extern "C"
         record_command(request.command_buffer, gb::command::cmd_draw_indexed_indirect_count, &request, sizeof(request));
     }
 
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer,
+                                                                                      VkDeviceSize offset, VkBuffer countBuffer,
+                                                                                      VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
+                                                                                      uint32_t stride)
+    {
+        vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+    }
+
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                                        uint32_t drawCount, uint32_t stride)
     {
@@ -4974,6 +5092,14 @@ extern "C"
         request.max_draw_count = maxDrawCount;
         request.stride = stride;
         record_command(request.command_buffer, gb::command::cmd_draw_indirect_count, &request, sizeof(request));
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer,
+                                                                               VkDeviceSize offset, VkBuffer countBuffer,
+                                                                               VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
+                                                                               uint32_t stride)
+    {
+        vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
     }
 
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdBindDescriptorSets(VkCommandBuffer commandBuffer,
@@ -5238,6 +5364,10 @@ extern "C"
              .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetPhysicalDeviceFragmentShadingRatesKHR)},
             {.name = "vkGetPhysicalDeviceCalibrateableTimeDomainsKHR",
              .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetPhysicalDeviceCalibrateableTimeDomainsKHR)},
+            {.name = "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT",
+             .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetPhysicalDeviceCalibrateableTimeDomainsEXT)},
+            {.name = "vkGetCalibratedTimestampsKHR", .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetCalibratedTimestampsKHR)},
+            {.name = "vkGetCalibratedTimestampsEXT", .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetCalibratedTimestampsEXT)},
             {.name = "vkGetPhysicalDeviceSurfaceCapabilities2KHR",
              .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetPhysicalDeviceSurfaceCapabilities2KHR)},
             {.name = "vkGetPhysicalDeviceSurfaceFormats2KHR",
@@ -5386,7 +5516,6 @@ extern "C"
             {.name = "vkQueuePresentKHR", .func = reinterpret_cast<PFN_vkVoidFunction>(vkQueuePresentKHR)},
             {.name = "vkCreateShaderModule", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateShaderModule)},
             {.name = "vkDestroyShaderModule", .func = reinterpret_cast<PFN_vkVoidFunction>(vkDestroyShaderModule)},
-            {.name = "vkGetShaderModuleIdentifierEXT", .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetShaderModuleIdentifierEXT)},
             {.name = "vkCreateImageView", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateImageView)},
             {.name = "vkDestroyImageView", .func = reinterpret_cast<PFN_vkVoidFunction>(vkDestroyImageView)},
             {.name = "vkCreateRenderPass", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateRenderPass)},
@@ -5426,10 +5555,6 @@ extern "C"
              .func = reinterpret_cast<PFN_vkVoidFunction>(vkUpdateDescriptorSetWithTemplate)},
             {.name = "vkCmdBindDescriptorSets", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBindDescriptorSets)},
             {.name = "vkCreateGraphicsPipelines", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateGraphicsPipelines)},
-            {.name = "vkCreatePipelineCache", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreatePipelineCache)},
-            {.name = "vkDestroyPipelineCache", .func = reinterpret_cast<PFN_vkVoidFunction>(vkDestroyPipelineCache)},
-            {.name = "vkGetPipelineCacheData", .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetPipelineCacheData)},
-            {.name = "vkMergePipelineCaches", .func = reinterpret_cast<PFN_vkVoidFunction>(vkMergePipelineCaches)},
             {.name = "vkCreateComputePipelines", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateComputePipelines)},
             {.name = "vkDestroyPipeline", .func = reinterpret_cast<PFN_vkVoidFunction>(vkDestroyPipeline)},
             {.name = "vkCmdBeginRenderPass", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBeginRenderPass)},
@@ -5456,8 +5581,10 @@ extern "C"
             {.name = "vkCmdDrawIndexed", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDrawIndexed)},
             {.name = "vkCmdDrawIndexedIndirect", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDrawIndexedIndirect)},
             {.name = "vkCmdDrawIndexedIndirectCount", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDrawIndexedIndirectCount)},
+            {.name = "vkCmdDrawIndexedIndirectCountKHR", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDrawIndexedIndirectCountKHR)},
             {.name = "vkCmdDrawIndirect", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDrawIndirect)},
             {.name = "vkCmdDrawIndirectCount", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDrawIndirectCount)},
+            {.name = "vkCmdDrawIndirectCountKHR", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDrawIndirectCountKHR)},
             {.name = "vkCmdEndRenderPass", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdEndRenderPass)},
             {.name = "vkCmdNextSubpass", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdNextSubpass)},
             {.name = "vkCmdPushConstants", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdPushConstants)},

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -227,6 +227,8 @@ namespace
     // lock. Each record is a gb::command_record_header followed by that command's request payload.
     std::unordered_map<gb::object_id, std::vector<uint8_t>> g_command_streams;
 
+    uint64_t g_next_pipeline_cache = UINT64_C(0xF000000000000000);
+
     // Pending coalesced vkUpdateDescriptorSets blobs (the hottest bridge call - DXVK updates per draw).
     // Unlike the per-command-buffer streams (each synchronised to one thread by Vulkan), this global is
     // touched by every DXVK thread, and the preemptive time-slice can interrupt a thread mid-append, so the
@@ -337,6 +339,27 @@ extern "C"
             if (auto* const fn = real_global_command<PFN_vkEnumerateInstanceLayerProperties>("vkEnumerateInstanceLayerProperties"))
             {
                 return fn(pPropertyCount, pProperties);
+            }
+        }
+
+        if (!pPropertyCount)
+        {
+            return VK_INCOMPLETE;
+        }
+
+        *pPropertyCount = 0;
+        return VK_SUCCESS;
+    }
+
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice,
+                                                                                          uint32_t* pPropertyCount,
+                                                                                          VkLayerProperties* pProperties)
+    {
+        if (passthrough_active())
+        {
+            if (auto* const fn = real_global_command<PFN_vkEnumerateDeviceLayerProperties>("vkEnumerateDeviceLayerProperties"))
+            {
+                return fn(physicalDevice, pPropertyCount, pProperties);
             }
         }
 
@@ -1729,6 +1752,39 @@ extern "C"
         record_command(request.command_buffer, gb::command::cmd_write_timestamp, &request, sizeof(request));
     }
 
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
+                                                                               uint32_t firstQuery, uint32_t queryCount, VkBuffer dstBuffer,
+                                                                               VkDeviceSize dstOffset, VkDeviceSize stride,
+                                                                               VkQueryResultFlags flags)
+    {
+        gb::cmd_copy_query_pool_results_request request{};
+        request.command_buffer = to_object_id(commandBuffer);
+        request.query_pool = to_object_id(queryPool);
+        request.first_query = firstQuery;
+        request.query_count = queryCount;
+        request.destination_buffer = to_object_id(dstBuffer);
+        request.destination_offset = dstOffset;
+        request.stride = stride;
+        request.flags = static_cast<uint32_t>(flags);
+        record_command(request.command_buffer, gb::command::cmd_copy_query_pool_results, &request, sizeof(request));
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdWriteTimestamp2(VkCommandBuffer commandBuffer,
+                                                                          VkPipelineStageFlags2 pipelineStage, VkQueryPool queryPool,
+                                                                          uint32_t query)
+    {
+        const auto legacy_stage = pipelineStage != 0 && pipelineStage <= 0xffffffffULL ? static_cast<VkPipelineStageFlagBits>(pipelineStage)
+                                                                                       : VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+        vkCmdWriteTimestamp(commandBuffer, legacy_stage, queryPool, query);
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer,
+                                                                             VkPipelineStageFlags2 pipelineStage, VkQueryPool queryPool,
+                                                                             uint32_t query)
+    {
+        vkCmdWriteTimestamp2(commandBuffer, pipelineStage, queryPool, query);
+    }
+
     // --- Extended-dynamic-state setters: record into the command stream, replayed on the host. ---
 
     static void record_set_dynamic_u32(VkCommandBuffer commandBuffer, gb::dynamic_state_u32 state, uint32_t value)
@@ -2642,6 +2698,36 @@ extern "C"
         }
     }
 
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo);
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage,
+                                                                    VkImageLayout srcImageLayout, VkImage dstImage,
+                                                                    VkImageLayout dstImageLayout, uint32_t regionCount,
+                                                                    const VkImageBlit* pRegions, VkFilter filter)
+    {
+        std::vector<VkImageBlit2> regions(regionCount);
+        for (uint32_t i = 0; i < regionCount; ++i)
+        {
+            regions[i].sType = VK_STRUCTURE_TYPE_IMAGE_BLIT_2;
+            regions[i].srcSubresource = pRegions[i].srcSubresource;
+            regions[i].srcOffsets[0] = pRegions[i].srcOffsets[0];
+            regions[i].srcOffsets[1] = pRegions[i].srcOffsets[1];
+            regions[i].dstSubresource = pRegions[i].dstSubresource;
+            regions[i].dstOffsets[0] = pRegions[i].dstOffsets[0];
+            regions[i].dstOffsets[1] = pRegions[i].dstOffsets[1];
+        }
+        VkBlitImageInfo2 info{};
+        info.sType = VK_STRUCTURE_TYPE_BLIT_IMAGE_INFO_2;
+        info.srcImage = srcImage;
+        info.srcImageLayout = srcImageLayout;
+        info.dstImage = dstImage;
+        info.dstImageLayout = dstImageLayout;
+        info.regionCount = regionCount;
+        info.pRegions = regions.data();
+        info.filter = filter;
+        vkCmdBlitImage2(commandBuffer, &info);
+    }
+
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo)
     {
         if (!pBlitImageInfo)
@@ -3256,6 +3342,44 @@ extern "C"
         }
     }
 
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL
+    vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR(VkPhysicalDevice, uint32_t* pPropertyCount, VkCooperativeMatrixPropertiesKHR*)
+    {
+        if (!pPropertyCount)
+        {
+            return VK_INCOMPLETE;
+        }
+
+        *pPropertyCount = 0;
+        return VK_SUCCESS;
+    }
+
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceFragmentShadingRatesKHR(VkPhysicalDevice,
+                                                                                                    uint32_t* pFragmentShadingRateCount,
+                                                                                                    VkPhysicalDeviceFragmentShadingRateKHR*)
+    {
+        if (!pFragmentShadingRateCount)
+        {
+            return VK_INCOMPLETE;
+        }
+
+        *pFragmentShadingRateCount = 0;
+        return VK_SUCCESS;
+    }
+
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceCalibrateableTimeDomainsKHR(VkPhysicalDevice,
+                                                                                                        uint32_t* pTimeDomainCount,
+                                                                                                        VkTimeDomainKHR*)
+    {
+        if (!pTimeDomainCount)
+        {
+            return VK_INCOMPLETE;
+        }
+
+        *pTimeDomainCount = 0;
+        return VK_SUCCESS;
+    }
+
     // VK_KHR_get_surface_capabilities2 / VK_EXT_surface_maintenance1: delegate to the KHR queries.
     __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL
     vkGetPhysicalDeviceSurfaceCapabilities2KHR(VkPhysicalDevice physicalDevice, const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
@@ -3547,6 +3671,25 @@ extern "C"
                                                                            const VkAllocationCallbacks*)
     {
         destroy_device_child(gb::ioctl_destroy_shader_module, device, shaderModule);
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetShaderModuleIdentifierEXT(VkDevice device, VkShaderModule shaderModule,
+                                                                                    VkShaderModuleIdentifierEXT* pIdentifier)
+    {
+        gb::device_child_request request{};
+        request.device = to_object_id(device);
+        request.object = to_object_id(shaderModule);
+
+        gb::shader_module_identifier_response response{};
+        if (!bridge_call(gb::ioctl_get_shader_module_identifier, &request, sizeof(request), &response, sizeof(response)) ||
+            response.vk_result != VK_SUCCESS)
+        {
+            pIdentifier->identifierSize = 0;
+            return;
+        }
+
+        pIdentifier->identifierSize = std::min<uint32_t>(response.identifier_size, VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT);
+        std::memcpy(pIdentifier->identifier, response.identifier.data(), pIdentifier->identifierSize);
     }
 
     __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
@@ -3842,6 +3985,21 @@ extern "C"
         return VK_SUCCESS;
     }
 
+    namespace
+    {
+        bool is_image_descriptor(VkDescriptorType type)
+        {
+            return type == VK_DESCRIPTOR_TYPE_SAMPLER || type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+                   type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE || type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE ||
+                   type == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
+        }
+
+        bool is_texel_buffer_descriptor(VkDescriptorType type)
+        {
+            return type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER || type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
+        }
+    }
+
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkUpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount,
                                                                             const VkWriteDescriptorSet* pDescriptorWrites, uint32_t,
                                                                             const VkCopyDescriptorSet*)
@@ -3859,17 +4017,21 @@ extern "C"
                 wire.dst_binding = src.dstBinding;
                 wire.dst_array_element = src.dstArrayElement + e;
                 wire.descriptor_type = static_cast<uint32_t>(src.descriptorType);
-                if (src.pBufferInfo)
-                {
-                    wire.buffer = to_object_id(src.pBufferInfo[e].buffer);
-                    wire.offset = src.pBufferInfo[e].offset;
-                    wire.range = src.pBufferInfo[e].range;
-                }
-                if (src.pImageInfo)
+                if (is_image_descriptor(src.descriptorType))
                 {
                     wire.sampler = to_object_id(src.pImageInfo[e].sampler);
                     wire.image_view = to_object_id(src.pImageInfo[e].imageView);
                     wire.image_layout = static_cast<uint32_t>(src.pImageInfo[e].imageLayout);
+                }
+                else if (is_texel_buffer_descriptor(src.descriptorType))
+                {
+                    wire.buffer_or_view = to_object_id(src.pTexelBufferView[e]);
+                }
+                else
+                {
+                    wire.buffer_or_view = to_object_id(src.pBufferInfo[e].buffer);
+                    wire.offset = src.pBufferInfo[e].offset;
+                    wire.range = src.pBufferInfo[e].range;
                 }
                 writes.push_back(wire);
             }
@@ -3901,18 +4063,6 @@ extern "C"
         {
             std::vector<VkDescriptorUpdateTemplateEntry> entries;
         };
-
-        bool is_image_descriptor(VkDescriptorType type)
-        {
-            return type == VK_DESCRIPTOR_TYPE_SAMPLER || type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
-                   type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE || type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE ||
-                   type == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
-        }
-
-        bool is_texel_buffer_descriptor(VkDescriptorType type)
-        {
-            return type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER || type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
-        }
     }
 
     __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL
@@ -4038,8 +4188,96 @@ extern "C"
         {
             return static_cast<VkResult>(response.vk_result);
         }
+
         *pSampler = to_handle<VkSampler>(response.object);
         return VK_SUCCESS;
+    }
+
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool,
+                                                                              uint32_t descriptorSetCount,
+                                                                              const VkDescriptorSet* pDescriptorSets)
+    {
+        std::vector<uint8_t> message(sizeof(gb::free_descriptor_sets_request) +
+                                     static_cast<size_t>(descriptorSetCount) * sizeof(gb::object_id));
+        auto* request = reinterpret_cast<gb::free_descriptor_sets_request*>(message.data());
+        request->device = to_object_id(device);
+        request->descriptor_pool = to_object_id(descriptorPool);
+        request->set_count = descriptorSetCount;
+
+        auto* sets = reinterpret_cast<gb::object_id*>(message.data() + sizeof(*request));
+        for (uint32_t i = 0; i < descriptorSetCount; ++i)
+        {
+            sets[i] = to_object_id(pDescriptorSets[i]);
+        }
+
+        gb::result_response response{};
+        if (!bridge_call(gb::ioctl_free_descriptor_sets, message.data(), static_cast<DWORD>(message.size()), &response, sizeof(response)))
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        return static_cast<VkResult>(response.vk_result);
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetDescriptorSetLayoutSupport(VkDevice, const VkDescriptorSetLayoutCreateInfo*,
+                                                                                     VkDescriptorSetLayoutSupport* pSupport)
+    {
+        if (pSupport)
+        {
+            pSupport->supported = VK_TRUE;
+        }
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetDeviceImageSparseMemoryRequirements(VkDevice,
+                                                                                              const VkDeviceImageMemoryRequirements*,
+                                                                                              uint32_t* pSparseMemoryRequirementCount,
+                                                                                              VkSparseImageMemoryRequirements2*)
+    {
+        if (pSparseMemoryRequirementCount)
+        {
+            *pSparseMemoryRequirementCount = 0;
+        }
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetDeviceMemoryCommitment(VkDevice, VkDeviceMemory,
+                                                                                 VkDeviceSize* pCommittedMemoryInBytes)
+    {
+        if (pCommittedMemoryInBytes)
+        {
+            *pCommittedMemoryInBytes = 0;
+        }
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetImageSparseMemoryRequirements(VkDevice, VkImage,
+                                                                                        uint32_t* pSparseMemoryRequirementCount,
+                                                                                        VkSparseImageMemoryRequirements*)
+    {
+        if (pSparseMemoryRequirementCount)
+        {
+            *pSparseMemoryRequirementCount = 0;
+        }
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetImageSparseMemoryRequirements2(VkDevice,
+                                                                                         const VkImageSparseMemoryRequirementsInfo2*,
+                                                                                         uint32_t* pSparseMemoryRequirementCount,
+                                                                                         VkSparseImageMemoryRequirements2*)
+    {
+        if (pSparseMemoryRequirementCount)
+        {
+            *pSparseMemoryRequirementCount = 0;
+        }
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetImageSparseMemoryRequirements2KHR(
+        VkDevice device, const VkImageSparseMemoryRequirementsInfo2* pInfo, uint32_t* pSparseMemoryRequirementCount,
+        VkSparseImageMemoryRequirements2* pSparseMemoryRequirements)
+    {
+        vkGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
+    }
+
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkQueueBindSparse(VkQueue, uint32_t, const VkBindSparseInfo*, VkFence)
+    {
+        return VK_ERROR_FEATURE_NOT_PRESENT;
     }
 
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkDestroySampler(VkDevice device, VkSampler sampler, const VkAllocationCallbacks*)
@@ -4076,6 +4314,37 @@ extern "C"
             }
             return VK_NULL_HANDLE;
         }
+    }
+
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkCreatePipelineCache(VkDevice, const VkPipelineCacheCreateInfo*,
+                                                                               const VkAllocationCallbacks*,
+                                                                               VkPipelineCache* pPipelineCache)
+    {
+        if (!pPipelineCache)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        *pPipelineCache = to_handle<VkPipelineCache>(g_next_pipeline_cache++);
+        return VK_SUCCESS;
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkDestroyPipelineCache(VkDevice, VkPipelineCache, const VkAllocationCallbacks*)
+    {
+    }
+
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkGetPipelineCacheData(VkDevice, VkPipelineCache, size_t* pDataSize, void*)
+    {
+        if (!pDataSize)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        *pDataSize = 0;
+        return VK_SUCCESS;
+    }
+
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkMergePipelineCaches(VkDevice, VkPipelineCache, uint32_t, const VkPipelineCache*)
+    {
+        return VK_SUCCESS;
     }
 
     __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkCreateGraphicsPipelines(VkDevice device, VkPipelineCache,
@@ -4498,6 +4767,62 @@ extern "C"
         record_command(request.command_buffer, gb::command::cmd_draw_indexed, &request, sizeof(request));
     }
 
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer,
+                                                                              VkDeviceSize offset, uint32_t drawCount, uint32_t stride)
+    {
+        gb::cmd_draw_indexed_indirect_request request{};
+        request.command_buffer = to_object_id(commandBuffer);
+        request.buffer = to_object_id(buffer);
+        request.offset = offset;
+        request.draw_count = drawCount;
+        request.stride = stride;
+        record_command(request.command_buffer, gb::command::cmd_draw_indexed_indirect, &request, sizeof(request));
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer,
+                                                                                   VkDeviceSize offset, VkBuffer countBuffer,
+                                                                                   VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
+                                                                                   uint32_t stride)
+    {
+        gb::cmd_draw_indexed_indirect_count_request request{};
+        request.command_buffer = to_object_id(commandBuffer);
+        request.buffer = to_object_id(buffer);
+        request.offset = offset;
+        request.count_buffer = to_object_id(countBuffer);
+        request.count_buffer_offset = countBufferOffset;
+        request.max_draw_count = maxDrawCount;
+        request.stride = stride;
+        record_command(request.command_buffer, gb::command::cmd_draw_indexed_indirect_count, &request, sizeof(request));
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
+                                                                       uint32_t drawCount, uint32_t stride)
+    {
+        gb::cmd_draw_indirect_request request{};
+        request.command_buffer = to_object_id(commandBuffer);
+        request.buffer = to_object_id(buffer);
+        request.offset = offset;
+        request.draw_count = drawCount;
+        request.stride = stride;
+        record_command(request.command_buffer, gb::command::cmd_draw_indirect, &request, sizeof(request));
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer,
+                                                                            VkDeviceSize offset, VkBuffer countBuffer,
+                                                                            VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
+                                                                            uint32_t stride)
+    {
+        gb::cmd_draw_indirect_count_request request{};
+        request.command_buffer = to_object_id(commandBuffer);
+        request.buffer = to_object_id(buffer);
+        request.offset = offset;
+        request.count_buffer = to_object_id(countBuffer);
+        request.count_buffer_offset = countBufferOffset;
+        request.max_draw_count = maxDrawCount;
+        request.stride = stride;
+        record_command(request.command_buffer, gb::command::cmd_draw_indirect_count, &request, sizeof(request));
+    }
+
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdBindDescriptorSets(VkCommandBuffer commandBuffer,
                                                                              VkPipelineBindPoint pipelineBindPoint, VkPipelineLayout layout,
                                                                              uint32_t firstSet, uint32_t descriptorSetCount,
@@ -4561,6 +4886,14 @@ extern "C"
         gb::cmd_end_render_pass_request request{};
         request.command_buffer = to_object_id(commandBuffer);
         record_command(request.command_buffer, gb::command::cmd_end_render_pass, &request, sizeof(request));
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents)
+    {
+        gb::cmd_next_subpass_request request{};
+        request.command_buffer = to_object_id(commandBuffer);
+        request.contents = static_cast<uint32_t>(contents);
+        record_command(request.command_buffer, gb::command::cmd_next_subpass, &request, sizeof(request));
     }
 
     // Dynamic rendering (VK_KHR_dynamic_rendering / core 1.3): DXVK 2.x records draws inside this instead of
@@ -4708,6 +5041,7 @@ extern "C"
             {.name = "vkEnumerateInstanceVersion", .func = reinterpret_cast<PFN_vkVoidFunction>(vkEnumerateInstanceVersion)},
             {.name = "vkEnumerateInstanceLayerProperties",
              .func = reinterpret_cast<PFN_vkVoidFunction>(vkEnumerateInstanceLayerProperties)},
+            {.name = "vkEnumerateDeviceLayerProperties", .func = reinterpret_cast<PFN_vkVoidFunction>(vkEnumerateDeviceLayerProperties)},
             {.name = "vkEnumerateInstanceExtensionProperties",
              .func = reinterpret_cast<PFN_vkVoidFunction>(vkEnumerateInstanceExtensionProperties)},
             {.name = "vkEnumeratePhysicalDevices", .func = reinterpret_cast<PFN_vkVoidFunction>(vkEnumeratePhysicalDevices)},
@@ -4745,6 +5079,12 @@ extern "C"
              .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetPhysicalDeviceSparseImageFormatProperties)},
             {.name = "vkGetPhysicalDeviceSparseImageFormatProperties2",
              .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetPhysicalDeviceSparseImageFormatProperties2)},
+            {.name = "vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR",
+             .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR)},
+            {.name = "vkGetPhysicalDeviceFragmentShadingRatesKHR",
+             .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetPhysicalDeviceFragmentShadingRatesKHR)},
+            {.name = "vkGetPhysicalDeviceCalibrateableTimeDomainsKHR",
+             .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetPhysicalDeviceCalibrateableTimeDomainsKHR)},
             {.name = "vkGetPhysicalDeviceSurfaceCapabilities2KHR",
              .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetPhysicalDeviceSurfaceCapabilities2KHR)},
             {.name = "vkGetPhysicalDeviceSurfaceFormats2KHR",
@@ -4825,7 +5165,10 @@ extern "C"
             {.name = "vkCmdResetQueryPool", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdResetQueryPool)},
             {.name = "vkCmdBeginQuery", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBeginQuery)},
             {.name = "vkCmdEndQuery", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdEndQuery)},
+            {.name = "vkCmdCopyQueryPoolResults", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdCopyQueryPoolResults)},
             {.name = "vkCmdWriteTimestamp", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdWriteTimestamp)},
+            {.name = "vkCmdWriteTimestamp2", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdWriteTimestamp2)},
+            {.name = "vkCmdWriteTimestamp2KHR", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdWriteTimestamp2KHR)},
             {.name = "vkFlushMappedMemoryRanges", .func = reinterpret_cast<PFN_vkVoidFunction>(vkFlushMappedMemoryRanges)},
             {.name = "vkInvalidateMappedMemoryRanges", .func = reinterpret_cast<PFN_vkVoidFunction>(vkInvalidateMappedMemoryRanges)},
             {.name = "vkGetBufferMemoryRequirements", .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetBufferMemoryRequirements)},
@@ -4890,6 +5233,7 @@ extern "C"
             {.name = "vkQueuePresentKHR", .func = reinterpret_cast<PFN_vkVoidFunction>(vkQueuePresentKHR)},
             {.name = "vkCreateShaderModule", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateShaderModule)},
             {.name = "vkDestroyShaderModule", .func = reinterpret_cast<PFN_vkVoidFunction>(vkDestroyShaderModule)},
+            {.name = "vkGetShaderModuleIdentifierEXT", .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetShaderModuleIdentifierEXT)},
             {.name = "vkCreateImageView", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateImageView)},
             {.name = "vkDestroyImageView", .func = reinterpret_cast<PFN_vkVoidFunction>(vkDestroyImageView)},
             {.name = "vkCreateRenderPass", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateRenderPass)},
@@ -4904,6 +5248,18 @@ extern "C"
             {.name = "vkDestroyDescriptorPool", .func = reinterpret_cast<PFN_vkVoidFunction>(vkDestroyDescriptorPool)},
             {.name = "vkResetDescriptorPool", .func = reinterpret_cast<PFN_vkVoidFunction>(vkResetDescriptorPool)},
             {.name = "vkAllocateDescriptorSets", .func = reinterpret_cast<PFN_vkVoidFunction>(vkAllocateDescriptorSets)},
+            {.name = "vkFreeDescriptorSets", .func = reinterpret_cast<PFN_vkVoidFunction>(vkFreeDescriptorSets)},
+            {.name = "vkGetDescriptorSetLayoutSupport", .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetDescriptorSetLayoutSupport)},
+            {.name = "vkGetDeviceImageSparseMemoryRequirements",
+             .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetDeviceImageSparseMemoryRequirements)},
+            {.name = "vkGetDeviceMemoryCommitment", .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetDeviceMemoryCommitment)},
+            {.name = "vkGetImageSparseMemoryRequirements",
+             .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetImageSparseMemoryRequirements)},
+            {.name = "vkGetImageSparseMemoryRequirements2",
+             .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetImageSparseMemoryRequirements2)},
+            {.name = "vkGetImageSparseMemoryRequirements2KHR",
+             .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetImageSparseMemoryRequirements2KHR)},
+            {.name = "vkQueueBindSparse", .func = reinterpret_cast<PFN_vkVoidFunction>(vkQueueBindSparse)},
             {.name = "vkUpdateDescriptorSets", .func = reinterpret_cast<PFN_vkVoidFunction>(vkUpdateDescriptorSets)},
             {.name = "vkCreateDescriptorUpdateTemplate", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateDescriptorUpdateTemplate)},
             {.name = "vkCreateDescriptorUpdateTemplateKHR", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateDescriptorUpdateTemplate)},
@@ -4915,6 +5271,10 @@ extern "C"
              .func = reinterpret_cast<PFN_vkVoidFunction>(vkUpdateDescriptorSetWithTemplate)},
             {.name = "vkCmdBindDescriptorSets", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBindDescriptorSets)},
             {.name = "vkCreateGraphicsPipelines", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateGraphicsPipelines)},
+            {.name = "vkCreatePipelineCache", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreatePipelineCache)},
+            {.name = "vkDestroyPipelineCache", .func = reinterpret_cast<PFN_vkVoidFunction>(vkDestroyPipelineCache)},
+            {.name = "vkGetPipelineCacheData", .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetPipelineCacheData)},
+            {.name = "vkMergePipelineCaches", .func = reinterpret_cast<PFN_vkVoidFunction>(vkMergePipelineCaches)},
             {.name = "vkCreateComputePipelines", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateComputePipelines)},
             {.name = "vkDestroyPipeline", .func = reinterpret_cast<PFN_vkVoidFunction>(vkDestroyPipeline)},
             {.name = "vkCmdBeginRenderPass", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBeginRenderPass)},
@@ -4928,6 +5288,7 @@ extern "C"
             {.name = "vkCmdDispatch", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDispatch)},
             {.name = "vkCmdDispatchIndirect", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDispatchIndirect)},
             {.name = "vkCmdBlitImage2", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBlitImage2)},
+            {.name = "vkCmdBlitImage", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBlitImage)},
             {.name = "vkCmdBlitImage2KHR", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBlitImage2KHR)},
             {.name = "vkCmdBindVertexBuffers", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBindVertexBuffers)},
             {.name = "vkCmdBindVertexBuffers2", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBindVertexBuffers2)},
@@ -4938,7 +5299,12 @@ extern "C"
             {.name = "vkCmdBindIndexBuffer2KHR", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBindIndexBuffer2KHR)},
             {.name = "vkCmdBindIndexBuffer2", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBindIndexBuffer2KHR)},
             {.name = "vkCmdDrawIndexed", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDrawIndexed)},
+            {.name = "vkCmdDrawIndexedIndirect", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDrawIndexedIndirect)},
+            {.name = "vkCmdDrawIndexedIndirectCount", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDrawIndexedIndirectCount)},
+            {.name = "vkCmdDrawIndirect", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDrawIndirect)},
+            {.name = "vkCmdDrawIndirectCount", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDrawIndirectCount)},
             {.name = "vkCmdEndRenderPass", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdEndRenderPass)},
+            {.name = "vkCmdNextSubpass", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdNextSubpass)},
             {.name = "vkCmdPushConstants", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdPushConstants)},
             {.name = "vkCmdPushConstants2KHR", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdPushConstants2KHR)},
             {.name = "vkCmdPushConstants2", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdPushConstants2KHR)},

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -1773,8 +1773,16 @@ extern "C"
                                                                           VkPipelineStageFlags2 pipelineStage, VkQueryPool queryPool,
                                                                           uint32_t query)
     {
-        const auto legacy_stage = pipelineStage != 0 && pipelineStage <= 0xffffffffULL ? static_cast<VkPipelineStageFlagBits>(pipelineStage)
-                                                                                       : VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+        VkPipelineStageFlagBits legacy_stage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+        if (pipelineStage == VK_PIPELINE_STAGE_2_NONE)
+        {
+            // NONE has an empty first synchronization scope, matching legacy TOP_OF_PIPE.
+            legacy_stage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+        }
+        else if (pipelineStage <= UINT32_MAX)
+        {
+            legacy_stage = static_cast<VkPipelineStageFlagBits>(pipelineStage);
+        }
         vkCmdWriteTimestamp(commandBuffer, legacy_stage, queryPool, query);
     }
 

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -188,6 +188,35 @@ namespace
         }
     }
 
+    // Sparse operations are intentionally stubbed below, so none of the related capabilities may be
+    // advertised. Keep the masking in one place so the legacy and Features2/Properties2 query paths
+    // cannot drift apart.
+    void mask_unsupported_sparse_features(VkPhysicalDeviceFeatures& features)
+    {
+        features.shaderResourceResidency = VK_FALSE;
+        features.shaderResourceMinLod = VK_FALSE;
+        features.sparseBinding = VK_FALSE;
+        features.sparseResidencyBuffer = VK_FALSE;
+        features.sparseResidencyImage2D = VK_FALSE;
+        features.sparseResidencyImage3D = VK_FALSE;
+        features.sparseResidency2Samples = VK_FALSE;
+        features.sparseResidency4Samples = VK_FALSE;
+        features.sparseResidency8Samples = VK_FALSE;
+        features.sparseResidency16Samples = VK_FALSE;
+        features.sparseResidencyAliased = VK_FALSE;
+    }
+
+    void mask_unsupported_sparse_properties(VkPhysicalDeviceProperties& properties)
+    {
+        properties.limits.sparseAddressSpaceSize = 0;
+        properties.sparseProperties = {};
+    }
+
+    VkQueueFlags mask_unsupported_queue_flags(VkQueueFlags flags)
+    {
+        return flags & ~static_cast<VkQueueFlags>(VK_QUEUE_SPARSE_BINDING_BIT);
+    }
+
     // VkDeviceMemory is host-side; the guest can't see a host pointer. We emulate vkMapMemory by
     // staging a guest-side copy: download the host range on map, hand the app that buffer, and upload
     // it back on unmap so writes persist. allocationSize is tracked here to resolve VK_WHOLE_SIZE.
@@ -454,9 +483,15 @@ extern "C"
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
                                                                                    VkPhysicalDeviceProperties* pProperties)
     {
+        if (!pProperties)
+        {
+            return;
+        }
+
         gb::get_physical_device_properties_request request{};
         request.physical_device = to_object_id(physicalDevice);
         bridge_call(gb::ioctl_get_physical_device_properties, &request, sizeof(request), pProperties, sizeof(*pProperties));
+        mask_unsupported_sparse_properties(*pProperties);
     }
 
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice physicalDevice,
@@ -489,7 +524,7 @@ extern "C"
             reinterpret_cast<const gb::queue_family_properties*>(buffer.data() + sizeof(gb::get_queue_family_properties_response));
         for (uint32_t i = 0; i < written; ++i)
         {
-            pProperties[i] = {.queueFlags = families[i].queue_flags,
+            pProperties[i] = {.queueFlags = mask_unsupported_queue_flags(families[i].queue_flags),
                               .queueCount = families[i].queue_count,
                               .timestampValidBits = families[i].timestamp_valid_bits,
                               .minImageTransferGranularity = {.width = families[i].min_image_transfer_granularity_width,
@@ -2870,6 +2905,7 @@ extern "C"
         {
             flags[i] = VK_TRUE;
         }
+        mask_unsupported_sparse_features(*pFeatures);
     }
 
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceFeatures2(VkPhysicalDevice physicalDevice,
@@ -2879,6 +2915,9 @@ extern "C"
         {
             return;
         }
+
+        // Keep unsupported fields deterministic even if the bridge query fails before filling the root.
+        mask_unsupported_sparse_features(pFeatures->features);
 
         // Collect the caller's chain: the root VkPhysicalDeviceFeatures2 (carrying the base
         // VkPhysicalDeviceFeatures), then each pNext struct. For each we record its sType + pad-free
@@ -2953,6 +2992,8 @@ extern "C"
             }
             offset += record->body_size;
         }
+
+        mask_unsupported_sparse_features(pFeatures->features);
     }
 
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceProperties2(VkPhysicalDevice physicalDevice,
@@ -3124,7 +3165,7 @@ extern "C"
         for (uint32_t i = 0; i < count; ++i)
         {
             pProperties[i].queueFamilyProperties = {
-                .queueFlags = families[i].queue_flags,
+                .queueFlags = mask_unsupported_queue_flags(families[i].queue_flags),
                 .queueCount = families[i].queue_count,
                 .timestampValidBits = families[i].timestamp_valid_bits,
                 .minImageTransferGranularity = {.width = families[i].min_image_transfer_granularity_width,

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -4226,13 +4226,92 @@ extern "C"
         return static_cast<VkResult>(response.vk_result);
     }
 
-    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetDescriptorSetLayoutSupport(VkDevice, const VkDescriptorSetLayoutCreateInfo*,
-                                                                                     VkDescriptorSetLayoutSupport* pSupport)
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetDescriptorSetLayoutSupport(
+        VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo, VkDescriptorSetLayoutSupport* pSupport)
     {
-        if (pSupport)
+        if (!pSupport)
         {
-            pSupport->supported = VK_TRUE;
+            return;
         }
+
+        pSupport->supported = VK_FALSE;
+
+        // Initialize the one output-chain structure relevant to descriptor-layout support. Unknown output
+        // structures make the query unsupported rather than leaving partially initialized data behind.
+        bool unsupported_output_chain = false;
+        for (auto* base = static_cast<VkBaseOutStructure*>(pSupport->pNext); base != nullptr; base = base->pNext)
+        {
+            if (base->sType == VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT)
+            {
+                auto* const variable = reinterpret_cast<VkDescriptorSetVariableDescriptorCountLayoutSupport*>(base);
+                variable->maxVariableDescriptorCount = 0;
+            }
+            else
+            {
+                unsupported_output_chain = true;
+            }
+        }
+
+        if (unsupported_output_chain || !pCreateInfo ||
+            (pCreateInfo->bindingCount != 0 && !pCreateInfo->pBindings))
+        {
+            return;
+        }
+
+        // Keep this query aligned with what vkCreateDescriptorSetLayout currently marshals. Layout flags,
+        // input pNext structures (including binding flags), and immutable samplers are not represented by
+        // the create command, so claiming support for them would recreate the original false positive.
+        if (pCreateInfo->flags != 0 || pCreateInfo->pNext != nullptr)
+        {
+            return;
+        }
+        for (uint32_t i = 0; i < pCreateInfo->bindingCount; ++i)
+        {
+            if (pCreateInfo->pBindings[i].pImmutableSamplers != nullptr)
+            {
+                return;
+            }
+        }
+
+        gb::get_descriptor_set_layout_support_request header{};
+        header.device = to_object_id(device);
+        header.binding_count = pCreateInfo->bindingCount;
+        if (header.binding_count >
+            (static_cast<size_t>(UINT32_MAX) - sizeof(header)) / sizeof(gb::descriptor_set_layout_binding))
+        {
+            return;
+        }
+
+        std::vector<uint8_t> message(sizeof(header) +
+                                     static_cast<size_t>(header.binding_count) * sizeof(gb::descriptor_set_layout_binding));
+        std::memcpy(message.data(), &header, sizeof(header));
+        for (uint32_t i = 0; i < header.binding_count; ++i)
+        {
+            const VkDescriptorSetLayoutBinding& b = pCreateInfo->pBindings[i];
+            const gb::descriptor_set_layout_binding wire{
+                .binding = b.binding,
+                .descriptor_type = static_cast<uint32_t>(b.descriptorType),
+                .descriptor_count = b.descriptorCount,
+                .stage_flags = b.stageFlags,
+            };
+            std::memcpy(message.data() + sizeof(header) + static_cast<size_t>(i) * sizeof(wire), &wire, sizeof(wire));
+        }
+
+        gb::descriptor_set_layout_support_response response{};
+        if (!bridge_call(gb::ioctl_get_descriptor_set_layout_support, message.data(), static_cast<DWORD>(message.size()), &response,
+                         sizeof(response)) ||
+            response.vk_result != VK_SUCCESS)
+        {
+            return;
+        }
+
+        pSupport->supported = response.supported ? VK_TRUE : VK_FALSE;
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetDescriptorSetLayoutSupportKHR(
+        VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo, VkDescriptorSetLayoutSupport* pSupport)
+    {
+        vkGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport);
     }
 
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetDeviceImageSparseMemoryRequirements(VkDevice,
@@ -5283,6 +5362,8 @@ extern "C"
             {.name = "vkAllocateDescriptorSets", .func = reinterpret_cast<PFN_vkVoidFunction>(vkAllocateDescriptorSets)},
             {.name = "vkFreeDescriptorSets", .func = reinterpret_cast<PFN_vkVoidFunction>(vkFreeDescriptorSets)},
             {.name = "vkGetDescriptorSetLayoutSupport", .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetDescriptorSetLayoutSupport)},
+            {.name = "vkGetDescriptorSetLayoutSupportKHR",
+             .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetDescriptorSetLayoutSupportKHR)},
             {.name = "vkGetDeviceImageSparseMemoryRequirements",
              .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetDeviceImageSparseMemoryRequirements)},
             {.name = "vkGetDeviceMemoryCommitment", .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetDeviceMemoryCommitment)},

--- a/src/samples/vulkan-shim/vulkan_shim.def
+++ b/src/samples/vulkan-shim/vulkan_shim.def
@@ -47,8 +47,10 @@ EXPORTS
     vkCmdDrawIndexed
     vkCmdDrawIndexedIndirect
     vkCmdDrawIndexedIndirectCount
+    vkCmdDrawIndexedIndirectCountKHR
     vkCmdDrawIndirect
     vkCmdDrawIndirectCount
+    vkCmdDrawIndirectCountKHR
     vkCmdEndQuery
     vkCmdResetQueryPool
     vkCmdWriteTimestamp
@@ -99,7 +101,6 @@ EXPORTS
     vkCreateFence
     vkCreateFramebuffer
     vkCreateGraphicsPipelines
-    vkCreatePipelineCache
     vkCreateImage
     vkCreateImageView
     vkCreateInstance
@@ -123,7 +124,6 @@ EXPORTS
     vkDestroyImageView
     vkDestroyInstance
     vkDestroyPipeline
-    vkDestroyPipelineCache
     vkDestroyPipelineLayout
     vkDestroyRenderPass
     vkDestroySampler
@@ -156,17 +156,17 @@ EXPORTS
     vkGetImageSparseMemoryRequirements2
     vkGetImageSparseMemoryRequirements2KHR
     vkGetImageSubresourceLayout
-    vkGetPipelineCacheData
     vkGetInstanceProcAddr
     vkGetQueryPoolResults
-    vkGetShaderModuleIdentifierEXT
-    vkMergePipelineCaches
     vkGetPhysicalDeviceExternalSemaphoreProperties
     vkGetPhysicalDeviceFeatures
     vkGetPhysicalDeviceFeatures2
     vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR
     vkGetPhysicalDeviceFragmentShadingRatesKHR
     vkGetPhysicalDeviceCalibrateableTimeDomainsKHR
+    vkGetPhysicalDeviceCalibrateableTimeDomainsEXT
+    vkGetCalibratedTimestampsKHR
+    vkGetCalibratedTimestampsEXT
     vkGetPhysicalDeviceFormatProperties
     vkGetPhysicalDeviceFormatProperties2
     vkGetPhysicalDeviceImageFormatProperties

--- a/src/samples/vulkan-shim/vulkan_shim.def
+++ b/src/samples/vulkan-shim/vulkan_shim.def
@@ -149,6 +149,7 @@ EXPORTS
     vkGetDeviceImageSparseMemoryRequirements
     vkGetDeviceMemoryCommitment
     vkGetDescriptorSetLayoutSupport
+    vkGetDescriptorSetLayoutSupportKHR
     vkGetFenceStatus
     vkGetImageMemoryRequirements
     vkGetImageSparseMemoryRequirements

--- a/src/samples/vulkan-shim/vulkan_shim.def
+++ b/src/samples/vulkan-shim/vulkan_shim.def
@@ -24,12 +24,14 @@ EXPORTS
     vkCmdBindVertexBuffers
     vkCmdBindVertexBuffers2
     vkCmdBlitImage2
+    vkCmdBlitImage
     vkCmdBlitImage2KHR
     vkCmdClearAttachments
     vkCmdClearColorImage
     vkCmdClearDepthStencilImage
     vkCmdBeginQuery
     vkCmdCopyBuffer
+    vkCmdCopyQueryPoolResults
     vkCmdCopyBufferToImage
     vkCmdCopyBufferToImage2
     vkCmdCopyImage
@@ -43,11 +45,18 @@ EXPORTS
     vkCmdDispatchIndirect
     vkCmdDraw
     vkCmdDrawIndexed
+    vkCmdDrawIndexedIndirect
+    vkCmdDrawIndexedIndirectCount
+    vkCmdDrawIndirect
+    vkCmdDrawIndirectCount
     vkCmdEndQuery
     vkCmdResetQueryPool
     vkCmdWriteTimestamp
+    vkCmdWriteTimestamp2
+    vkCmdWriteTimestamp2KHR
     vkCmdEndDebugUtilsLabelEXT
     vkCmdEndRenderPass
+    vkCmdNextSubpass
     vkCmdEndRendering
     vkCmdExecuteCommands
     vkCmdFillBuffer
@@ -90,6 +99,7 @@ EXPORTS
     vkCreateFence
     vkCreateFramebuffer
     vkCreateGraphicsPipelines
+    vkCreatePipelineCache
     vkCreateImage
     vkCreateImageView
     vkCreateInstance
@@ -113,6 +123,7 @@ EXPORTS
     vkDestroyImageView
     vkDestroyInstance
     vkDestroyPipeline
+    vkDestroyPipelineCache
     vkDestroyPipelineLayout
     vkDestroyRenderPass
     vkDestroySampler
@@ -122,6 +133,7 @@ EXPORTS
     vkDeviceWaitIdle
     vkEndCommandBuffer
     vkEnumerateDeviceExtensionProperties
+    vkEnumerateDeviceLayerProperties
     vkFlushMappedMemoryRanges
     vkInvalidateMappedMemoryRanges
     vkEnumerateInstanceExtensionProperties
@@ -129,18 +141,31 @@ EXPORTS
     vkEnumerateInstanceVersion
     vkEnumeratePhysicalDevices
     vkFreeCommandBuffers
+    vkFreeDescriptorSets
     vkFreeMemory
     vkGetBufferMemoryRequirements
     vkGetDeviceProcAddr
     vkGetDeviceQueue
+    vkGetDeviceImageSparseMemoryRequirements
+    vkGetDeviceMemoryCommitment
+    vkGetDescriptorSetLayoutSupport
     vkGetFenceStatus
     vkGetImageMemoryRequirements
+    vkGetImageSparseMemoryRequirements
+    vkGetImageSparseMemoryRequirements2
+    vkGetImageSparseMemoryRequirements2KHR
     vkGetImageSubresourceLayout
+    vkGetPipelineCacheData
     vkGetInstanceProcAddr
     vkGetQueryPoolResults
+    vkGetShaderModuleIdentifierEXT
+    vkMergePipelineCaches
     vkGetPhysicalDeviceExternalSemaphoreProperties
     vkGetPhysicalDeviceFeatures
     vkGetPhysicalDeviceFeatures2
+    vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR
+    vkGetPhysicalDeviceFragmentShadingRatesKHR
+    vkGetPhysicalDeviceCalibrateableTimeDomainsKHR
     vkGetPhysicalDeviceFormatProperties
     vkGetPhysicalDeviceFormatProperties2
     vkGetPhysicalDeviceImageFormatProperties
@@ -164,6 +189,7 @@ EXPORTS
     vkGetSwapchainImagesKHR
     vkMapMemory
     vkQueuePresentKHR
+    vkQueueBindSparse
     vkQueueSubmit
     vkQueueWaitIdle
     vkReleaseSwapchainImagesEXT

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -166,6 +166,8 @@ namespace sogen
                     return handle_create_shader_module(win_emu, context);
                 case gpu_bridge::ioctl_destroy_shader_module:
                     return handle_destroy_shader_module(win_emu, context);
+                case gpu_bridge::ioctl_get_shader_module_identifier:
+                    return handle_get_shader_module_identifier(win_emu, context);
                 case gpu_bridge::ioctl_create_image_view:
                     return handle_create_image_view(win_emu, context);
                 case gpu_bridge::ioctl_destroy_image_view:
@@ -214,6 +216,8 @@ namespace sogen
                     return handle_reset_descriptor_pool(win_emu, context);
                 case gpu_bridge::ioctl_allocate_descriptor_sets:
                     return handle_allocate_descriptor_sets(win_emu, context);
+                case gpu_bridge::ioctl_free_descriptor_sets:
+                    return handle_free_descriptor_sets(win_emu, context);
                 case gpu_bridge::ioctl_update_descriptor_sets:
                     return handle_update_descriptor_sets(win_emu, context);
                 case gpu_bridge::ioctl_update_descriptor_sets_batch:
@@ -1757,6 +1761,20 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
 
+            NTSTATUS handle_get_shader_module_identifier(windows_emulator& win_emu, const io_device_context& context)
+            {
+                gpu_bridge::device_child_request request{};
+                if (!read_input(win_emu, context, request))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                gpu_bridge::shader_module_identifier_response response{};
+                response.vk_result = this->vulkan_.get_shader_module_identifier(request.device, request.object, response.identifier,
+                                                                                response.identifier_size);
+                return write_output(win_emu, context, response);
+            }
+
             NTSTATUS handle_create_image_view(windows_emulator& win_emu, const io_device_context& context)
             {
                 gpu_bridge::create_image_view_request request{};
@@ -2256,6 +2274,25 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
 
+            NTSTATUS handle_free_descriptor_sets(windows_emulator& win_emu, const io_device_context& context)
+            {
+                using request_t = gpu_bridge::free_descriptor_sets_request;
+                request_t request{};
+                if (!read_input(win_emu, context, request))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                std::vector<uint64_t> sets;
+                if (!read_trailing_array(win_emu, context, sizeof(request_t), request.set_count, sets))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                const int32_t result = this->vulkan_.free_descriptor_sets(request.device, request.descriptor_pool, sets);
+                return write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});
+            }
+
             // Cap guest-declared descriptor-update payloads so a bogus IOCTL length can't force a huge allocation.
             static constexpr size_t max_descriptor_update_input_bytes = size_t{256} * 1024 * 1024;
 
@@ -2316,7 +2353,7 @@ namespace sogen
                              .dst_binding = w.dst_binding,
                              .dst_array_element = w.dst_array_element,
                              .descriptor_type = w.descriptor_type,
-                             .buffer = w.buffer,
+                             .buffer_or_view = w.buffer_or_view,
                              .offset = w.offset,
                              .range = w.range,
                              .sampler = w.sampler,
@@ -2324,7 +2361,6 @@ namespace sogen
                              .image_layout = w.image_layout};
                 }
                 offset += writes_bytes;
-
                 return this->vulkan_.update_descriptor_sets(request.device, writes);
             }
 
@@ -2630,6 +2666,15 @@ namespace sogen
                     }
                     return this->vulkan_.cmd_write_timestamp(req.command_buffer, req.query_pool, req.query, req.pipeline_stage);
                 }
+                case gpu_bridge::command::cmd_copy_query_pool_results: {
+                    gpu_bridge::cmd_copy_query_pool_results_request req{};
+                    if (!read(req))
+                    {
+                        return vk_error_initialization_failed;
+                    }
+                    return this->vulkan_.cmd_copy_query_pool_results(req.command_buffer, req.query_pool, req.first_query, req.query_count,
+                                                                     req.destination_buffer, req.destination_offset, req.stride, req.flags);
+                }
                 case gpu_bridge::command::cmd_dispatch: {
                     gpu_bridge::cmd_dispatch_request req{};
                     if (!read(req))
@@ -2755,6 +2800,40 @@ namespace sogen
                     return this->vulkan_.cmd_draw_indexed(req.command_buffer, req.index_count, req.instance_count, req.first_index,
                                                           req.vertex_offset, req.first_instance);
                 }
+                case gpu_bridge::command::cmd_draw_indexed_indirect: {
+                    gpu_bridge::cmd_draw_indexed_indirect_request req{};
+                    if (!read(req))
+                    {
+                        return vk_error_initialization_failed;
+                    }
+                    return this->vulkan_.cmd_draw_indexed_indirect(req.command_buffer, req.buffer, req.offset, req.draw_count, req.stride);
+                }
+                case gpu_bridge::command::cmd_draw_indexed_indirect_count: {
+                    gpu_bridge::cmd_draw_indexed_indirect_count_request req{};
+                    if (!read(req))
+                    {
+                        return vk_error_initialization_failed;
+                    }
+                    return this->vulkan_.cmd_draw_indexed_indirect_count(req.command_buffer, req.buffer, req.offset, req.count_buffer,
+                                                                         req.count_buffer_offset, req.max_draw_count, req.stride);
+                }
+                case gpu_bridge::command::cmd_draw_indirect: {
+                    gpu_bridge::cmd_draw_indirect_request req{};
+                    if (!read(req))
+                    {
+                        return vk_error_initialization_failed;
+                    }
+                    return this->vulkan_.cmd_draw_indirect(req.command_buffer, req.buffer, req.offset, req.draw_count, req.stride);
+                }
+                case gpu_bridge::command::cmd_draw_indirect_count: {
+                    gpu_bridge::cmd_draw_indirect_count_request req{};
+                    if (!read(req))
+                    {
+                        return vk_error_initialization_failed;
+                    }
+                    return this->vulkan_.cmd_draw_indirect_count(req.command_buffer, req.buffer, req.offset, req.count_buffer,
+                                                                 req.count_buffer_offset, req.max_draw_count, req.stride);
+                }
                 case gpu_bridge::command::cmd_bind_descriptor_sets: {
                     gpu_bridge::cmd_bind_descriptor_sets_request req{};
                     if (!read(req))
@@ -2791,6 +2870,14 @@ namespace sogen
                         return vk_error_initialization_failed;
                     }
                     return this->vulkan_.cmd_end_render_pass(req.command_buffer);
+                }
+                case gpu_bridge::command::cmd_next_subpass: {
+                    gpu_bridge::cmd_next_subpass_request req{};
+                    if (!read(req))
+                    {
+                        return vk_error_initialization_failed;
+                    }
+                    return this->vulkan_.cmd_next_subpass(req.command_buffer, req.contents);
                 }
                 case gpu_bridge::command::cmd_begin_rendering: {
                     gpu_bridge::cmd_begin_rendering_request req{};

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -38,6 +38,14 @@ namespace sogen
                     return handle_destroy_instance(win_emu, context);
                 case gpu_bridge::ioctl_enumerate_physical_devices:
                     return handle_enumerate_physical_devices(win_emu, context);
+                case gpu_bridge::ioctl_get_physical_device_cooperative_matrix_properties:
+                    return handle_get_physical_device_cooperative_matrix_properties(win_emu, context);
+                case gpu_bridge::ioctl_get_physical_device_fragment_shading_rates:
+                    return handle_get_physical_device_fragment_shading_rates(win_emu, context);
+                case gpu_bridge::ioctl_get_physical_device_calibrateable_time_domains:
+                    return handle_get_physical_device_calibrateable_time_domains(win_emu, context);
+                case gpu_bridge::ioctl_get_calibrated_timestamps:
+                    return handle_get_calibrated_timestamps(win_emu, context);
                 case gpu_bridge::ioctl_get_physical_device_properties:
                     return handle_get_physical_device_properties(win_emu, context);
                 case gpu_bridge::ioctl_get_queue_family_properties:
@@ -112,6 +120,8 @@ namespace sogen
                     return handle_get_physical_device_memory_properties(win_emu, context);
                 case gpu_bridge::ioctl_get_physical_device_memory_budget:
                     return handle_get_physical_device_memory_budget(win_emu, context);
+                case gpu_bridge::ioctl_get_device_memory_commitment:
+                    return handle_get_device_memory_commitment(win_emu, context);
                 case gpu_bridge::ioctl_allocate_memory:
                     return handle_allocate_memory(win_emu, context);
                 case gpu_bridge::ioctl_free_memory:
@@ -166,10 +176,6 @@ namespace sogen
                     return handle_create_shader_module(win_emu, context);
                 case gpu_bridge::ioctl_destroy_shader_module:
                     return handle_destroy_shader_module(win_emu, context);
-                case gpu_bridge::ioctl_get_shader_module_identifier:
-                    return handle_get_shader_module_identifier(win_emu, context);
-                case gpu_bridge::ioctl_get_shader_module_create_info_identifier:
-                    return handle_get_shader_module_create_info_identifier(win_emu, context);
                 case gpu_bridge::ioctl_create_image_view:
                     return handle_create_image_view(win_emu, context);
                 case gpu_bridge::ioctl_destroy_image_view:
@@ -562,6 +568,154 @@ namespace sogen
                 }
 
                 set_information(context, static_cast<ULONG>(sizeof(response_t) + array_bytes));
+                return STATUS_SUCCESS;
+            }
+
+            NTSTATUS handle_get_physical_device_cooperative_matrix_properties(windows_emulator& win_emu, const io_device_context& context)
+            {
+                using request_t = gpu_bridge::physical_device_enumeration_request;
+                using response_t = gpu_bridge::physical_device_enumeration_response;
+                using entry_t = gpu_bridge::cooperative_matrix_property;
+
+                if (!context.input_buffer || context.input_buffer_length < sizeof(request_t))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+                if (!context.output_buffer || context.output_buffer_length < sizeof(response_t))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                const auto request = emulator_object<request_t>{win_emu.emu(), context.input_buffer}.read();
+                const uint32_t capacity = static_cast<uint32_t>(std::min<size_t>(
+                    (context.output_buffer_length - sizeof(response_t)) / sizeof(entry_t), max_array_readback_bytes / sizeof(entry_t)));
+                const uint32_t max_count = std::min(request.max_count, capacity);
+                std::vector<entry_t> entries(max_count);
+
+                uint32_t count = 0;
+                const int32_t result = this->vulkan_.get_physical_device_cooperative_matrix_properties(
+                    request.physical_device, entries.data(), entries.size() * sizeof(entry_t), max_count, request.has_entries != 0, count);
+
+                const response_t response{.vk_result = result, .count = count};
+                emulator_object<response_t>{win_emu.emu(), context.output_buffer}.write(response);
+                const uint32_t written = std::min(count, max_count);
+                if (written > 0)
+                {
+                    win_emu.emu().write_memory(context.output_buffer + sizeof(response_t), entries.data(),
+                                               static_cast<size_t>(written) * sizeof(entry_t));
+                }
+                set_information(context, static_cast<ULONG>(sizeof(response_t) + static_cast<size_t>(written) * sizeof(entry_t)));
+                return STATUS_SUCCESS;
+            }
+
+            NTSTATUS handle_get_physical_device_fragment_shading_rates(windows_emulator& win_emu, const io_device_context& context)
+            {
+                using request_t = gpu_bridge::physical_device_enumeration_request;
+                using response_t = gpu_bridge::physical_device_enumeration_response;
+                using entry_t = gpu_bridge::fragment_shading_rate;
+
+                if (!context.input_buffer || context.input_buffer_length < sizeof(request_t))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+                if (!context.output_buffer || context.output_buffer_length < sizeof(response_t))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                const auto request = emulator_object<request_t>{win_emu.emu(), context.input_buffer}.read();
+                const uint32_t capacity = static_cast<uint32_t>(std::min<size_t>(
+                    (context.output_buffer_length - sizeof(response_t)) / sizeof(entry_t), max_array_readback_bytes / sizeof(entry_t)));
+                const uint32_t max_count = std::min(request.max_count, capacity);
+                std::vector<entry_t> entries(max_count);
+
+                uint32_t count = 0;
+                const int32_t result = this->vulkan_.get_physical_device_fragment_shading_rates(
+                    request.physical_device, entries.data(), entries.size() * sizeof(entry_t), max_count, request.has_entries != 0, count);
+
+                const response_t response{.vk_result = result, .count = count};
+                emulator_object<response_t>{win_emu.emu(), context.output_buffer}.write(response);
+                const uint32_t written = std::min(count, max_count);
+                if (written > 0)
+                {
+                    win_emu.emu().write_memory(context.output_buffer + sizeof(response_t), entries.data(),
+                                               static_cast<size_t>(written) * sizeof(entry_t));
+                }
+                set_information(context, static_cast<ULONG>(sizeof(response_t) + static_cast<size_t>(written) * sizeof(entry_t)));
+                return STATUS_SUCCESS;
+            }
+
+            NTSTATUS handle_get_physical_device_calibrateable_time_domains(windows_emulator& win_emu, const io_device_context& context)
+            {
+                using request_t = gpu_bridge::physical_device_enumeration_request;
+                using response_t = gpu_bridge::physical_device_enumeration_response;
+
+                if (!context.input_buffer || context.input_buffer_length < sizeof(request_t))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+                if (!context.output_buffer || context.output_buffer_length < sizeof(response_t))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                const auto request = emulator_object<request_t>{win_emu.emu(), context.input_buffer}.read();
+                const uint32_t capacity = static_cast<uint32_t>(std::min<size_t>(
+                    (context.output_buffer_length - sizeof(response_t)) / sizeof(uint32_t), max_array_readback_bytes / sizeof(uint32_t)));
+                const uint32_t max_count = std::min(request.max_count, capacity);
+                std::vector<uint32_t> domains(max_count);
+
+                uint32_t count = 0;
+                const int32_t result = this->vulkan_.get_physical_device_calibrateable_time_domains(
+                    request.physical_device, domains, max_count, request.has_entries != 0, count);
+
+                const response_t response{.vk_result = result, .count = count};
+                emulator_object<response_t>{win_emu.emu(), context.output_buffer}.write(response);
+                const uint32_t written = std::min(count, max_count);
+                if (written > 0)
+                {
+                    win_emu.emu().write_memory(context.output_buffer + sizeof(response_t), domains.data(),
+                                               static_cast<size_t>(written) * sizeof(uint32_t));
+                }
+                set_information(context, static_cast<ULONG>(sizeof(response_t) + static_cast<size_t>(written) * sizeof(uint32_t)));
+                return STATUS_SUCCESS;
+            }
+
+            NTSTATUS handle_get_calibrated_timestamps(windows_emulator& win_emu, const io_device_context& context)
+            {
+                using request_t = gpu_bridge::get_calibrated_timestamps_request;
+                using response_t = gpu_bridge::get_calibrated_timestamps_response;
+
+                request_t request{};
+                if (!read_input(win_emu, context, request) || request.timestamp_count == 0 ||
+                    request.timestamp_count > max_array_readback_bytes / sizeof(uint64_t))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                std::vector<uint32_t> time_domains;
+                if (!read_trailing_array(win_emu, context, sizeof(request), request.timestamp_count, time_domains))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                const size_t output_size = sizeof(response_t) + static_cast<size_t>(request.timestamp_count) * sizeof(uint64_t);
+                if (!context.output_buffer || context.output_buffer_length < output_size)
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                std::vector<uint64_t> timestamps(request.timestamp_count);
+                uint64_t max_deviation = 0;
+                const int32_t result = this->vulkan_.get_calibrated_timestamps(request.device, time_domains, timestamps, max_deviation);
+                emulator_object<response_t>{win_emu.emu(), context.output_buffer}.write(
+                    response_t{.vk_result = result, .reserved = 0, .max_deviation = max_deviation});
+                if (!timestamps.empty())
+                {
+                    win_emu.emu().write_memory(context.output_buffer + sizeof(response_t), timestamps.data(),
+                                               timestamps.size() * sizeof(uint64_t));
+                }
+                set_information(context, static_cast<ULONG>(output_size));
                 return STATUS_SUCCESS;
             }
 
@@ -1085,19 +1239,9 @@ namespace sogen
                     return STATUS_INVALID_PARAMETER;
                 }
 
-                if (request.shader.identifier_size > gpu_bridge::max_shader_module_identifier_size)
-                {
-                    return STATUS_INVALID_PARAMETER;
-                }
-                const uint32_t identifier_size = request.shader.identifier_size;
-                const vulkan_host::shader_stage_source shader{
-                    .module = request.shader.module,
-                    .identifier = std::span<const uint8_t>{request.shader.identifier.data(), identifier_size},
-                };
-
                 uint64_t pipeline = gpu_bridge::null_object;
-                const int32_t result =
-                    this->vulkan_.create_compute_pipeline(request.device, request.pipeline_layout, shader, request.flags, pipeline);
+                const int32_t result = this->vulkan_.create_compute_pipeline(request.device, request.pipeline_layout, request.shader_module,
+                                                                             request.flags, pipeline);
                 return write_output(win_emu, context,
                                     gpu_bridge::create_compute_pipeline_response{.vk_result = result, .reserved = 0, .pipeline = pipeline});
             }
@@ -1229,6 +1373,21 @@ namespace sogen
                                                                     response.heap_usage.data(), gpu_bridge::max_memory_heaps, heap_count);
                 response.heap_count = heap_count;
                 return write_output(win_emu, context, response);
+            }
+
+            NTSTATUS handle_get_device_memory_commitment(windows_emulator& win_emu, const io_device_context& context)
+            {
+                gpu_bridge::get_device_memory_commitment_request request{};
+                if (!read_input(win_emu, context, request))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                uint64_t committed = 0;
+                const int32_t result = this->vulkan_.get_device_memory_commitment(request.device, request.memory, committed);
+                return write_output(
+                    win_emu, context,
+                    gpu_bridge::get_device_memory_commitment_response{.vk_result = result, .reserved = 0, .committed_bytes = committed});
             }
 
             NTSTATUS handle_allocate_memory(windows_emulator& win_emu, const io_device_context& context)
@@ -1765,7 +1924,7 @@ namespace sogen
                 }
 
                 uint64_t module = gpu_bridge::null_object;
-                const int32_t result = this->vulkan_.create_shader_module(request.device, request.flags, code.data(), code.size(), module);
+                const int32_t result = this->vulkan_.create_shader_module(request.device, code.data(), code.size(), module);
                 return write_output(win_emu, context, gpu_bridge::object_response{.vk_result = result, .reserved = 0, .object = module});
             }
 
@@ -1778,48 +1937,6 @@ namespace sogen
                 }
                 this->vulkan_.destroy_shader_module(request.device, request.object);
                 return STATUS_SUCCESS;
-            }
-
-            NTSTATUS handle_get_shader_module_identifier(windows_emulator& win_emu, const io_device_context& context)
-            {
-                gpu_bridge::device_child_request request{};
-                if (!read_input(win_emu, context, request))
-                {
-                    return STATUS_INVALID_PARAMETER;
-                }
-
-                gpu_bridge::shader_module_identifier_response response{};
-                response.vk_result = this->vulkan_.get_shader_module_identifier(request.device, request.object, response.identifier,
-                                                                                response.identifier_size);
-                return write_output(win_emu, context, response);
-            }
-
-            NTSTATUS handle_get_shader_module_create_info_identifier(windows_emulator& win_emu, const io_device_context& context)
-            {
-                using request_t = gpu_bridge::create_shader_module_request;
-
-                request_t request{};
-                if (!read_input(win_emu, context, request))
-                {
-                    return STATUS_INVALID_PARAMETER;
-                }
-
-                const uint64_t available = context.input_buffer_length - sizeof(request_t);
-                if (request.code_size == 0 || request.code_size % sizeof(uint32_t) != 0 || request.code_size > available)
-                {
-                    return STATUS_INVALID_PARAMETER;
-                }
-
-                std::vector<std::byte> code(request.code_size);
-                if (!code.empty())
-                {
-                    win_emu.emu().read_memory(context.input_buffer + sizeof(request_t), code.data(), code.size());
-                }
-
-                gpu_bridge::shader_module_identifier_response response{};
-                response.vk_result = this->vulkan_.get_shader_module_create_info_identifier(
-                    request.device, request.flags, code.data(), code.size(), response.identifier, response.identifier_size);
-                return write_output(win_emu, context, response);
             }
 
             NTSTATUS handle_create_image_view(windows_emulator& win_emu, const io_device_context& context)
@@ -2170,35 +2287,19 @@ namespace sogen
                                                .color_write_mask = b.color_write_mask};
                 }
 
-                if (request.vertex_shader.identifier_size > gpu_bridge::max_shader_module_identifier_size ||
-                    request.fragment_shader.identifier_size > gpu_bridge::max_shader_module_identifier_size)
-                {
-                    return STATUS_INVALID_PARAMETER;
-                }
-                const uint32_t vertex_identifier_size = request.vertex_shader.identifier_size;
-                const uint32_t fragment_identifier_size = request.fragment_shader.identifier_size;
-                const vulkan_host::shader_stage_source vertex_shader{
-                    .module = request.vertex_shader.module,
-                    .identifier = std::span<const uint8_t>{request.vertex_shader.identifier.data(), vertex_identifier_size},
-                };
-                const vulkan_host::shader_stage_source fragment_shader{
-                    .module = request.fragment_shader.module,
-                    .identifier = std::span<const uint8_t>{request.fragment_shader.identifier.data(), fragment_identifier_size},
-                };
-
                 uint64_t pipeline = gpu_bridge::null_object;
                 const int32_t result = this->vulkan_.create_graphics_pipeline(
-                    request.device, request.render_pass, request.pipeline_layout, vertex_shader, fragment_shader, request.flags,
-                    request.width, request.height, bindings, attributes, divisors, depth, color_formats, request.depth_format,
-                    request.stencil_format, request.rasterization_samples, request.primitive_topology, request.primitive_restart_enable,
-                    dynamic_states, vs_spec, fs_spec, blend_attachments, pipeline);
+                    request.device, request.render_pass, request.pipeline_layout, request.vertex_shader, request.fragment_shader,
+                    request.flags, request.width, request.height, bindings, attributes, divisors, depth, color_formats,
+                    request.depth_format, request.stencil_format, request.rasterization_samples, request.primitive_topology,
+                    request.primitive_restart_enable, dynamic_states, vs_spec, fs_spec, blend_attachments, pipeline);
                 if (result != 0)
                 {
                     win_emu.log.error(
                         "GPU bridge: create_graphics_pipeline FAILED vk=%d (rp=0x%llx layout=0x%llx vs=0x%llx fs=0x%llx %ux%u)\n", result,
                         static_cast<unsigned long long>(request.render_pass), static_cast<unsigned long long>(request.pipeline_layout),
-                        static_cast<unsigned long long>(request.vertex_shader.module),
-                        static_cast<unsigned long long>(request.fragment_shader.module), request.width, request.height);
+                        static_cast<unsigned long long>(request.vertex_shader), static_cast<unsigned long long>(request.fragment_shader),
+                        request.width, request.height);
                 }
                 return write_output(win_emu, context, gpu_bridge::object_response{.vk_result = result, .reserved = 0, .object = pipeline});
             }
@@ -2773,6 +2874,14 @@ namespace sogen
                         return vk_error_initialization_failed;
                     }
                     return this->vulkan_.cmd_write_timestamp(req.command_buffer, req.query_pool, req.query, req.pipeline_stage);
+                }
+                case gpu_bridge::command::cmd_write_timestamp2: {
+                    gpu_bridge::cmd_write_timestamp2_request req{};
+                    if (!read(req))
+                    {
+                        return vk_error_initialization_failed;
+                    }
+                    return this->vulkan_.cmd_write_timestamp2(req.command_buffer, req.query_pool, req.query, req.pipeline_stage);
                 }
                 case gpu_bridge::command::cmd_copy_query_pool_results: {
                     gpu_bridge::cmd_copy_query_pool_results_request req{};

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -208,6 +208,8 @@ namespace sogen
                     return handle_record_commands(win_emu, context);
                 case gpu_bridge::ioctl_create_descriptor_set_layout:
                     return handle_create_descriptor_set_layout(win_emu, context);
+                case gpu_bridge::ioctl_get_descriptor_set_layout_support:
+                    return handle_get_descriptor_set_layout_support(win_emu, context);
                 case gpu_bridge::ioctl_destroy_descriptor_set_layout:
                     return handle_destroy_descriptor_set_layout(win_emu, context);
                 case gpu_bridge::ioctl_create_descriptor_pool:
@@ -2242,6 +2244,38 @@ namespace sogen
                 uint64_t layout = gpu_bridge::null_object;
                 const int32_t result = this->vulkan_.create_descriptor_set_layout(request.device, bindings, layout);
                 return write_output(win_emu, context, gpu_bridge::object_response{.vk_result = result, .reserved = 0, .object = layout});
+            }
+
+            NTSTATUS handle_get_descriptor_set_layout_support(windows_emulator& win_emu, const io_device_context& context)
+            {
+                using request_t = gpu_bridge::get_descriptor_set_layout_support_request;
+
+                request_t request{};
+                if (!read_input(win_emu, context, request))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                std::vector<gpu_bridge::descriptor_set_layout_binding> wire;
+                if (!read_trailing_array(win_emu, context, sizeof(request_t), request.binding_count, wire))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                std::vector<vulkan_host::descriptor_binding> bindings(wire.size());
+                auto binding_out = bindings.begin();
+                for (const auto& entry : wire)
+                {
+                    *binding_out = {.binding = entry.binding,
+                                    .descriptor_type = entry.descriptor_type,
+                                    .descriptor_count = entry.descriptor_count,
+                                    .stage_flags = entry.stage_flags};
+                    ++binding_out;
+                }
+
+                gpu_bridge::descriptor_set_layout_support_response response{};
+                response.vk_result = this->vulkan_.get_descriptor_set_layout_support(request.device, bindings, response.supported);
+                return write_output(win_emu, context, response);
             }
 
             NTSTATUS handle_destroy_descriptor_set_layout(windows_emulator& win_emu, const io_device_context& context)

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -168,6 +168,8 @@ namespace sogen
                     return handle_destroy_shader_module(win_emu, context);
                 case gpu_bridge::ioctl_get_shader_module_identifier:
                     return handle_get_shader_module_identifier(win_emu, context);
+                case gpu_bridge::ioctl_get_shader_module_create_info_identifier:
+                    return handle_get_shader_module_create_info_identifier(win_emu, context);
                 case gpu_bridge::ioctl_create_image_view:
                     return handle_create_image_view(win_emu, context);
                 case gpu_bridge::ioctl_destroy_image_view:
@@ -1081,9 +1083,19 @@ namespace sogen
                     return STATUS_INVALID_PARAMETER;
                 }
 
+                if (request.shader.identifier_size > gpu_bridge::max_shader_module_identifier_size)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+                const uint32_t identifier_size = request.shader.identifier_size;
+                const vulkan_host::shader_stage_source shader{
+                    .module = request.shader.module,
+                    .identifier = std::span<const uint8_t>{request.shader.identifier.data(), identifier_size},
+                };
+
                 uint64_t pipeline = gpu_bridge::null_object;
                 const int32_t result =
-                    this->vulkan_.create_compute_pipeline(request.device, request.pipeline_layout, request.shader_module, pipeline);
+                    this->vulkan_.create_compute_pipeline(request.device, request.pipeline_layout, shader, request.flags, pipeline);
                 return write_output(win_emu, context,
                                     gpu_bridge::create_compute_pipeline_response{.vk_result = result, .reserved = 0, .pipeline = pipeline});
             }
@@ -1738,7 +1750,12 @@ namespace sogen
                     return STATUS_INVALID_PARAMETER;
                 }
 
-                const auto code_bytes = std::min<uint64_t>(request.code_size, context.input_buffer_length - sizeof(request_t));
+                const uint64_t available = context.input_buffer_length - sizeof(request_t);
+                if (request.code_size == 0 || request.code_size % sizeof(uint32_t) != 0 || request.code_size > available)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+                const auto code_bytes = static_cast<uint64_t>(request.code_size);
                 std::vector<std::byte> code(static_cast<size_t>(code_bytes));
                 if (code_bytes > 0)
                 {
@@ -1746,7 +1763,7 @@ namespace sogen
                 }
 
                 uint64_t module = gpu_bridge::null_object;
-                const int32_t result = this->vulkan_.create_shader_module(request.device, code.data(), code.size(), module);
+                const int32_t result = this->vulkan_.create_shader_module(request.device, request.flags, code.data(), code.size(), module);
                 return write_output(win_emu, context, gpu_bridge::object_response{.vk_result = result, .reserved = 0, .object = module});
             }
 
@@ -1772,6 +1789,34 @@ namespace sogen
                 gpu_bridge::shader_module_identifier_response response{};
                 response.vk_result = this->vulkan_.get_shader_module_identifier(request.device, request.object, response.identifier,
                                                                                 response.identifier_size);
+                return write_output(win_emu, context, response);
+            }
+
+            NTSTATUS handle_get_shader_module_create_info_identifier(windows_emulator& win_emu, const io_device_context& context)
+            {
+                using request_t = gpu_bridge::create_shader_module_request;
+
+                request_t request{};
+                if (!read_input(win_emu, context, request))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                const uint64_t available = context.input_buffer_length - sizeof(request_t);
+                if (request.code_size == 0 || request.code_size % sizeof(uint32_t) != 0 || request.code_size > available)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                std::vector<std::byte> code(request.code_size);
+                if (!code.empty())
+                {
+                    win_emu.emu().read_memory(context.input_buffer + sizeof(request_t), code.data(), code.size());
+                }
+
+                gpu_bridge::shader_module_identifier_response response{};
+                response.vk_result = this->vulkan_.get_shader_module_create_info_identifier(
+                    request.device, request.flags, code.data(), code.size(), response.identifier, response.identifier_size);
                 return write_output(win_emu, context, response);
             }
 
@@ -1997,8 +2042,8 @@ namespace sogen
                     return STATUS_INVALID_PARAMETER;
                 }
 
-                // The vertex input state trails the header: binding_count vertex_input_binding entries
-                // then attribute_count vertex_input_attribute entries. Bound the read by the buffer.
+                // The vertex input state trails the header: bindings, attributes, then per-binding divisors.
+                // Bound every section by the supplied IOCTL buffer before parsing it.
                 const auto available = context.input_buffer_length - static_cast<uint32_t>(sizeof(request_t));
                 std::vector<std::byte> trailer(available);
                 if (available > 0)
@@ -2008,7 +2053,9 @@ namespace sogen
 
                 const size_t bindings_bytes = static_cast<size_t>(request.binding_count) * sizeof(gpu_bridge::vertex_input_binding);
                 const size_t attributes_bytes = static_cast<size_t>(request.attribute_count) * sizeof(gpu_bridge::vertex_input_attribute);
-                if (bindings_bytes > trailer.size() || attributes_bytes > trailer.size() - bindings_bytes)
+                const size_t divisors_bytes = static_cast<size_t>(request.divisor_count) * sizeof(gpu_bridge::vertex_input_divisor);
+                if (bindings_bytes > trailer.size() || attributes_bytes > trailer.size() - bindings_bytes ||
+                    divisors_bytes > trailer.size() - bindings_bytes - attributes_bytes)
                 {
                     return STATUS_INVALID_PARAMETER;
                 }
@@ -2033,20 +2080,31 @@ namespace sogen
                     attribute = {.location = a.location, .binding = a.binding, .format = a.format, .offset = a.offset};
                 }
 
+                std::vector<vulkan_host::vertex_divisor> divisors(request.divisor_count);
+                size_t divisor_offset = bindings_bytes + attributes_bytes;
+                for (auto& divisor : divisors)
+                {
+                    gpu_bridge::vertex_input_divisor d{};
+                    std::memcpy(&d, trailer.data() + divisor_offset, sizeof(d));
+                    divisor_offset += sizeof(d);
+                    divisor = {.binding = d.binding, .divisor = d.divisor};
+                }
+
+                const size_t vertex_input_bytes = bindings_bytes + attributes_bytes + divisors_bytes;
                 const size_t dynamic_bytes = static_cast<size_t>(request.dynamic_state_count) * sizeof(uint32_t);
-                if (dynamic_bytes > trailer.size() - bindings_bytes - attributes_bytes)
+                if (dynamic_bytes > trailer.size() - vertex_input_bytes)
                 {
                     return STATUS_INVALID_PARAMETER;
                 }
                 std::vector<uint32_t> dynamic_states(request.dynamic_state_count);
                 if (request.dynamic_state_count > 0)
                 {
-                    std::memcpy(dynamic_states.data(), trailer.data() + bindings_bytes + attributes_bytes, dynamic_bytes);
+                    std::memcpy(dynamic_states.data(), trailer.data() + vertex_input_bytes, dynamic_bytes);
                 }
 
                 // The two per-stage specialization-constant blocks (vertex then fragment) trail the dynamic
                 // states: each is `entry_count` specialization_map_entry records followed by `data_size` bytes.
-                size_t spec_cursor = bindings_bytes + attributes_bytes + dynamic_bytes;
+                size_t spec_cursor = vertex_input_bytes + dynamic_bytes;
                 std::vector<vulkan_host::spec_entry> vs_entries;
                 std::vector<vulkan_host::spec_entry> fs_entries;
                 std::vector<uint8_t> vs_data;
@@ -2110,19 +2168,35 @@ namespace sogen
                                                .color_write_mask = b.color_write_mask};
                 }
 
+                if (request.vertex_shader.identifier_size > gpu_bridge::max_shader_module_identifier_size ||
+                    request.fragment_shader.identifier_size > gpu_bridge::max_shader_module_identifier_size)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+                const uint32_t vertex_identifier_size = request.vertex_shader.identifier_size;
+                const uint32_t fragment_identifier_size = request.fragment_shader.identifier_size;
+                const vulkan_host::shader_stage_source vertex_shader{
+                    .module = request.vertex_shader.module,
+                    .identifier = std::span<const uint8_t>{request.vertex_shader.identifier.data(), vertex_identifier_size},
+                };
+                const vulkan_host::shader_stage_source fragment_shader{
+                    .module = request.fragment_shader.module,
+                    .identifier = std::span<const uint8_t>{request.fragment_shader.identifier.data(), fragment_identifier_size},
+                };
+
                 uint64_t pipeline = gpu_bridge::null_object;
                 const int32_t result = this->vulkan_.create_graphics_pipeline(
-                    request.device, request.render_pass, request.pipeline_layout, request.vertex_shader, request.fragment_shader,
-                    request.width, request.height, bindings, attributes, depth, color_formats, request.depth_format, request.stencil_format,
-                    request.rasterization_samples, request.primitive_topology, request.primitive_restart_enable, dynamic_states, vs_spec,
-                    fs_spec, blend_attachments, pipeline);
+                    request.device, request.render_pass, request.pipeline_layout, vertex_shader, fragment_shader, request.flags,
+                    request.width, request.height, bindings, attributes, divisors, depth, color_formats, request.depth_format,
+                    request.stencil_format, request.rasterization_samples, request.primitive_topology, request.primitive_restart_enable,
+                    dynamic_states, vs_spec, fs_spec, blend_attachments, pipeline);
                 if (result != 0)
                 {
                     win_emu.log.error(
                         "GPU bridge: create_graphics_pipeline FAILED vk=%d (rp=0x%llx layout=0x%llx vs=0x%llx fs=0x%llx %ux%u)\n", result,
                         static_cast<unsigned long long>(request.render_pass), static_cast<unsigned long long>(request.pipeline_layout),
-                        static_cast<unsigned long long>(request.vertex_shader), static_cast<unsigned long long>(request.fragment_shader),
-                        request.width, request.height);
+                        static_cast<unsigned long long>(request.vertex_shader.module),
+                        static_cast<unsigned long long>(request.fragment_shader.module), request.width, request.height);
                 }
                 return write_output(win_emu, context, gpu_bridge::object_response{.vk_result = result, .reserved = 0, .object = pipeline});
             }

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -214,6 +214,9 @@ namespace sogen
             PFN_vkGetPhysicalDeviceFeatures2 get_physical_device_features2{};
             PFN_vkGetPhysicalDeviceProperties2 get_physical_device_properties2{};
             PFN_vkEnumerateDeviceExtensionProperties enumerate_device_extension_properties{};
+            PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR get_cooperative_matrix_properties{};
+            PFN_vkGetPhysicalDeviceFragmentShadingRatesKHR get_fragment_shading_rates{};
+            PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsKHR get_calibrateable_time_domains{};
             PFN_vkCreateDevice create_device{};
             PFN_vkGetDeviceProcAddr get_device_proc_addr{};
         };
@@ -261,6 +264,8 @@ namespace sogen
             PFN_vkQueueSubmit2 queue_submit2{};
             PFN_vkAllocateMemory allocate_memory{};
             PFN_vkFreeMemory free_memory{};
+            PFN_vkGetDeviceMemoryCommitment get_device_memory_commitment{};
+            PFN_vkGetCalibratedTimestampsKHR get_calibrated_timestamps{};
             PFN_vkMapMemory map_memory{};
             PFN_vkUnmapMemory unmap_memory{};
             PFN_vkFlushMappedMemoryRanges flush_mapped_memory_ranges{};
@@ -290,8 +295,6 @@ namespace sogen
             PFN_vkDestroySampler destroy_sampler{};
             PFN_vkCreateShaderModule create_shader_module{};
             PFN_vkDestroyShaderModule destroy_shader_module{};
-            PFN_vkGetShaderModuleIdentifierEXT get_shader_module_identifier{};
-            PFN_vkGetShaderModuleCreateInfoIdentifierEXT get_shader_module_create_info_identifier{};
             PFN_vkCreateImageView create_image_view{};
             PFN_vkDestroyImageView destroy_image_view{};
             PFN_vkCreateBufferView create_buffer_view{};
@@ -304,6 +307,7 @@ namespace sogen
             PFN_vkCmdBeginQuery cmd_begin_query{};
             PFN_vkCmdEndQuery cmd_end_query{};
             PFN_vkCmdWriteTimestamp cmd_write_timestamp{};
+            PFN_vkCmdWriteTimestamp2 cmd_write_timestamp2{};
             PFN_vkCmdCopyQueryPoolResults cmd_copy_query_pool_results{};
             PFN_vkCreateRenderPass create_render_pass{};
             PFN_vkDestroyRenderPass destroy_render_pass{};
@@ -1085,6 +1089,17 @@ namespace sogen
             this->impl_->load_instance_proc<PFN_vkGetPhysicalDeviceProperties2>(instance, "vkGetPhysicalDeviceProperties2");
         data.enumerate_device_extension_properties =
             this->impl_->load_instance_proc<PFN_vkEnumerateDeviceExtensionProperties>(instance, "vkEnumerateDeviceExtensionProperties");
+        data.get_cooperative_matrix_properties = this->impl_->load_instance_proc<PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR>(
+            instance, "vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR");
+        data.get_fragment_shading_rates = this->impl_->load_instance_proc<PFN_vkGetPhysicalDeviceFragmentShadingRatesKHR>(
+            instance, "vkGetPhysicalDeviceFragmentShadingRatesKHR");
+        data.get_calibrateable_time_domains = this->impl_->load_instance_proc<PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsKHR>(
+            instance, "vkGetPhysicalDeviceCalibrateableTimeDomainsKHR");
+        if (!data.get_calibrateable_time_domains)
+        {
+            data.get_calibrateable_time_domains = this->impl_->load_instance_proc<PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsKHR>(
+                instance, "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT");
+        }
         data.create_device = this->impl_->load_instance_proc<PFN_vkCreateDevice>(instance, "vkCreateDevice");
         data.get_device_proc_addr = this->impl_->load_instance_proc<PFN_vkGetDeviceProcAddr>(instance, "vkGetDeviceProcAddr");
 
@@ -1401,6 +1416,176 @@ namespace sogen
         }
 
         return VK_SUCCESS;
+    }
+
+    int32_t vulkan_host::get_physical_device_cooperative_matrix_properties(uint64_t physical_device, void* out, size_t out_size,
+                                                                           uint32_t max_count, bool has_entries, uint32_t& out_count)
+    {
+        out_count = 0;
+        const auto pd = this->impl_->physical_devices.find(physical_device);
+        if (pd == this->impl_->physical_devices.end())
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        const auto instance = this->impl_->instances.find(pd->second.instance_id);
+        if (instance == this->impl_->instances.end())
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        if (!instance->second.get_cooperative_matrix_properties)
+        {
+            return VK_ERROR_EXTENSION_NOT_PRESENT;
+        }
+
+        uint32_t count = max_count;
+        if (!has_entries)
+        {
+            const VkResult result = instance->second.get_cooperative_matrix_properties(pd->second.handle, &count, nullptr);
+            out_count = count;
+            return result;
+        }
+
+        std::vector<VkCooperativeMatrixPropertiesKHR> properties(std::max(max_count, 1u));
+        for (auto& property : properties)
+        {
+            property.sType = VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_KHR;
+            property.pNext = nullptr;
+        }
+
+        const VkResult result = instance->second.get_cooperative_matrix_properties(pd->second.handle, &count, properties.data());
+        out_count = count;
+
+        const size_t capacity = out_size / sizeof(gpu_bridge::cooperative_matrix_property);
+        const size_t written = std::min<size_t>(count, std::min<size_t>(max_count, capacity));
+        auto* wire = static_cast<gpu_bridge::cooperative_matrix_property*>(out);
+        for (size_t i = 0; i < written; ++i)
+        {
+            wire[i] = {
+                .m_size = properties[i].MSize,
+                .n_size = properties[i].NSize,
+                .k_size = properties[i].KSize,
+                .a_type = static_cast<uint32_t>(properties[i].AType),
+                .b_type = static_cast<uint32_t>(properties[i].BType),
+                .c_type = static_cast<uint32_t>(properties[i].CType),
+                .result_type = static_cast<uint32_t>(properties[i].ResultType),
+                .saturating_accumulation = properties[i].saturatingAccumulation,
+                .scope = static_cast<uint32_t>(properties[i].scope),
+            };
+        }
+        return result;
+    }
+
+    int32_t vulkan_host::get_physical_device_fragment_shading_rates(uint64_t physical_device, void* out, size_t out_size,
+                                                                    uint32_t max_count, bool has_entries, uint32_t& out_count)
+    {
+        out_count = 0;
+        const auto pd = this->impl_->physical_devices.find(physical_device);
+        if (pd == this->impl_->physical_devices.end())
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        const auto instance = this->impl_->instances.find(pd->second.instance_id);
+        if (instance == this->impl_->instances.end())
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        if (!instance->second.get_fragment_shading_rates)
+        {
+            return VK_ERROR_EXTENSION_NOT_PRESENT;
+        }
+
+        uint32_t count = max_count;
+        if (!has_entries)
+        {
+            const VkResult result = instance->second.get_fragment_shading_rates(pd->second.handle, &count, nullptr);
+            out_count = count;
+            return result;
+        }
+
+        std::vector<VkPhysicalDeviceFragmentShadingRateKHR> rates(std::max(max_count, 1u));
+        for (auto& rate : rates)
+        {
+            rate.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_KHR;
+            rate.pNext = nullptr;
+        }
+
+        const VkResult result = instance->second.get_fragment_shading_rates(pd->second.handle, &count, rates.data());
+        out_count = count;
+
+        const size_t capacity = out_size / sizeof(gpu_bridge::fragment_shading_rate);
+        const size_t written = std::min<size_t>(count, std::min<size_t>(max_count, capacity));
+        auto* wire = static_cast<gpu_bridge::fragment_shading_rate*>(out);
+        for (size_t i = 0; i < written; ++i)
+        {
+            wire[i] = {
+                .sample_counts = rates[i].sampleCounts,
+                .width = rates[i].fragmentSize.width,
+                .height = rates[i].fragmentSize.height,
+            };
+        }
+        return result;
+    }
+
+    int32_t vulkan_host::get_physical_device_calibrateable_time_domains(uint64_t physical_device, std::span<uint32_t> out_domains,
+                                                                        uint32_t max_count, bool has_entries, uint32_t& out_count)
+    {
+        out_count = 0;
+        const auto pd = this->impl_->physical_devices.find(physical_device);
+        if (pd == this->impl_->physical_devices.end())
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        const auto instance = this->impl_->instances.find(pd->second.instance_id);
+        if (instance == this->impl_->instances.end())
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        if (!instance->second.get_calibrateable_time_domains)
+        {
+            return VK_ERROR_EXTENSION_NOT_PRESENT;
+        }
+
+        uint32_t count = max_count;
+        if (!has_entries)
+        {
+            const VkResult result = instance->second.get_calibrateable_time_domains(pd->second.handle, &count, nullptr);
+            out_count = count;
+            return result;
+        }
+
+        std::vector<VkTimeDomainKHR> domains(std::max(max_count, 1u));
+        const VkResult result = instance->second.get_calibrateable_time_domains(pd->second.handle, &count, domains.data());
+        out_count = count;
+        const size_t written = std::min<size_t>(count, std::min<size_t>(max_count, out_domains.size()));
+        for (size_t i = 0; i < written; ++i)
+        {
+            out_domains[i] = static_cast<uint32_t>(domains[i]);
+        }
+        return result;
+    }
+
+    int32_t vulkan_host::get_calibrated_timestamps(uint64_t device, std::span<const uint32_t> time_domains, std::span<uint64_t> timestamps,
+                                                   uint64_t& max_deviation)
+    {
+        max_deviation = 0;
+        const auto dev = this->impl_->devices.find(device);
+        if (dev == this->impl_->devices.end() || time_domains.size() != timestamps.size())
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        if (!dev->second.get_calibrated_timestamps)
+        {
+            return VK_ERROR_EXTENSION_NOT_PRESENT;
+        }
+
+        std::vector<VkCalibratedTimestampInfoKHR> timestamp_infos(time_domains.size());
+        for (size_t i = 0; i < time_domains.size(); ++i)
+        {
+            timestamp_infos[i].sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR;
+            timestamp_infos[i].timeDomain = static_cast<VkTimeDomainKHR>(time_domains[i]);
+        }
+        return dev->second.get_calibrated_timestamps(dev->second.handle, static_cast<uint32_t>(timestamp_infos.size()),
+                                                     timestamp_infos.data(), timestamps.data(), &max_deviation);
     }
 
     int32_t vulkan_host::get_physical_device_features2(uint64_t physical_device, const void* in_records, size_t in_records_size,
@@ -1765,6 +1950,13 @@ namespace sogen
             data.queue_submit2 = reinterpret_cast<PFN_vkQueueSubmit2>(resolve("vkQueueSubmit2"));
             data.allocate_memory = reinterpret_cast<PFN_vkAllocateMemory>(resolve("vkAllocateMemory"));
             data.free_memory = reinterpret_cast<PFN_vkFreeMemory>(resolve("vkFreeMemory"));
+            data.get_device_memory_commitment = reinterpret_cast<PFN_vkGetDeviceMemoryCommitment>(resolve("vkGetDeviceMemoryCommitment"));
+            data.get_calibrated_timestamps = reinterpret_cast<PFN_vkGetCalibratedTimestampsKHR>(resolve("vkGetCalibratedTimestampsKHR"));
+            if (!data.get_calibrated_timestamps)
+            {
+                data.get_calibrated_timestamps =
+                    reinterpret_cast<PFN_vkGetCalibratedTimestampsKHR>(resolve("vkGetCalibratedTimestampsEXT"));
+            }
             data.map_memory = reinterpret_cast<PFN_vkMapMemory>(resolve("vkMapMemory"));
             data.unmap_memory = reinterpret_cast<PFN_vkUnmapMemory>(resolve("vkUnmapMemory"));
             data.flush_mapped_memory_ranges = reinterpret_cast<PFN_vkFlushMappedMemoryRanges>(resolve("vkFlushMappedMemoryRanges"));
@@ -1797,10 +1989,6 @@ namespace sogen
             data.destroy_sampler = reinterpret_cast<PFN_vkDestroySampler>(resolve("vkDestroySampler"));
             data.create_shader_module = reinterpret_cast<PFN_vkCreateShaderModule>(resolve("vkCreateShaderModule"));
             data.destroy_shader_module = reinterpret_cast<PFN_vkDestroyShaderModule>(resolve("vkDestroyShaderModule"));
-            data.get_shader_module_identifier =
-                reinterpret_cast<PFN_vkGetShaderModuleIdentifierEXT>(resolve("vkGetShaderModuleIdentifierEXT"));
-            data.get_shader_module_create_info_identifier =
-                reinterpret_cast<PFN_vkGetShaderModuleCreateInfoIdentifierEXT>(resolve("vkGetShaderModuleCreateInfoIdentifierEXT"));
             data.create_image_view = reinterpret_cast<PFN_vkCreateImageView>(resolve("vkCreateImageView"));
             data.destroy_image_view = reinterpret_cast<PFN_vkDestroyImageView>(resolve("vkDestroyImageView"));
             data.create_buffer_view = reinterpret_cast<PFN_vkCreateBufferView>(resolve("vkCreateBufferView"));
@@ -1813,6 +2001,11 @@ namespace sogen
             data.cmd_begin_query = reinterpret_cast<PFN_vkCmdBeginQuery>(resolve("vkCmdBeginQuery"));
             data.cmd_end_query = reinterpret_cast<PFN_vkCmdEndQuery>(resolve("vkCmdEndQuery"));
             data.cmd_write_timestamp = reinterpret_cast<PFN_vkCmdWriteTimestamp>(resolve("vkCmdWriteTimestamp"));
+            data.cmd_write_timestamp2 = reinterpret_cast<PFN_vkCmdWriteTimestamp2>(resolve("vkCmdWriteTimestamp2"));
+            if (!data.cmd_write_timestamp2)
+            {
+                data.cmd_write_timestamp2 = reinterpret_cast<PFN_vkCmdWriteTimestamp2>(resolve("vkCmdWriteTimestamp2KHR"));
+            }
             data.cmd_copy_query_pool_results = reinterpret_cast<PFN_vkCmdCopyQueryPoolResults>(resolve("vkCmdCopyQueryPoolResults"));
             data.create_render_pass = reinterpret_cast<PFN_vkCreateRenderPass>(resolve("vkCreateRenderPass"));
             data.destroy_render_pass = reinterpret_cast<PFN_vkDestroyRenderPass>(resolve("vkDestroyRenderPass"));
@@ -1855,8 +2048,17 @@ namespace sogen
             data.cmd_draw_indexed_indirect = reinterpret_cast<PFN_vkCmdDrawIndexedIndirect>(resolve("vkCmdDrawIndexedIndirect"));
             data.cmd_draw_indexed_indirect_count =
                 reinterpret_cast<PFN_vkCmdDrawIndexedIndirectCount>(resolve("vkCmdDrawIndexedIndirectCount"));
+            if (!data.cmd_draw_indexed_indirect_count)
+            {
+                data.cmd_draw_indexed_indirect_count =
+                    reinterpret_cast<PFN_vkCmdDrawIndexedIndirectCount>(resolve("vkCmdDrawIndexedIndirectCountKHR"));
+            }
             data.cmd_draw_indirect = reinterpret_cast<PFN_vkCmdDrawIndirect>(resolve("vkCmdDrawIndirect"));
             data.cmd_draw_indirect_count = reinterpret_cast<PFN_vkCmdDrawIndirectCount>(resolve("vkCmdDrawIndirectCount"));
+            if (!data.cmd_draw_indirect_count)
+            {
+                data.cmd_draw_indirect_count = reinterpret_cast<PFN_vkCmdDrawIndirectCount>(resolve("vkCmdDrawIndirectCountKHR"));
+            }
             data.cmd_end_render_pass = reinterpret_cast<PFN_vkCmdEndRenderPass>(resolve("vkCmdEndRenderPass"));
             data.cmd_next_subpass = reinterpret_cast<PFN_vkCmdNextSubpass>(resolve("vkCmdNextSubpass"));
             data.cmd_push_constants = reinterpret_cast<PFN_vkCmdPushConstants>(resolve("vkCmdPushConstants"));
@@ -2741,6 +2943,26 @@ namespace sogen
         }
 
         this->impl_->memories.erase(it);
+    }
+
+    int32_t vulkan_host::get_device_memory_commitment(uint64_t device, uint64_t memory, uint64_t& out_committed_bytes)
+    {
+        out_committed_bytes = 0;
+        const auto dev = this->impl_->devices.find(device);
+        const auto mem = this->impl_->memories.find(memory);
+        if (dev == this->impl_->devices.end() || mem == this->impl_->memories.end() || mem->second.device_id != device)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        if (!dev->second.get_device_memory_commitment)
+        {
+            return VK_ERROR_FEATURE_NOT_PRESENT;
+        }
+
+        VkDeviceSize committed = 0;
+        dev->second.get_device_memory_commitment(dev->second.handle, mem->second.handle, &committed);
+        out_committed_bytes = committed;
+        return VK_SUCCESS;
     }
 
     int32_t vulkan_host::create_buffer(uint64_t device, uint64_t size, uint32_t usage, uint64_t& out_buffer)
@@ -4000,7 +4222,7 @@ namespace sogen
         return frames;
     }
 
-    int32_t vulkan_host::create_shader_module(uint64_t device, uint32_t flags, const void* code, size_t code_size, uint64_t& out_module)
+    int32_t vulkan_host::create_shader_module(uint64_t device, const void* code, size_t code_size, uint64_t& out_module)
     {
         out_module = 0;
         const auto dev = this->impl_->devices.find(device);
@@ -4011,7 +4233,6 @@ namespace sogen
 
         VkShaderModuleCreateInfo info{};
         info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-        info.flags = static_cast<VkShaderModuleCreateFlags>(flags);
         info.codeSize = code_size;
         info.pCode = static_cast<const uint32_t*>(code);
 
@@ -4041,50 +4262,6 @@ namespace sogen
             dev->second.destroy_shader_module(dev->second.handle, it->second.handle, nullptr);
         }
         this->impl_->shader_modules.erase(it);
-    }
-
-    int32_t vulkan_host::get_shader_module_identifier(uint64_t device, uint64_t shader_module, std::span<uint8_t> identifier,
-                                                      uint32_t& identifier_size)
-    {
-        identifier_size = 0;
-        const auto dev = this->impl_->devices.find(device);
-        const auto module = this->impl_->shader_modules.find(shader_module);
-        if (dev == this->impl_->devices.end() || module == this->impl_->shader_modules.end() || module->second.device_id != device ||
-            !dev->second.get_shader_module_identifier)
-        {
-            return VK_ERROR_INITIALIZATION_FAILED;
-        }
-
-        VkShaderModuleIdentifierEXT result{};
-        result.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT;
-        dev->second.get_shader_module_identifier(dev->second.handle, module->second.handle, &result);
-        identifier_size = std::min<uint32_t>(result.identifierSize, static_cast<uint32_t>(identifier.size()));
-        std::memcpy(identifier.data(), result.identifier, identifier_size);
-        return VK_SUCCESS;
-    }
-
-    int32_t vulkan_host::get_shader_module_create_info_identifier(uint64_t device, uint32_t flags, const void* code, size_t code_size,
-                                                                  std::span<uint8_t> identifier, uint32_t& identifier_size)
-    {
-        identifier_size = 0;
-        const auto dev = this->impl_->devices.find(device);
-        if (dev == this->impl_->devices.end() || !dev->second.get_shader_module_create_info_identifier)
-        {
-            return VK_ERROR_INITIALIZATION_FAILED;
-        }
-
-        VkShaderModuleCreateInfo create_info{};
-        create_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-        create_info.flags = static_cast<VkShaderModuleCreateFlags>(flags);
-        create_info.codeSize = code_size;
-        create_info.pCode = static_cast<const uint32_t*>(code);
-
-        VkShaderModuleIdentifierEXT result{};
-        result.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT;
-        dev->second.get_shader_module_create_info_identifier(dev->second.handle, &create_info, &result);
-        identifier_size = std::min<uint32_t>(result.identifierSize, static_cast<uint32_t>(identifier.size()));
-        std::memcpy(identifier.data(), result.identifier, identifier_size);
-        return VK_SUCCESS;
     }
 
     int32_t vulkan_host::create_image_view(uint64_t device, uint64_t image, uint32_t format, uint32_t aspect_mask, uint32_t view_type,
@@ -4394,6 +4571,29 @@ namespace sogen
         return VK_SUCCESS;
     }
 
+    int32_t vulkan_host::cmd_write_timestamp2(uint64_t command_buffer, uint64_t query_pool, uint32_t query, uint64_t pipeline_stage)
+    {
+        const auto cb = this->impl_->command_buffers.find(command_buffer);
+        const auto qp = this->impl_->query_pools.find(query_pool);
+        if (cb == this->impl_->command_buffers.end() || qp == this->impl_->query_pools.end() ||
+            qp->second.device_id != cb->second.device_id)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        const auto dev = this->impl_->devices.find(cb->second.device_id);
+        if (dev == this->impl_->devices.end())
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        if (!dev->second.cmd_write_timestamp2)
+        {
+            return VK_ERROR_FEATURE_NOT_PRESENT;
+        }
+
+        dev->second.cmd_write_timestamp2(cb->second.handle, static_cast<VkPipelineStageFlags2>(pipeline_stage), qp->second.handle, query);
+        return VK_SUCCESS;
+    }
+
     int32_t vulkan_host::cmd_copy_query_pool_results(uint64_t command_buffer, uint64_t query_pool, uint32_t first_query,
                                                      uint32_t query_count, uint64_t destination_buffer, uint64_t destination_offset,
                                                      uint64_t stride, uint32_t flags)
@@ -4682,7 +4882,7 @@ namespace sogen
     }
 
     int32_t vulkan_host::get_descriptor_set_layout_support(uint64_t device, std::span<const descriptor_binding> bindings,
-                                                            uint32_t& supported)
+                                                           uint32_t& supported)
     {
         supported = VK_FALSE;
 
@@ -5021,12 +5221,12 @@ namespace sogen
         return VK_SUCCESS;
     }
 
-    int32_t vulkan_host::create_graphics_pipeline(uint64_t device, uint64_t render_pass, uint64_t pipeline_layout,
-                                                  const shader_stage_source& vertex_shader, const shader_stage_source& fragment_shader,
-                                                  uint32_t flags, uint32_t width, uint32_t height, std::span<const vertex_binding> bindings,
-                                                  std::span<const vertex_attribute> attributes, std::span<const vertex_divisor> divisors,
-                                                  const depth_state& depth, std::span<const uint32_t> color_formats, uint32_t depth_format,
-                                                  uint32_t stencil_format, uint32_t rasterization_samples, uint32_t primitive_topology,
+    int32_t vulkan_host::create_graphics_pipeline(uint64_t device, uint64_t render_pass, uint64_t pipeline_layout, uint64_t vertex_shader,
+                                                  uint64_t fragment_shader, uint32_t flags, uint32_t width, uint32_t height,
+                                                  std::span<const vertex_binding> bindings, std::span<const vertex_attribute> attributes,
+                                                  std::span<const vertex_divisor> divisors, const depth_state& depth,
+                                                  std::span<const uint32_t> color_formats, uint32_t depth_format, uint32_t stencil_format,
+                                                  uint32_t rasterization_samples, uint32_t primitive_topology,
                                                   uint32_t primitive_restart_enable, std::span<const uint32_t> dynamic_states,
                                                   const specialization& vs_spec, const specialization& fs_spec,
                                                   std::span<const color_blend_attachment> blend_attachments_in, uint64_t& out_pipeline)
@@ -5040,33 +5240,15 @@ namespace sogen
             return VK_ERROR_INITIALIZATION_FAILED;
         }
 
-        const auto resolve_stage = [&](const shader_stage_source& source, VkShaderModule& module) {
-            const bool has_module = source.module != 0;
-            const bool has_identifier = !source.identifier.empty();
-            if (has_module == has_identifier || source.identifier.size() > VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT)
-            {
-                return false;
-            }
-            if (!has_module)
-            {
-                module = VK_NULL_HANDLE;
-                return true;
-            }
-            const auto shader = this->impl_->shader_modules.find(source.module);
-            if (shader == this->impl_->shader_modules.end() || shader->second.device_id != device)
-            {
-                return false;
-            }
-            module = shader->second.handle;
-            return true;
-        };
-
-        VkShaderModule vertex_module = VK_NULL_HANDLE;
-        VkShaderModule fragment_module = VK_NULL_HANDLE;
-        if (!resolve_stage(vertex_shader, vertex_module) || !resolve_stage(fragment_shader, fragment_module))
+        const auto vert = this->impl_->shader_modules.find(vertex_shader);
+        const auto frag = this->impl_->shader_modules.find(fragment_shader);
+        if (vert == this->impl_->shader_modules.end() || frag == this->impl_->shader_modules.end() || vert->second.device_id != device ||
+            frag->second.device_id != device)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
+        const VkShaderModule vertex_module = vert->second.handle;
+        const VkShaderModule fragment_module = frag->second.handle;
 
         // render_pass == 0 means the pipeline targets dynamic rendering (DXVK 2.x): there is no render-pass
         // object; the attachment formats come in via VkPipelineRenderingCreateInfo and viewport/scissor are
@@ -5124,28 +5306,13 @@ namespace sogen
 
         const specialization fs_effective = fs_spec;
 
-        std::array<VkPipelineShaderStageModuleIdentifierCreateInfoEXT, 2> stage_identifiers{};
-        const auto initialize_identifier = [&](size_t index, const shader_stage_source& source) -> const void* {
-            if (source.identifier.empty())
-            {
-                return nullptr;
-            }
-            auto& identifier = stage_identifiers[index];
-            identifier.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_MODULE_IDENTIFIER_CREATE_INFO_EXT;
-            identifier.identifierSize = static_cast<uint32_t>(source.identifier.size());
-            identifier.pIdentifier = source.identifier.data();
-            return &identifier;
-        };
-
         std::array<VkPipelineShaderStageCreateInfo, 2> stages{};
         stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-        stages[0].pNext = initialize_identifier(0, vertex_shader);
         stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
         stages[0].module = vertex_module;
         stages[0].pName = "main";
         stages[0].pSpecializationInfo = build_spec(vs_spec, 0);
         stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-        stages[1].pNext = initialize_identifier(1, fragment_shader);
         stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
         stages[1].module = fragment_module;
         stages[1].pName = "main";
@@ -5330,8 +5497,8 @@ namespace sogen
         return VK_SUCCESS;
     }
 
-    int32_t vulkan_host::create_compute_pipeline(uint64_t device, uint64_t pipeline_layout, const shader_stage_source& shader,
-                                                 uint32_t flags, uint64_t& out_pipeline)
+    int32_t vulkan_host::create_compute_pipeline(uint64_t device, uint64_t pipeline_layout, uint64_t shader_module, uint32_t flags,
+                                                 uint64_t& out_pipeline)
     {
         out_pipeline = 0;
 
@@ -5343,30 +5510,10 @@ namespace sogen
             return VK_ERROR_INITIALIZATION_FAILED;
         }
 
-        const bool has_module = shader.module != 0;
-        const bool has_identifier = !shader.identifier.empty();
-        if (has_module == has_identifier || shader.identifier.size() > VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT)
+        const auto shader = this->impl_->shader_modules.find(shader_module);
+        if (shader == this->impl_->shader_modules.end() || shader->second.device_id != device)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
-        }
-
-        VkShaderModule module = VK_NULL_HANDLE;
-        if (has_module)
-        {
-            const auto module_it = this->impl_->shader_modules.find(shader.module);
-            if (module_it == this->impl_->shader_modules.end() || module_it->second.device_id != device)
-            {
-                return VK_ERROR_INITIALIZATION_FAILED;
-            }
-            module = module_it->second.handle;
-        }
-
-        VkPipelineShaderStageModuleIdentifierCreateInfoEXT identifier{};
-        if (has_identifier)
-        {
-            identifier.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_MODULE_IDENTIFIER_CREATE_INFO_EXT;
-            identifier.identifierSize = static_cast<uint32_t>(shader.identifier.size());
-            identifier.pIdentifier = shader.identifier.data();
         }
 
         VkComputePipelineCreateInfo info{};
@@ -5374,9 +5521,8 @@ namespace sogen
         info.flags = static_cast<VkPipelineCreateFlags>(flags);
         info.layout = layout->second.handle;
         info.stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-        info.stage.pNext = has_identifier ? &identifier : nullptr;
         info.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-        info.stage.module = module;
+        info.stage.module = shader->second.handle;
         info.stage.pName = "main";
 
         VkPipeline pipeline{};

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -45,7 +45,6 @@ namespace sogen
             std::string_view{"VK_KHR_external_fence_win32"},     //
             std::string_view{"VK_KHR_win32_keyed_mutex"},        //
             std::string_view{"VK_EXT_full_screen_exclusive"},    //
-            std::string_view{"VK_EXT_shader_module_identifier"}, //
             std::string_view{"VK_NV_low_latency2"},              //
         };
 
@@ -57,16 +56,6 @@ namespace sogen
         bool is_unsupported_device_extension(const VkExtensionProperties& extension)
         {
             return is_unsupported_extension_name(std::string_view{static_cast<const char*>(extension.extensionName)});
-        }
-
-        bool is_unsupported_feature_structure(const VkStructureType type)
-        {
-            return type == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_FEATURES_EXT;
-        }
-
-        bool is_unsupported_property_structure(const VkStructureType type)
-        {
-            return type == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_PROPERTIES_EXT;
         }
 
 #ifdef _WIN32
@@ -302,6 +291,7 @@ namespace sogen
             PFN_vkCreateShaderModule create_shader_module{};
             PFN_vkDestroyShaderModule destroy_shader_module{};
             PFN_vkGetShaderModuleIdentifierEXT get_shader_module_identifier{};
+            PFN_vkGetShaderModuleCreateInfoIdentifierEXT get_shader_module_create_info_identifier{};
             PFN_vkCreateImageView create_image_view{};
             PFN_vkDestroyImageView destroy_image_view{};
             PFN_vkCreateBufferView create_buffer_view{};
@@ -1449,10 +1439,6 @@ namespace sogen
             {
                 continue; // the root struct itself
             }
-            if (is_unsupported_feature_structure(type))
-            {
-                continue;
-            }
             const size_t size = gpu_bridge::feature_struct_size(type);
             if (size == 0)
             {
@@ -1544,10 +1530,6 @@ namespace sogen
         for (uint32_t i = 0; i < struct_count; ++i)
         {
             const auto type = static_cast<VkStructureType>(records[i].s_type);
-            if (is_unsupported_property_structure(type))
-            {
-                continue;
-            }
             const size_t size = gpu_bridge::property_struct_size(type);
             if (size == 0)
             {
@@ -1697,7 +1679,7 @@ namespace sogen
 
                 const auto type = static_cast<VkStructureType>(record.s_type);
                 const size_t size = gpu_bridge::feature_struct_size(type);
-                if (size != 0 && !is_unsupported_feature_structure(type))
+                if (size != 0)
                 {
                     const size_t capacity = size - gpu_bridge::feature_chain_header_size;
                     const size_t copy = std::min<size_t>(record.body_size, capacity);
@@ -1816,6 +1798,8 @@ namespace sogen
             data.destroy_shader_module = reinterpret_cast<PFN_vkDestroyShaderModule>(resolve("vkDestroyShaderModule"));
             data.get_shader_module_identifier =
                 reinterpret_cast<PFN_vkGetShaderModuleIdentifierEXT>(resolve("vkGetShaderModuleIdentifierEXT"));
+            data.get_shader_module_create_info_identifier =
+                reinterpret_cast<PFN_vkGetShaderModuleCreateInfoIdentifierEXT>(resolve("vkGetShaderModuleCreateInfoIdentifierEXT"));
             data.create_image_view = reinterpret_cast<PFN_vkCreateImageView>(resolve("vkCreateImageView"));
             data.destroy_image_view = reinterpret_cast<PFN_vkDestroyImageView>(resolve("vkDestroyImageView"));
             data.create_buffer_view = reinterpret_cast<PFN_vkCreateBufferView>(resolve("vkCreateBufferView"));
@@ -4008,7 +3992,7 @@ namespace sogen
         return frames;
     }
 
-    int32_t vulkan_host::create_shader_module(uint64_t device, const void* code, size_t code_size, uint64_t& out_module)
+    int32_t vulkan_host::create_shader_module(uint64_t device, uint32_t flags, const void* code, size_t code_size, uint64_t& out_module)
     {
         out_module = 0;
         const auto dev = this->impl_->devices.find(device);
@@ -4019,6 +4003,7 @@ namespace sogen
 
         VkShaderModuleCreateInfo info{};
         info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+        info.flags = static_cast<VkShaderModuleCreateFlags>(flags);
         info.codeSize = code_size;
         info.pCode = static_cast<const uint32_t*>(code);
 
@@ -4065,6 +4050,30 @@ namespace sogen
         VkShaderModuleIdentifierEXT result{};
         result.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT;
         dev->second.get_shader_module_identifier(dev->second.handle, module->second.handle, &result);
+        identifier_size = std::min<uint32_t>(result.identifierSize, static_cast<uint32_t>(identifier.size()));
+        std::memcpy(identifier.data(), result.identifier, identifier_size);
+        return VK_SUCCESS;
+    }
+
+    int32_t vulkan_host::get_shader_module_create_info_identifier(uint64_t device, uint32_t flags, const void* code, size_t code_size,
+                                                                  std::span<uint8_t> identifier, uint32_t& identifier_size)
+    {
+        identifier_size = 0;
+        const auto dev = this->impl_->devices.find(device);
+        if (dev == this->impl_->devices.end() || !dev->second.get_shader_module_create_info_identifier)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        VkShaderModuleCreateInfo create_info{};
+        create_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+        create_info.flags = static_cast<VkShaderModuleCreateFlags>(flags);
+        create_info.codeSize = code_size;
+        create_info.pCode = static_cast<const uint32_t*>(code);
+
+        VkShaderModuleIdentifierEXT result{};
+        result.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT;
+        dev->second.get_shader_module_create_info_identifier(dev->second.handle, &create_info, &result);
         identifier_size = std::min<uint32_t>(result.identifierSize, static_cast<uint32_t>(identifier.size()));
         std::memcpy(identifier.data(), result.identifier, identifier_size);
         return VK_SUCCESS;
@@ -4969,9 +4978,10 @@ namespace sogen
         return VK_SUCCESS;
     }
 
-    int32_t vulkan_host::create_graphics_pipeline(uint64_t device, uint64_t render_pass, uint64_t pipeline_layout, uint64_t vertex_shader,
-                                                  uint64_t fragment_shader, uint32_t width, uint32_t height,
-                                                  std::span<const vertex_binding> bindings, std::span<const vertex_attribute> attributes,
+    int32_t vulkan_host::create_graphics_pipeline(uint64_t device, uint64_t render_pass, uint64_t pipeline_layout,
+                                                  const shader_stage_source& vertex_shader, const shader_stage_source& fragment_shader,
+                                                  uint32_t flags, uint32_t width, uint32_t height, std::span<const vertex_binding> bindings,
+                                                  std::span<const vertex_attribute> attributes, std::span<const vertex_divisor> divisors,
                                                   const depth_state& depth, std::span<const uint32_t> color_formats, uint32_t depth_format,
                                                   uint32_t stencil_format, uint32_t rasterization_samples, uint32_t primitive_topology,
                                                   uint32_t primitive_restart_enable, std::span<const uint32_t> dynamic_states,
@@ -4981,11 +4991,36 @@ namespace sogen
         out_pipeline = 0;
         const auto dev = this->impl_->devices.find(device);
         const auto layout = this->impl_->pipeline_layouts.find(pipeline_layout);
-        const auto vert = this->impl_->shader_modules.find(vertex_shader);
-        const auto frag = this->impl_->shader_modules.find(fragment_shader);
-        if (dev == this->impl_->devices.end() || layout == this->impl_->pipeline_layouts.end() ||
-            vert == this->impl_->shader_modules.end() || frag == this->impl_->shader_modules.end() || layout->second.device_id != device ||
-            vert->second.device_id != device || frag->second.device_id != device || !dev->second.create_graphics_pipelines)
+        if (dev == this->impl_->devices.end() || layout == this->impl_->pipeline_layouts.end() || layout->second.device_id != device ||
+            !dev->second.create_graphics_pipelines)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        const auto resolve_stage = [&](const shader_stage_source& source, VkShaderModule& module) {
+            const bool has_module = source.module != 0;
+            const bool has_identifier = !source.identifier.empty();
+            if (has_module == has_identifier || source.identifier.size() > VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT)
+            {
+                return false;
+            }
+            if (!has_module)
+            {
+                module = VK_NULL_HANDLE;
+                return true;
+            }
+            const auto shader = this->impl_->shader_modules.find(source.module);
+            if (shader == this->impl_->shader_modules.end() || shader->second.device_id != device)
+            {
+                return false;
+            }
+            module = shader->second.handle;
+            return true;
+        };
+
+        VkShaderModule vertex_module = VK_NULL_HANDLE;
+        VkShaderModule fragment_module = VK_NULL_HANDLE;
+        if (!resolve_stage(vertex_shader, vertex_module) || !resolve_stage(fragment_shader, fragment_module))
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
@@ -5046,15 +5081,30 @@ namespace sogen
 
         const specialization fs_effective = fs_spec;
 
+        std::array<VkPipelineShaderStageModuleIdentifierCreateInfoEXT, 2> stage_identifiers{};
+        const auto initialize_identifier = [&](size_t index, const shader_stage_source& source) -> const void* {
+            if (source.identifier.empty())
+            {
+                return nullptr;
+            }
+            auto& identifier = stage_identifiers[index];
+            identifier.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_MODULE_IDENTIFIER_CREATE_INFO_EXT;
+            identifier.identifierSize = static_cast<uint32_t>(source.identifier.size());
+            identifier.pIdentifier = source.identifier.data();
+            return &identifier;
+        };
+
         std::array<VkPipelineShaderStageCreateInfo, 2> stages{};
         stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        stages[0].pNext = initialize_identifier(0, vertex_shader);
         stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-        stages[0].module = vert->second.handle;
+        stages[0].module = vertex_module;
         stages[0].pName = "main";
         stages[0].pSpecializationInfo = build_spec(vs_spec, 0);
         stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        stages[1].pNext = initialize_identifier(1, fragment_shader);
         stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-        stages[1].module = frag->second.handle;
+        stages[1].module = fragment_module;
         stages[1].pName = "main";
         stages[1].pSpecializationInfo = build_spec(fs_effective, 1);
 
@@ -5073,8 +5123,33 @@ namespace sogen
                 {.location = a.location, .binding = a.binding, .format = static_cast<VkFormat>(a.format), .offset = a.offset});
         }
 
+        std::vector<VkVertexInputBindingDivisorDescription> vk_divisors;
+        vk_divisors.reserve(divisors.size());
+        for (const vertex_divisor& divisor : divisors)
+        {
+            const auto binding =
+                std::ranges::find_if(bindings, [&](const vertex_binding& candidate) { return candidate.binding == divisor.binding; });
+            if (binding == bindings.end() || binding->input_rate != VK_VERTEX_INPUT_RATE_INSTANCE ||
+                std::ranges::find_if(vk_divisors, [&](const VkVertexInputBindingDivisorDescription& candidate) {
+                    return candidate.binding == divisor.binding;
+                }) != vk_divisors.end())
+            {
+                return VK_ERROR_INITIALIZATION_FAILED;
+            }
+            vk_divisors.push_back({.binding = divisor.binding, .divisor = divisor.divisor});
+        }
+
+        VkPipelineVertexInputDivisorStateCreateInfo divisor_state{};
+        if (!vk_divisors.empty())
+        {
+            divisor_state.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO;
+            divisor_state.vertexBindingDivisorCount = static_cast<uint32_t>(vk_divisors.size());
+            divisor_state.pVertexBindingDivisors = vk_divisors.data();
+        }
+
         VkPipelineVertexInputStateCreateInfo vertex_input{};
         vertex_input.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+        vertex_input.pNext = vk_divisors.empty() ? nullptr : &divisor_state;
         vertex_input.vertexBindingDescriptionCount = static_cast<uint32_t>(vk_bindings.size());
         vertex_input.pVertexBindingDescriptions = vk_bindings.empty() ? nullptr : vk_bindings.data();
         vertex_input.vertexAttributeDescriptionCount = static_cast<uint32_t>(vk_attributes.size());
@@ -5183,6 +5258,7 @@ namespace sogen
 
         VkGraphicsPipelineCreateInfo info{};
         info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+        info.flags = static_cast<VkPipelineCreateFlags>(flags);
         info.pNext = dynamic_rendering ? &rendering_info : nullptr;
         info.stageCount = static_cast<uint32_t>(stages.size());
         info.pStages = stages.data();
@@ -5211,26 +5287,53 @@ namespace sogen
         return VK_SUCCESS;
     }
 
-    int32_t vulkan_host::create_compute_pipeline(uint64_t device, uint64_t pipeline_layout, uint64_t shader_module, uint64_t& out_pipeline)
+    int32_t vulkan_host::create_compute_pipeline(uint64_t device, uint64_t pipeline_layout, const shader_stage_source& shader,
+                                                 uint32_t flags, uint64_t& out_pipeline)
     {
         out_pipeline = 0;
 
         const auto dev = this->impl_->devices.find(device);
         const auto layout = this->impl_->pipeline_layouts.find(pipeline_layout);
-        const auto shader = this->impl_->shader_modules.find(shader_module);
-        if (dev == this->impl_->devices.end() || layout == this->impl_->pipeline_layouts.end() ||
-            shader == this->impl_->shader_modules.end() || layout->second.device_id != device || shader->second.device_id != device ||
+        if (dev == this->impl_->devices.end() || layout == this->impl_->pipeline_layouts.end() || layout->second.device_id != device ||
             !dev->second.create_compute_pipelines)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
 
+        const bool has_module = shader.module != 0;
+        const bool has_identifier = !shader.identifier.empty();
+        if (has_module == has_identifier || shader.identifier.size() > VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        VkShaderModule module = VK_NULL_HANDLE;
+        if (has_module)
+        {
+            const auto module_it = this->impl_->shader_modules.find(shader.module);
+            if (module_it == this->impl_->shader_modules.end() || module_it->second.device_id != device)
+            {
+                return VK_ERROR_INITIALIZATION_FAILED;
+            }
+            module = module_it->second.handle;
+        }
+
+        VkPipelineShaderStageModuleIdentifierCreateInfoEXT identifier{};
+        if (has_identifier)
+        {
+            identifier.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_MODULE_IDENTIFIER_CREATE_INFO_EXT;
+            identifier.identifierSize = static_cast<uint32_t>(shader.identifier.size());
+            identifier.pIdentifier = shader.identifier.data();
+        }
+
         VkComputePipelineCreateInfo info{};
         info.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+        info.flags = static_cast<VkPipelineCreateFlags>(flags);
         info.layout = layout->second.handle;
         info.stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        info.stage.pNext = has_identifier ? &identifier : nullptr;
         info.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-        info.stage.module = shader->second.handle;
+        info.stage.module = module;
         info.stage.pName = "main";
 
         VkPipeline pipeline{};

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -312,6 +312,7 @@ namespace sogen
             PFN_vkCreatePipelineLayout create_pipeline_layout{};
             PFN_vkDestroyPipelineLayout destroy_pipeline_layout{};
             PFN_vkCreateDescriptorSetLayout create_descriptor_set_layout{};
+            PFN_vkGetDescriptorSetLayoutSupport get_descriptor_set_layout_support{};
             PFN_vkDestroyDescriptorSetLayout destroy_descriptor_set_layout{};
             PFN_vkCreateDescriptorPool create_descriptor_pool{};
             PFN_vkDestroyDescriptorPool destroy_descriptor_pool{};
@@ -1820,6 +1821,13 @@ namespace sogen
             data.create_pipeline_layout = reinterpret_cast<PFN_vkCreatePipelineLayout>(resolve("vkCreatePipelineLayout"));
             data.destroy_pipeline_layout = reinterpret_cast<PFN_vkDestroyPipelineLayout>(resolve("vkDestroyPipelineLayout"));
             data.create_descriptor_set_layout = reinterpret_cast<PFN_vkCreateDescriptorSetLayout>(resolve("vkCreateDescriptorSetLayout"));
+            data.get_descriptor_set_layout_support =
+                reinterpret_cast<PFN_vkGetDescriptorSetLayoutSupport>(resolve("vkGetDescriptorSetLayoutSupport"));
+            if (!data.get_descriptor_set_layout_support)
+            {
+                data.get_descriptor_set_layout_support =
+                    reinterpret_cast<PFN_vkGetDescriptorSetLayoutSupport>(resolve("vkGetDescriptorSetLayoutSupportKHR"));
+            }
             data.destroy_descriptor_set_layout =
                 reinterpret_cast<PFN_vkDestroyDescriptorSetLayout>(resolve("vkDestroyDescriptorSetLayout"));
             data.create_descriptor_pool = reinterpret_cast<PFN_vkCreateDescriptorPool>(resolve("vkCreateDescriptorPool"));
@@ -4670,6 +4678,41 @@ namespace sogen
         const uint64_t id = this->impl_->next_id++;
         this->impl_->descriptor_set_layouts.emplace(id, impl::descriptor_set_layout_data{.handle = layout, .device_id = device});
         out_layout = id;
+        return VK_SUCCESS;
+    }
+
+    int32_t vulkan_host::get_descriptor_set_layout_support(uint64_t device, std::span<const descriptor_binding> bindings,
+                                                            uint32_t& supported)
+    {
+        supported = VK_FALSE;
+
+        const auto dev = this->impl_->devices.find(device);
+        if (dev == this->impl_->devices.end() || !dev->second.get_descriptor_set_layout_support)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        std::vector<VkDescriptorSetLayoutBinding> vk_bindings;
+        vk_bindings.reserve(bindings.size());
+        for (const descriptor_binding& b : bindings)
+        {
+            VkDescriptorSetLayoutBinding vb{};
+            vb.binding = b.binding;
+            vb.descriptorType = static_cast<VkDescriptorType>(b.descriptor_type);
+            vb.descriptorCount = b.descriptor_count;
+            vb.stageFlags = b.stage_flags;
+            vk_bindings.push_back(vb);
+        }
+
+        VkDescriptorSetLayoutCreateInfo info{};
+        info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        info.bindingCount = static_cast<uint32_t>(vk_bindings.size());
+        info.pBindings = vk_bindings.empty() ? nullptr : vk_bindings.data();
+
+        VkDescriptorSetLayoutSupport support{};
+        support.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT;
+        dev->second.get_descriptor_set_layout_support(dev->second.handle, &info, &support);
+        supported = support.supported;
         return VK_SUCCESS;
     }
 

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -45,6 +45,8 @@ namespace sogen
             std::string_view{"VK_KHR_external_fence_win32"},     //
             std::string_view{"VK_KHR_win32_keyed_mutex"},        //
             std::string_view{"VK_EXT_full_screen_exclusive"},    //
+            std::string_view{"VK_EXT_shader_module_identifier"}, //
+            std::string_view{"VK_NV_low_latency2"},              //
         };
 
         bool is_unsupported_extension_name(const std::string_view name)
@@ -55,6 +57,16 @@ namespace sogen
         bool is_unsupported_device_extension(const VkExtensionProperties& extension)
         {
             return is_unsupported_extension_name(std::string_view{static_cast<const char*>(extension.extensionName)});
+        }
+
+        bool is_unsupported_feature_structure(const VkStructureType type)
+        {
+            return type == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_FEATURES_EXT;
+        }
+
+        bool is_unsupported_property_structure(const VkStructureType type)
+        {
+            return type == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_PROPERTIES_EXT;
         }
 
 #ifdef _WIN32
@@ -289,6 +301,7 @@ namespace sogen
             PFN_vkDestroySampler destroy_sampler{};
             PFN_vkCreateShaderModule create_shader_module{};
             PFN_vkDestroyShaderModule destroy_shader_module{};
+            PFN_vkGetShaderModuleIdentifierEXT get_shader_module_identifier{};
             PFN_vkCreateImageView create_image_view{};
             PFN_vkDestroyImageView destroy_image_view{};
             PFN_vkCreateBufferView create_buffer_view{};
@@ -301,6 +314,7 @@ namespace sogen
             PFN_vkCmdBeginQuery cmd_begin_query{};
             PFN_vkCmdEndQuery cmd_end_query{};
             PFN_vkCmdWriteTimestamp cmd_write_timestamp{};
+            PFN_vkCmdCopyQueryPoolResults cmd_copy_query_pool_results{};
             PFN_vkCreateRenderPass create_render_pass{};
             PFN_vkDestroyRenderPass destroy_render_pass{};
             PFN_vkCreateFramebuffer create_framebuffer{};
@@ -313,6 +327,7 @@ namespace sogen
             PFN_vkDestroyDescriptorPool destroy_descriptor_pool{};
             PFN_vkResetDescriptorPool reset_descriptor_pool{};
             PFN_vkAllocateDescriptorSets allocate_descriptor_sets{};
+            PFN_vkFreeDescriptorSets free_descriptor_sets{};
             PFN_vkUpdateDescriptorSets update_descriptor_sets{};
             PFN_vkCmdBindDescriptorSets cmd_bind_descriptor_sets{};
             PFN_vkCreateGraphicsPipelines create_graphics_pipelines{};
@@ -330,7 +345,12 @@ namespace sogen
             PFN_vkCmdBindVertexBuffers2 cmd_bind_vertex_buffers2{};
             PFN_vkCmdBindIndexBuffer cmd_bind_index_buffer{};
             PFN_vkCmdDrawIndexed cmd_draw_indexed{};
+            PFN_vkCmdDrawIndexedIndirect cmd_draw_indexed_indirect{};
+            PFN_vkCmdDrawIndexedIndirectCount cmd_draw_indexed_indirect_count{};
+            PFN_vkCmdDrawIndirect cmd_draw_indirect{};
+            PFN_vkCmdDrawIndirectCount cmd_draw_indirect_count{};
             PFN_vkCmdEndRenderPass cmd_end_render_pass{};
+            PFN_vkCmdNextSubpass cmd_next_subpass{};
             PFN_vkCmdPushConstants cmd_push_constants{};
             PFN_vkCmdSetViewport cmd_set_viewport{};
             PFN_vkCmdSetViewportWithCount cmd_set_viewport_with_count{};
@@ -1429,6 +1449,10 @@ namespace sogen
             {
                 continue; // the root struct itself
             }
+            if (is_unsupported_feature_structure(type))
+            {
+                continue;
+            }
             const size_t size = gpu_bridge::feature_struct_size(type);
             if (size == 0)
             {
@@ -1520,6 +1544,10 @@ namespace sogen
         for (uint32_t i = 0; i < struct_count; ++i)
         {
             const auto type = static_cast<VkStructureType>(records[i].s_type);
+            if (is_unsupported_property_structure(type))
+            {
+                continue;
+            }
             const size_t size = gpu_bridge::property_struct_size(type);
             if (size == 0)
             {
@@ -1669,7 +1697,7 @@ namespace sogen
 
                 const auto type = static_cast<VkStructureType>(record.s_type);
                 const size_t size = gpu_bridge::feature_struct_size(type);
-                if (size != 0)
+                if (size != 0 && !is_unsupported_feature_structure(type))
                 {
                     const size_t capacity = size - gpu_bridge::feature_chain_header_size;
                     const size_t copy = std::min<size_t>(record.body_size, capacity);
@@ -1786,6 +1814,8 @@ namespace sogen
             data.destroy_sampler = reinterpret_cast<PFN_vkDestroySampler>(resolve("vkDestroySampler"));
             data.create_shader_module = reinterpret_cast<PFN_vkCreateShaderModule>(resolve("vkCreateShaderModule"));
             data.destroy_shader_module = reinterpret_cast<PFN_vkDestroyShaderModule>(resolve("vkDestroyShaderModule"));
+            data.get_shader_module_identifier =
+                reinterpret_cast<PFN_vkGetShaderModuleIdentifierEXT>(resolve("vkGetShaderModuleIdentifierEXT"));
             data.create_image_view = reinterpret_cast<PFN_vkCreateImageView>(resolve("vkCreateImageView"));
             data.destroy_image_view = reinterpret_cast<PFN_vkDestroyImageView>(resolve("vkDestroyImageView"));
             data.create_buffer_view = reinterpret_cast<PFN_vkCreateBufferView>(resolve("vkCreateBufferView"));
@@ -1798,6 +1828,7 @@ namespace sogen
             data.cmd_begin_query = reinterpret_cast<PFN_vkCmdBeginQuery>(resolve("vkCmdBeginQuery"));
             data.cmd_end_query = reinterpret_cast<PFN_vkCmdEndQuery>(resolve("vkCmdEndQuery"));
             data.cmd_write_timestamp = reinterpret_cast<PFN_vkCmdWriteTimestamp>(resolve("vkCmdWriteTimestamp"));
+            data.cmd_copy_query_pool_results = reinterpret_cast<PFN_vkCmdCopyQueryPoolResults>(resolve("vkCmdCopyQueryPoolResults"));
             data.create_render_pass = reinterpret_cast<PFN_vkCreateRenderPass>(resolve("vkCreateRenderPass"));
             data.destroy_render_pass = reinterpret_cast<PFN_vkDestroyRenderPass>(resolve("vkDestroyRenderPass"));
             data.create_framebuffer = reinterpret_cast<PFN_vkCreateFramebuffer>(resolve("vkCreateFramebuffer"));
@@ -1811,6 +1842,7 @@ namespace sogen
             data.destroy_descriptor_pool = reinterpret_cast<PFN_vkDestroyDescriptorPool>(resolve("vkDestroyDescriptorPool"));
             data.reset_descriptor_pool = reinterpret_cast<PFN_vkResetDescriptorPool>(resolve("vkResetDescriptorPool"));
             data.allocate_descriptor_sets = reinterpret_cast<PFN_vkAllocateDescriptorSets>(resolve("vkAllocateDescriptorSets"));
+            data.free_descriptor_sets = reinterpret_cast<PFN_vkFreeDescriptorSets>(resolve("vkFreeDescriptorSets"));
             data.update_descriptor_sets = reinterpret_cast<PFN_vkUpdateDescriptorSets>(resolve("vkUpdateDescriptorSets"));
             data.cmd_bind_descriptor_sets = reinterpret_cast<PFN_vkCmdBindDescriptorSets>(resolve("vkCmdBindDescriptorSets"));
             data.create_graphics_pipelines = reinterpret_cast<PFN_vkCreateGraphicsPipelines>(resolve("vkCreateGraphicsPipelines"));
@@ -1828,7 +1860,13 @@ namespace sogen
             data.cmd_bind_vertex_buffers2 = reinterpret_cast<PFN_vkCmdBindVertexBuffers2>(resolve("vkCmdBindVertexBuffers2"));
             data.cmd_bind_index_buffer = reinterpret_cast<PFN_vkCmdBindIndexBuffer>(resolve("vkCmdBindIndexBuffer"));
             data.cmd_draw_indexed = reinterpret_cast<PFN_vkCmdDrawIndexed>(resolve("vkCmdDrawIndexed"));
+            data.cmd_draw_indexed_indirect = reinterpret_cast<PFN_vkCmdDrawIndexedIndirect>(resolve("vkCmdDrawIndexedIndirect"));
+            data.cmd_draw_indexed_indirect_count =
+                reinterpret_cast<PFN_vkCmdDrawIndexedIndirectCount>(resolve("vkCmdDrawIndexedIndirectCount"));
+            data.cmd_draw_indirect = reinterpret_cast<PFN_vkCmdDrawIndirect>(resolve("vkCmdDrawIndirect"));
+            data.cmd_draw_indirect_count = reinterpret_cast<PFN_vkCmdDrawIndirectCount>(resolve("vkCmdDrawIndirectCount"));
             data.cmd_end_render_pass = reinterpret_cast<PFN_vkCmdEndRenderPass>(resolve("vkCmdEndRenderPass"));
+            data.cmd_next_subpass = reinterpret_cast<PFN_vkCmdNextSubpass>(resolve("vkCmdNextSubpass"));
             data.cmd_push_constants = reinterpret_cast<PFN_vkCmdPushConstants>(resolve("vkCmdPushConstants"));
             data.cmd_set_viewport = reinterpret_cast<PFN_vkCmdSetViewport>(resolve("vkCmdSetViewport"));
             data.cmd_set_viewport_with_count = reinterpret_cast<PFN_vkCmdSetViewportWithCount>(resolve("vkCmdSetViewportWithCount"));
@@ -4012,6 +4050,26 @@ namespace sogen
         this->impl_->shader_modules.erase(it);
     }
 
+    int32_t vulkan_host::get_shader_module_identifier(uint64_t device, uint64_t shader_module, std::span<uint8_t> identifier,
+                                                      uint32_t& identifier_size)
+    {
+        identifier_size = 0;
+        const auto dev = this->impl_->devices.find(device);
+        const auto module = this->impl_->shader_modules.find(shader_module);
+        if (dev == this->impl_->devices.end() || module == this->impl_->shader_modules.end() || module->second.device_id != device ||
+            !dev->second.get_shader_module_identifier)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        VkShaderModuleIdentifierEXT result{};
+        result.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT;
+        dev->second.get_shader_module_identifier(dev->second.handle, module->second.handle, &result);
+        identifier_size = std::min<uint32_t>(result.identifierSize, static_cast<uint32_t>(identifier.size()));
+        std::memcpy(identifier.data(), result.identifier, identifier_size);
+        return VK_SUCCESS;
+    }
+
     int32_t vulkan_host::create_image_view(uint64_t device, uint64_t image, uint32_t format, uint32_t aspect_mask, uint32_t view_type,
                                            uint32_t base_mip_level, uint32_t level_count, uint32_t base_array_layer, uint32_t layer_count,
                                            uint32_t swizzle_r, uint32_t swizzle_g, uint32_t swizzle_b, uint32_t swizzle_a,
@@ -4316,6 +4374,30 @@ namespace sogen
             return VK_ERROR_INITIALIZATION_FAILED;
         }
         dev->second.cmd_write_timestamp(cb->second.handle, static_cast<VkPipelineStageFlagBits>(pipeline_stage), qp->second.handle, query);
+        return VK_SUCCESS;
+    }
+
+    int32_t vulkan_host::cmd_copy_query_pool_results(uint64_t command_buffer, uint64_t query_pool, uint32_t first_query,
+                                                     uint32_t query_count, uint64_t destination_buffer, uint64_t destination_offset,
+                                                     uint64_t stride, uint32_t flags)
+    {
+        const auto cb = this->impl_->command_buffers.find(command_buffer);
+        const auto qp = this->impl_->query_pools.find(query_pool);
+        const auto buffer = this->impl_->buffers.find(destination_buffer);
+        if (cb == this->impl_->command_buffers.end() || qp == this->impl_->query_pools.end() || buffer == this->impl_->buffers.end() ||
+            qp->second.device_id != cb->second.device_id || buffer->second.device_id != cb->second.device_id)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        const auto dev = this->impl_->devices.find(cb->second.device_id);
+        if (dev == this->impl_->devices.end() || !dev->second.cmd_copy_query_pool_results)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        dev->second.cmd_copy_query_pool_results(cb->second.handle, qp->second.handle, first_query, query_count, buffer->second.handle,
+                                                destination_offset, stride, static_cast<VkQueryResultFlags>(flags));
         return VK_SUCCESS;
     }
 
@@ -4722,6 +4804,40 @@ namespace sogen
         return VK_SUCCESS;
     }
 
+    int32_t vulkan_host::free_descriptor_sets(uint64_t device, uint64_t pool, std::span<const uint64_t> sets)
+    {
+        const auto dev = this->impl_->devices.find(device);
+        const auto pool_it = this->impl_->descriptor_pools.find(pool);
+        if (dev == this->impl_->devices.end() || pool_it == this->impl_->descriptor_pools.end() || pool_it->second.device_id != device ||
+            !dev->second.free_descriptor_sets)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        std::vector<VkDescriptorSet> handles;
+        handles.reserve(sets.size());
+        for (const uint64_t id : sets)
+        {
+            const auto set = this->impl_->descriptor_sets.find(id);
+            if (set == this->impl_->descriptor_sets.end() || set->second.device_id != device || set->second.pool_id != pool)
+            {
+                return VK_ERROR_INITIALIZATION_FAILED;
+            }
+            handles.push_back(set->second.handle);
+        }
+
+        const VkResult result = dev->second.free_descriptor_sets(dev->second.handle, pool_it->second.handle,
+                                                                 static_cast<uint32_t>(handles.size()), handles.data());
+        if (result == VK_SUCCESS)
+        {
+            for (const uint64_t id : sets)
+            {
+                this->impl_->descriptor_sets.erase(id);
+            }
+        }
+        return result;
+    }
+
     int32_t vulkan_host::update_descriptor_sets(uint64_t device, std::span<const descriptor_write> writes)
     {
         const auto dev = this->impl_->devices.find(device);
@@ -4737,9 +4853,11 @@ namespace sogen
         static thread_local std::vector<VkWriteDescriptorSet> vk_writes;
         static thread_local std::vector<VkDescriptorBufferInfo> buffer_infos;
         static thread_local std::vector<VkDescriptorImageInfo> image_infos;
+        static thread_local std::vector<VkBufferView> texel_buffer_views;
         vk_writes.clear();
         buffer_infos.resize(writes.size());
         image_infos.resize(writes.size());
+        texel_buffer_views.resize(writes.size());
         vk_writes.reserve(writes.size());
 
         // Consecutive writes usually target the same descriptor set; cache the last lookup to avoid a hash
@@ -4775,7 +4893,24 @@ namespace sogen
                 (w.descriptor_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER || w.descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ||
                  w.descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE || w.descriptor_type == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT ||
                  w.descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLER);
-            if (is_image)
+            const bool is_texel_buffer = (w.descriptor_type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER ||
+                                          w.descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
+            if (is_texel_buffer)
+            {
+                VkBufferView& buffer_view = texel_buffer_views[i];
+                buffer_view = VK_NULL_HANDLE;
+                if (w.buffer_or_view != 0)
+                {
+                    const auto view = this->impl_->buffer_views.find(w.buffer_or_view);
+                    if (view == this->impl_->buffer_views.end() || view->second.device_id != device)
+                    {
+                        return VK_ERROR_INITIALIZATION_FAILED;
+                    }
+                    buffer_view = view->second.handle;
+                }
+                vw.pTexelBufferView = &buffer_view;
+            }
+            else if (is_image)
             {
                 const auto view = this->impl_->image_views.find(w.image_view);
                 if (view != this->impl_->image_views.end() && view->second.device_id != device)
@@ -4800,7 +4935,7 @@ namespace sogen
             else
             {
                 VkDescriptorBufferInfo& bi = buffer_infos[i];
-                if (w.buffer == 0)
+                if (w.buffer_or_view == 0)
                 {
                     // Null descriptor (VK_EXT_robustness2 nullDescriptor, which DXVK enables): an unused
                     // uniform/storage buffer slot is bound to VK_NULL_HANDLE. Returning an error here makes
@@ -4811,7 +4946,7 @@ namespace sogen
                 }
                 else
                 {
-                    const auto buf = this->impl_->buffers.find(w.buffer);
+                    const auto buf = this->impl_->buffers.find(w.buffer_or_view);
                     if (buf == this->impl_->buffers.end() || buf->second.device_id != device)
                     {
                         return VK_ERROR_INITIALIZATION_FAILED;
@@ -4819,8 +4954,8 @@ namespace sogen
                     bi.buffer = buf->second.handle;
                     bi.offset = w.offset;
                     bi.range = w.range;
-                    cached_set->buffer_bindings[w.dst_binding] =
-                        impl::bound_buffer_info{.buffer_id = w.buffer, .offset = w.offset, .range = w.range, .type = w.descriptor_type};
+                    cached_set->buffer_bindings[w.dst_binding] = impl::bound_buffer_info{
+                        .buffer_id = w.buffer_or_view, .offset = w.offset, .range = w.range, .type = w.descriptor_type};
                 }
                 vw.pBufferInfo = &bi;
             }
@@ -5354,6 +5489,93 @@ namespace sogen
         return VK_SUCCESS;
     }
 
+    int32_t vulkan_host::cmd_draw_indexed_indirect(uint64_t command_buffer, uint64_t buffer, uint64_t offset, uint32_t draw_count,
+                                                   uint32_t stride)
+    {
+        const auto cb = this->impl_->command_buffers.find(command_buffer);
+        const auto buf = this->impl_->buffers.find(buffer);
+        if (cb == this->impl_->command_buffers.end() || buf == this->impl_->buffers.end() || buf->second.device_id != cb->second.device_id)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        const auto dev = this->impl_->devices.find(cb->second.device_id);
+        if (dev == this->impl_->devices.end() || !dev->second.cmd_draw_indexed_indirect)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        dev->second.cmd_draw_indexed_indirect(cb->second.handle, buf->second.handle, offset, draw_count, stride);
+        return VK_SUCCESS;
+    }
+
+    int32_t vulkan_host::cmd_draw_indexed_indirect_count(uint64_t command_buffer, uint64_t buffer, uint64_t offset, uint64_t count_buffer,
+                                                         uint64_t count_buffer_offset, uint32_t max_draw_count, uint32_t stride)
+    {
+        const auto cb = this->impl_->command_buffers.find(command_buffer);
+        const auto indirect_buffer = this->impl_->buffers.find(buffer);
+        const auto draw_count_buffer = this->impl_->buffers.find(count_buffer);
+        if (cb == this->impl_->command_buffers.end() || indirect_buffer == this->impl_->buffers.end() ||
+            draw_count_buffer == this->impl_->buffers.end() || indirect_buffer->second.device_id != cb->second.device_id ||
+            draw_count_buffer->second.device_id != cb->second.device_id)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        const auto dev = this->impl_->devices.find(cb->second.device_id);
+        if (dev == this->impl_->devices.end() || !dev->second.cmd_draw_indexed_indirect_count)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        dev->second.cmd_draw_indexed_indirect_count(cb->second.handle, indirect_buffer->second.handle, offset,
+                                                    draw_count_buffer->second.handle, count_buffer_offset, max_draw_count, stride);
+        return VK_SUCCESS;
+    }
+
+    int32_t vulkan_host::cmd_draw_indirect(uint64_t command_buffer, uint64_t buffer, uint64_t offset, uint32_t draw_count, uint32_t stride)
+    {
+        const auto cb = this->impl_->command_buffers.find(command_buffer);
+        const auto buf = this->impl_->buffers.find(buffer);
+        if (cb == this->impl_->command_buffers.end() || buf == this->impl_->buffers.end() || buf->second.device_id != cb->second.device_id)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        const auto dev = this->impl_->devices.find(cb->second.device_id);
+        if (dev == this->impl_->devices.end() || !dev->second.cmd_draw_indirect)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        dev->second.cmd_draw_indirect(cb->second.handle, buf->second.handle, offset, draw_count, stride);
+        return VK_SUCCESS;
+    }
+
+    int32_t vulkan_host::cmd_draw_indirect_count(uint64_t command_buffer, uint64_t buffer, uint64_t offset, uint64_t count_buffer,
+                                                 uint64_t count_buffer_offset, uint32_t max_draw_count, uint32_t stride)
+    {
+        const auto cb = this->impl_->command_buffers.find(command_buffer);
+        const auto indirect_buffer = this->impl_->buffers.find(buffer);
+        const auto draw_count_buffer = this->impl_->buffers.find(count_buffer);
+        if (cb == this->impl_->command_buffers.end() || indirect_buffer == this->impl_->buffers.end() ||
+            draw_count_buffer == this->impl_->buffers.end() || indirect_buffer->second.device_id != cb->second.device_id ||
+            draw_count_buffer->second.device_id != cb->second.device_id)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        const auto dev = this->impl_->devices.find(cb->second.device_id);
+        if (dev == this->impl_->devices.end() || !dev->second.cmd_draw_indirect_count)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        dev->second.cmd_draw_indirect_count(cb->second.handle, indirect_buffer->second.handle, offset, draw_count_buffer->second.handle,
+                                            count_buffer_offset, max_draw_count, stride);
+        return VK_SUCCESS;
+    }
+
     int32_t vulkan_host::cmd_bind_descriptor_sets(uint64_t command_buffer, uint64_t pipeline_layout, uint32_t first_set,
                                                   std::span<const uint64_t> sets, uint32_t bind_point,
                                                   std::span<const uint32_t> dynamic_offsets)
@@ -5402,6 +5624,24 @@ namespace sogen
             return VK_ERROR_INITIALIZATION_FAILED;
         }
         dev->second.cmd_end_render_pass(cb->second.handle);
+        return VK_SUCCESS;
+    }
+
+    int32_t vulkan_host::cmd_next_subpass(uint64_t command_buffer, uint32_t contents)
+    {
+        const auto cb = this->impl_->command_buffers.find(command_buffer);
+        if (cb == this->impl_->command_buffers.end())
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        const auto dev = this->impl_->devices.find(cb->second.device_id);
+        if (dev == this->impl_->devices.end() || !dev->second.cmd_next_subpass)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        dev->second.cmd_next_subpass(cb->second.handle, static_cast<VkSubpassContents>(contents));
         return VK_SUCCESS;
     }
 

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -396,6 +396,8 @@ namespace sogen
 
         int32_t create_shader_module(uint64_t device, const void* code, size_t code_size, uint64_t& out_module);
         void destroy_shader_module(uint64_t device, uint64_t shader_module);
+        int32_t get_shader_module_identifier(uint64_t device, uint64_t shader_module, std::span<uint8_t> identifier,
+                                             uint32_t& identifier_size);
 
         // aspect_mask selects COLOR vs DEPTH (0 defaults to COLOR).
         int32_t create_image_view(uint64_t device, uint64_t image, uint32_t format, uint32_t aspect_mask, uint32_t view_type,
@@ -415,6 +417,8 @@ namespace sogen
         int32_t cmd_begin_query(uint64_t command_buffer, uint64_t query_pool, uint32_t query, uint32_t flags);
         int32_t cmd_end_query(uint64_t command_buffer, uint64_t query_pool, uint32_t query);
         int32_t cmd_write_timestamp(uint64_t command_buffer, uint64_t query_pool, uint32_t query, uint32_t pipeline_stage);
+        int32_t cmd_copy_query_pool_results(uint64_t command_buffer, uint64_t query_pool, uint32_t first_query, uint32_t query_count,
+                                            uint64_t destination_buffer, uint64_t destination_offset, uint64_t stride, uint32_t flags);
 
         // One color attachment + an optional depth attachment (depth_format == 0 => color only), single
         // subpass (initial/final layouts as given; PRESENT_SRC_KHR is mapped to TRANSFER_SRC_OPTIMAL).
@@ -453,7 +457,7 @@ namespace sogen
             uint32_t dst_binding;
             uint32_t dst_array_element;
             uint32_t descriptor_type;
-            uint64_t buffer;
+            uint64_t buffer_or_view;
             uint64_t offset;
             uint64_t range;
             uint64_t sampler;
@@ -470,6 +474,7 @@ namespace sogen
         // true count.
         int32_t allocate_descriptor_sets(uint64_t device, uint64_t pool, std::span<const uint64_t> set_layouts,
                                          std::span<uint64_t> out_sets, uint32_t& out_count);
+        int32_t free_descriptor_sets(uint64_t device, uint64_t pool, std::span<const uint64_t> sets);
         int32_t update_descriptor_sets(uint64_t device, std::span<const descriptor_write> writes);
 
         // Optionally one push-constant range from offset 0 (push_constant_size == 0 means none), plus a
@@ -564,9 +569,16 @@ namespace sogen
         int32_t cmd_bind_index_buffer(uint64_t command_buffer, uint64_t buffer, uint64_t offset, uint32_t index_type);
         int32_t cmd_draw_indexed(uint64_t command_buffer, uint32_t index_count, uint32_t instance_count, uint32_t first_index,
                                  int32_t vertex_offset, uint32_t first_instance);
+        int32_t cmd_draw_indexed_indirect(uint64_t command_buffer, uint64_t buffer, uint64_t offset, uint32_t draw_count, uint32_t stride);
+        int32_t cmd_draw_indexed_indirect_count(uint64_t command_buffer, uint64_t buffer, uint64_t offset, uint64_t count_buffer,
+                                                uint64_t count_buffer_offset, uint32_t max_draw_count, uint32_t stride);
+        int32_t cmd_draw_indirect(uint64_t command_buffer, uint64_t buffer, uint64_t offset, uint32_t draw_count, uint32_t stride);
+        int32_t cmd_draw_indirect_count(uint64_t command_buffer, uint64_t buffer, uint64_t offset, uint64_t count_buffer,
+                                        uint64_t count_buffer_offset, uint32_t max_draw_count, uint32_t stride);
         int32_t cmd_bind_descriptor_sets(uint64_t command_buffer, uint64_t pipeline_layout, uint32_t first_set,
                                          std::span<const uint64_t> sets, uint32_t bind_point, std::span<const uint32_t> dynamic_offsets);
         int32_t cmd_end_render_pass(uint64_t command_buffer);
+        int32_t cmd_next_subpass(uint64_t command_buffer, uint32_t contents);
         // Dynamic rendering (VK_KHR_dynamic_rendering / core 1.3). depth/stencil are null when absent.
         int32_t cmd_begin_rendering(uint64_t command_buffer, int32_t area_x, int32_t area_y, uint32_t area_w, uint32_t area_h,
                                     uint32_t layer_count, uint32_t view_mask, uint32_t flags, std::span<const rendering_attachment> color,

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -468,6 +468,7 @@ namespace sogen
         };
 
         int32_t create_descriptor_set_layout(uint64_t device, std::span<const descriptor_binding> bindings, uint64_t& out_layout);
+        int32_t get_descriptor_set_layout_support(uint64_t device, std::span<const descriptor_binding> bindings, uint32_t& supported);
         void destroy_descriptor_set_layout(uint64_t device, uint64_t layout);
         int32_t create_descriptor_pool(uint64_t device, uint32_t max_sets, std::span<const descriptor_pool_size> sizes, uint64_t& out_pool);
         int32_t reset_descriptor_pool(uint64_t device, uint64_t pool, uint32_t flags);

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -72,6 +72,15 @@ namespace sogen
         // always receives the true device-extension count.
         int32_t enumerate_device_extension_properties(uint64_t physical_device, void* out, size_t out_size, uint32_t& out_count);
 
+        int32_t get_physical_device_cooperative_matrix_properties(uint64_t physical_device, void* out, size_t out_size, uint32_t max_count,
+                                                                  bool has_entries, uint32_t& out_count);
+        int32_t get_physical_device_fragment_shading_rates(uint64_t physical_device, void* out, size_t out_size, uint32_t max_count,
+                                                           bool has_entries, uint32_t& out_count);
+        int32_t get_physical_device_calibrateable_time_domains(uint64_t physical_device, std::span<uint32_t> out_domains,
+                                                               uint32_t max_count, bool has_entries, uint32_t& out_count);
+        int32_t get_calibrated_timestamps(uint64_t device, std::span<const uint32_t> time_domains, std::span<uint64_t> timestamps,
+                                          uint64_t& max_deviation);
+
         // Queries vkGetPhysicalDeviceFeatures2 for the pNext chain the guest described. in_records is a
         // packed array of `struct_count` feature_chain_record {sType, body_size} (guest-supplied,
         // pad-free body sizes). out_blob receives, in the same order, one record + body bytes per entry
@@ -155,6 +164,7 @@ namespace sogen
         // fresh object id, or 0 on failure.
         int32_t allocate_memory(uint64_t device, uint64_t size, uint32_t memory_type_index, uint64_t& out_memory);
         void free_memory(uint64_t device, uint64_t memory);
+        int32_t get_device_memory_commitment(uint64_t device, uint64_t memory, uint64_t& out_committed_bytes);
 
         int32_t create_buffer(uint64_t device, uint64_t size, uint32_t usage, uint64_t& out_buffer);
         void destroy_buffer(uint64_t device, uint64_t buffer);
@@ -394,12 +404,8 @@ namespace sogen
 
         // --- graphics pipeline (enough for a render-pass triangle) ---
 
-        int32_t create_shader_module(uint64_t device, uint32_t flags, const void* code, size_t code_size, uint64_t& out_module);
+        int32_t create_shader_module(uint64_t device, const void* code, size_t code_size, uint64_t& out_module);
         void destroy_shader_module(uint64_t device, uint64_t shader_module);
-        int32_t get_shader_module_identifier(uint64_t device, uint64_t shader_module, std::span<uint8_t> identifier,
-                                             uint32_t& identifier_size);
-        int32_t get_shader_module_create_info_identifier(uint64_t device, uint32_t flags, const void* code, size_t code_size,
-                                                         std::span<uint8_t> identifier, uint32_t& identifier_size);
 
         // aspect_mask selects COLOR vs DEPTH (0 defaults to COLOR).
         int32_t create_image_view(uint64_t device, uint64_t image, uint32_t format, uint32_t aspect_mask, uint32_t view_type,
@@ -419,6 +425,7 @@ namespace sogen
         int32_t cmd_begin_query(uint64_t command_buffer, uint64_t query_pool, uint32_t query, uint32_t flags);
         int32_t cmd_end_query(uint64_t command_buffer, uint64_t query_pool, uint32_t query);
         int32_t cmd_write_timestamp(uint64_t command_buffer, uint64_t query_pool, uint32_t query, uint32_t pipeline_stage);
+        int32_t cmd_write_timestamp2(uint64_t command_buffer, uint64_t query_pool, uint32_t query, uint64_t pipeline_stage);
         int32_t cmd_copy_query_pool_results(uint64_t command_buffer, uint64_t query_pool, uint32_t first_query, uint32_t query_count,
                                             uint64_t destination_buffer, uint64_t destination_offset, uint64_t stride, uint32_t flags);
 
@@ -547,26 +554,20 @@ namespace sogen
             std::span<const uint8_t> data;
         };
 
-        struct shader_stage_source
-        {
-            uint64_t module;
-            std::span<const uint8_t> identifier;
-        };
-
         // Triangle list, static full-extent viewport/scissor, one non-blended color attachment, optional
         // depth test. Empty vertex input (no bindings/attributes) leaves vertices to be baked into the shader.
         // When render_pass == 0 the pipeline is built for dynamic rendering (VK_KHR_dynamic_rendering) using
         // color_formats/depth_format/stencil_format, with viewport and scissor as dynamic state.
-        int32_t create_graphics_pipeline(uint64_t device, uint64_t render_pass, uint64_t pipeline_layout,
-                                         const shader_stage_source& vertex_shader, const shader_stage_source& fragment_shader,
-                                         uint32_t flags, uint32_t width, uint32_t height, std::span<const vertex_binding> bindings,
-                                         std::span<const vertex_attribute> attributes, std::span<const vertex_divisor> divisors,
-                                         const depth_state& depth, std::span<const uint32_t> color_formats, uint32_t depth_format,
-                                         uint32_t stencil_format, uint32_t rasterization_samples, uint32_t primitive_topology,
-                                         uint32_t primitive_restart_enable, std::span<const uint32_t> dynamic_states,
-                                         const specialization& vs_spec, const specialization& fs_spec,
-                                         std::span<const color_blend_attachment> blend_attachments, uint64_t& out_pipeline);
-        int32_t create_compute_pipeline(uint64_t device, uint64_t pipeline_layout, const shader_stage_source& shader, uint32_t flags,
+        int32_t create_graphics_pipeline(uint64_t device, uint64_t render_pass, uint64_t pipeline_layout, uint64_t vertex_shader,
+                                         uint64_t fragment_shader, uint32_t flags, uint32_t width, uint32_t height,
+                                         std::span<const vertex_binding> bindings, std::span<const vertex_attribute> attributes,
+                                         std::span<const vertex_divisor> divisors, const depth_state& depth,
+                                         std::span<const uint32_t> color_formats, uint32_t depth_format, uint32_t stencil_format,
+                                         uint32_t rasterization_samples, uint32_t primitive_topology, uint32_t primitive_restart_enable,
+                                         std::span<const uint32_t> dynamic_states, const specialization& vs_spec,
+                                         const specialization& fs_spec, std::span<const color_blend_attachment> blend_attachments,
+                                         uint64_t& out_pipeline);
+        int32_t create_compute_pipeline(uint64_t device, uint64_t pipeline_layout, uint64_t shader_module, uint32_t flags,
                                         uint64_t& out_pipeline);
         void destroy_pipeline(uint64_t device, uint64_t pipeline);
 

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -394,10 +394,12 @@ namespace sogen
 
         // --- graphics pipeline (enough for a render-pass triangle) ---
 
-        int32_t create_shader_module(uint64_t device, const void* code, size_t code_size, uint64_t& out_module);
+        int32_t create_shader_module(uint64_t device, uint32_t flags, const void* code, size_t code_size, uint64_t& out_module);
         void destroy_shader_module(uint64_t device, uint64_t shader_module);
         int32_t get_shader_module_identifier(uint64_t device, uint64_t shader_module, std::span<uint8_t> identifier,
                                              uint32_t& identifier_size);
+        int32_t get_shader_module_create_info_identifier(uint64_t device, uint32_t flags, const void* code, size_t code_size,
+                                                         std::span<uint8_t> identifier, uint32_t& identifier_size);
 
         // aspect_mask selects COLOR vs DEPTH (0 defaults to COLOR).
         int32_t create_image_view(uint64_t device, uint64_t image, uint32_t format, uint32_t aspect_mask, uint32_t view_type,
@@ -500,6 +502,12 @@ namespace sogen
             uint32_t offset;
         };
 
+        struct vertex_divisor
+        {
+            uint32_t binding;
+            uint32_t divisor;
+        };
+
         // Optional depth-stencil state for a pipeline (test_enable == 0 => none, as before).
         struct depth_state
         {
@@ -538,19 +546,27 @@ namespace sogen
             std::span<const uint8_t> data;
         };
 
+        struct shader_stage_source
+        {
+            uint64_t module;
+            std::span<const uint8_t> identifier;
+        };
+
         // Triangle list, static full-extent viewport/scissor, one non-blended color attachment, optional
         // depth test. Empty vertex input (no bindings/attributes) leaves vertices to be baked into the shader.
         // When render_pass == 0 the pipeline is built for dynamic rendering (VK_KHR_dynamic_rendering) using
         // color_formats/depth_format/stencil_format, with viewport and scissor as dynamic state.
-        int32_t create_graphics_pipeline(uint64_t device, uint64_t render_pass, uint64_t pipeline_layout, uint64_t vertex_shader,
-                                         uint64_t fragment_shader, uint32_t width, uint32_t height,
-                                         std::span<const vertex_binding> bindings, std::span<const vertex_attribute> attributes,
+        int32_t create_graphics_pipeline(uint64_t device, uint64_t render_pass, uint64_t pipeline_layout,
+                                         const shader_stage_source& vertex_shader, const shader_stage_source& fragment_shader,
+                                         uint32_t flags, uint32_t width, uint32_t height, std::span<const vertex_binding> bindings,
+                                         std::span<const vertex_attribute> attributes, std::span<const vertex_divisor> divisors,
                                          const depth_state& depth, std::span<const uint32_t> color_formats, uint32_t depth_format,
                                          uint32_t stencil_format, uint32_t rasterization_samples, uint32_t primitive_topology,
                                          uint32_t primitive_restart_enable, std::span<const uint32_t> dynamic_states,
                                          const specialization& vs_spec, const specialization& fs_spec,
                                          std::span<const color_blend_attachment> blend_attachments, uint64_t& out_pipeline);
-        int32_t create_compute_pipeline(uint64_t device, uint64_t pipeline_layout, uint64_t shader_module, uint64_t& out_pipeline);
+        int32_t create_compute_pipeline(uint64_t device, uint64_t pipeline_layout, const shader_stage_source& shader, uint32_t flags,
+                                        uint64_t& out_pipeline);
         void destroy_pipeline(uint64_t device, uint64_t pipeline);
 
         // clear_depth is used only when the render pass has a depth attachment.


### PR DESCRIPTION
This PR implements several extensions and entry points that were missing from the GPU bridge and are required for VKD3D to work.

Tested using the Mario 64 PC port with DirectX 12 through VKD3D:

<img width="1114" height="623" alt="image" src="https://github.com/user-attachments/assets/a7cea648-31c8-4e6c-bc5e-ac4ad69eb1fb" />

I also tested CoD MW3, and it still works and renders after this patch, so there was no DXVK regression.

**Disclaimer:** This PR was largely vibe-coded. I did multiple review passes with an LLM and made an effort to clean up the implementation, but I can’t confidently say I fully understand whether everything is as correct as it could be.