### PR TITLE
Load locale constants from register

### DIFF
--- a/src/windows-emulator/ports/api_port.cpp
+++ b/src/windows-emulator/ports/api_port.cpp
@@ -15,6 +15,22 @@ namespace sogen
                    static_cast<uint32_t>(server_dll_index) == win32k_userconnect::k_user_server_dll_index;
         }
 
+        constexpr uint32_t k_base_srv_nls_get_user_info_api = 0x0001001b;
+
+        bool is_nls_get_user_info_request(windows_emulator& win_emu, const lpc_request_context& c)
+        {
+            const ULONG api_number_offset = 0x08u;
+
+            if (c.send_buffer_length < api_number_offset + sizeof(uint32_t))
+            {
+                return false;
+            }
+
+            uint32_t api_number{};
+            return win_emu.memory.try_read_memory(c.send_buffer + api_number_offset, &api_number, sizeof(api_number)) &&
+                   api_number == k_base_srv_nls_get_user_info_api;
+        }
+
         struct wow64_userconnect_payload
         {
             uint64_t request_capture_handle{};
@@ -122,6 +138,16 @@ namespace sogen
 
             lpc_request_result handle_request(windows_emulator& win_emu, const lpc_request_context& c) override
             {
+                if (is_nls_get_user_info_request(win_emu, c))
+                {
+                    // BASESRV BaseSrvNlsGetUserInfo, called by kernelbase's GetCurrentNlsCache.
+                    // Sogen does not emulate the private 0x67c-byte NLS server cache. Returning
+                    // a failing status here intentionally selects GetCurrentNlsCache's native
+                    // registry-backed fallback (Control Panel\International / NlsUpdateCacheInfo)
+                    // instead of reporting success with an uninitialized capture buffer.
+                    return {STATUS_NOT_SUPPORTED, lpc_request_result::reply_in_place};
+                }
+
                 wow64_userconnect_payload payload{};
                 if (try_read_wow64_payload(win_emu, c, payload))
                 {

--- a/src/windows-emulator/syscalls/locale.cpp
+++ b/src/windows-emulator/syscalls/locale.cpp
@@ -1,14 +1,141 @@
 #include "../std_include.hpp"
 #include "../emulator_utils.hpp"
 #include "../syscall_utils.hpp"
+#include "../registry/registry_utils.hpp"
+
+#include <charconv>
 
 #include <utils/io.hpp>
+#include <utils/string.hpp>
 
 namespace sogen
 {
 
     namespace syscalls
     {
+        namespace
+        {
+            std::optional<uint32_t> parse_hex_identifier(std::u16string_view value)
+            {
+                while (!value.empty() && (value.front() == u' ' || value.front() == u'\t'))
+                {
+                    value.remove_prefix(1);
+                }
+                while (!value.empty() && (value.back() == u' ' || value.back() == u'\t'))
+                {
+                    value.remove_suffix(1);
+                }
+
+                if (value.starts_with(u"0x") || value.starts_with(u"0X"))
+                {
+                    value.remove_prefix(2);
+                }
+
+                if (value.empty())
+                {
+                    return std::nullopt;
+                }
+
+                const auto text = u16_to_u8(value);
+                uint32_t result{};
+                const auto [end, error] = std::from_chars(text.data(), text.data() + text.size(), result, 16);
+                if (error != std::errc{} || end != text.data() + text.size())
+                {
+                    return std::nullopt;
+                }
+
+                return result;
+            }
+
+            std::optional<uint32_t> read_hex_identifier(registry_manager& registry, const std::filesystem::path& key_path,
+                                                        const std::string_view value_name)
+            {
+                const auto value = registry_utils::read_registry_string(registry, key_path, value_name);
+                return value ? parse_hex_identifier(*value) : std::nullopt;
+            }
+
+            LCID get_system_locale_id(registry_manager& registry)
+            {
+                return read_hex_identifier(registry, R"(\Registry\Machine\System\CurrentControlSet\Control\Nls\Language)", "Default")
+                    .value_or(0x407);
+            }
+
+            LCID get_user_locale_id(registry_manager& registry)
+            {
+                return read_hex_identifier(registry, R"(\Registry\User\Control Panel\International)", "Locale")
+                    .value_or(get_system_locale_id(registry));
+            }
+
+            LANGID get_install_language_id(registry_manager& registry)
+            {
+                return static_cast<LANGID>(
+                    read_hex_identifier(registry, R"(\Registry\Machine\System\CurrentControlSet\Control\Nls\Language)", "InstallLanguage")
+                        .value_or(0x407));
+            }
+
+            std::vector<uint32_t> get_keyboard_layouts(registry_manager& registry)
+            {
+                std::vector<uint32_t> result{};
+                const auto key = registry.get_key(utils::path_key{R"(\Registry\User\Keyboard Layout\Preload)"});
+                if (key)
+                {
+                    for (size_t index = 1; index <= 64; ++index)
+                    {
+                        const auto value = registry_utils::read_registry_string(registry, *key, std::to_string(index));
+                        if (!value)
+                        {
+                            break;
+                        }
+
+                        if (value->size() != 8)
+                        {
+                            continue;
+                        }
+
+                        if (const auto identifier = parse_hex_identifier(*value))
+                        {
+                            result.push_back(*identifier);
+                        }
+                    }
+                }
+
+                if (result.empty())
+                {
+                    result.push_back(0x00000407);
+                }
+
+                return result;
+            }
+
+            uint64_t keyboard_layout_to_handle(const uint32_t identifier)
+            {
+                const auto language = static_cast<uint16_t>(identifier & 0xFFFF);
+
+                // Standard KLIDs have a zero high word. Windows represents those HKLs by
+                // repeating the language identifier in both words (for example,
+                // 00000416 -> 04160416). Preserve non-standard identifiers as-is until
+                // per-layout device handles are emulated.
+                if ((identifier & 0xFFFF0000) == 0)
+                {
+                    return (static_cast<uint64_t>(language) << 16) | language;
+                }
+
+                return identifier;
+            }
+
+            std::u16string keyboard_layout_to_name(const uint32_t identifier)
+            {
+                auto name = utils::string::to_hex_number(identifier, true);
+                name.insert(0, 8 - name.size(), '0');
+                return u8_to_u16(name);
+            }
+
+            uint64_t get_default_keyboard_layout(registry_manager& registry)
+            {
+                return keyboard_layout_to_handle(get_keyboard_layouts(registry).front());
+            }
+        }
+
         NTSTATUS handle_NtInitializeNlsFiles(const syscall_context& c, const emulator_object<uint64_t> base_address,
                                              const emulator_object<LCID> default_locale_id,
                                              const emulator_object<LARGE_INTEGER> /*default_casing_table_size*/)
@@ -24,15 +151,15 @@ namespace sogen
             c.emu.write_memory(base, locale_file.data(), locale_file.size());
 
             base_address.write(base);
-            default_locale_id.write(0x407);
+            default_locale_id.write(get_system_locale_id(c.win_emu.registry));
 
             return STATUS_SUCCESS;
         }
 
-        NTSTATUS handle_NtQueryDefaultLocale(const syscall_context&, BOOLEAN /*user_profile*/,
+        NTSTATUS handle_NtQueryDefaultLocale(const syscall_context& c, const BOOLEAN user_profile,
                                              const emulator_object<LCID> default_locale_id)
         {
-            default_locale_id.write(0x407);
+            default_locale_id.write(user_profile ? get_user_locale_id(c.win_emu.registry) : get_system_locale_id(c.win_emu.registry));
             return STATUS_SUCCESS;
         }
 
@@ -73,32 +200,43 @@ namespace sogen
             return STATUS_NOT_SUPPORTED;
         }
 
-        uint64_t handle_NtUserActivateKeyboardLayout(const syscall_context&, const uint64_t /*keyboard_layout*/, const uint32_t /*flags*/)
+        uint64_t handle_NtUserActivateKeyboardLayout(const syscall_context& c, const uint64_t keyboard_layout, const uint32_t /*flags*/)
         {
-            return 0x04070407;
+            return keyboard_layout == 0 ? get_default_keyboard_layout(c.win_emu.registry) : keyboard_layout;
         }
 
-        uint64_t handle_NtUserLoadKeyboardLayoutEx(const syscall_context&, const handle /*file*/, const uint32_t /*table_offset*/,
+        uint64_t handle_NtUserLoadKeyboardLayoutEx(const syscall_context& c, const handle /*file*/, const uint32_t /*table_offset*/,
                                                    const emulator_pointer /*tables*/, const uint64_t /*old_keyboard_layout*/,
-                                                   const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> /*keyboard_layout_id*/,
+                                                   const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> keyboard_layout_id,
                                                    const uint32_t /*new_keyboard_layout*/, const uint32_t /*flags*/)
         {
-            return 0x04070407;
+            if (keyboard_layout_id)
+            {
+                const auto requested_layout = read_unicode_string(c.emu, keyboard_layout_id);
+                if (requested_layout.size() == 8)
+                {
+                    if (const auto identifier = parse_hex_identifier(requested_layout))
+                    {
+                        return keyboard_layout_to_handle(*identifier);
+                    }
+                }
+            }
+
+            return get_default_keyboard_layout(c.win_emu.registry);
         }
 
-        uint64_t handle_NtUserGetKeyboardLayout(const syscall_context&, const uint32_t /*thread_id*/)
+        uint64_t handle_NtUserGetKeyboardLayout(const syscall_context& c, const uint32_t /*thread_id*/)
         {
-            return 0x04070407;
+            return get_default_keyboard_layout(c.win_emu.registry);
         }
 
         uint32_t handle_NtUserGetKeyboardLayoutList(const syscall_context& c, const uint32_t buffer_count,
                                                     const emulator_pointer keyboard_layouts)
         {
-            constexpr uint64_t keyboard_layout = 0x04070407;
-
+            const auto layouts = get_keyboard_layouts(c.win_emu.registry);
             if (buffer_count == 0)
             {
-                return 1;
+                return static_cast<uint32_t>(layouts.size());
             }
 
             if (keyboard_layouts == 0)
@@ -106,40 +244,38 @@ namespace sogen
                 return 0;
             }
 
-            if (c.proc.is_wow64_process)
+            const auto count = std::min<size_t>(buffer_count, layouts.size());
+            for (size_t i = 0; i < count; ++i)
             {
-                c.emu.write_memory(keyboard_layouts, static_cast<uint32_t>(keyboard_layout));
-            }
-            else
-            {
-                c.emu.write_memory(keyboard_layouts, keyboard_layout);
+                const auto keyboard_layout = keyboard_layout_to_handle(layouts[i]);
+                c.emu.write_memory(keyboard_layouts + i * sizeof(uint64_t), keyboard_layout);
             }
 
-            return 1;
+            return static_cast<uint32_t>(count);
         }
 
         BOOL handle_NtUserGetKeyboardLayoutName(const syscall_context& c, const emulator_pointer name)
         {
-            static const std::u16string keyboard_layout_name = u"00000407";
-
             if (name == 0)
             {
                 return FALSE;
             }
 
+            auto keyboard_layout_name = keyboard_layout_to_name(get_keyboard_layouts(c.win_emu.registry).front());
+            keyboard_layout_name.push_back(u'\0');
             c.emu.write_memory(name, keyboard_layout_name.data(), keyboard_layout_name.size() * sizeof(char16_t));
             return TRUE;
         }
 
-        NTSTATUS handle_NtQueryDefaultUILanguage(const syscall_context&, const emulator_object<LANGID> language_id)
+        NTSTATUS handle_NtQueryDefaultUILanguage(const syscall_context& c, const emulator_object<LANGID> language_id)
         {
-            language_id.write(0x407);
+            language_id.write(static_cast<LANGID>(get_user_locale_id(c.win_emu.registry)));
             return STATUS_SUCCESS;
         }
 
-        NTSTATUS handle_NtQueryInstallUILanguage(const syscall_context&, const emulator_object<LANGID> language_id)
+        NTSTATUS handle_NtQueryInstallUILanguage(const syscall_context& c, const emulator_object<LANGID> language_id)
         {
-            language_id.write(0x407);
+            language_id.write(get_install_language_id(c.win_emu.registry));
             return STATUS_SUCCESS;
         }
     }


### PR DESCRIPTION
This PR makes all hard-coded locale constants that were in `locale.cpp` load from the registry instead. It also fixes a gap in ApiPort that was causing `GetUserDefaultLocaleName` to return an empty string under WoW64.

This PR doesn't attempt to improve the actual accuracy of the locale syscall implementations, so it's expected that keyboard layouts still won't change, some value sources might not be 100% accurate to the syscall name, etc.