### PR TITLE
Add support for importing `.reg` files

### DIFF
--- a/src/windows-analyzer/main.cpp
+++ b/src/windows-analyzer/main.cpp
@@ -7,6 +7,7 @@
 #include <win_x86_64_gdb_stub_handler.hpp>
 #include <minidump_loader.hpp>
 #include <scoped_hook.hpp>
+#include <registry/registry_file.hpp>
 
 #include "object_watching.hpp"
 #include "snapshot.hpp"
@@ -72,6 +73,7 @@ namespace sogen
             bool disable_instruction_precision{false};
             uint32_t vcpu_count{1};
             std::filesystem::path registry_path{get_current_binary_dir() / "registry"};
+            std::vector<std::filesystem::path> registry_files{};
             std::filesystem::path emulation_root{};
             std::unordered_map<windows_path, std::filesystem::path> path_mappings{};
             utils::unordered_insensitive_u16string_map<std::u16string> environment{};
@@ -548,6 +550,14 @@ namespace sogen
             return std::make_unique<windows_emulator>(create_configured_backend(options), std::move(app_settings), settings);
         }
 
+        void apply_registry_files(windows_emulator& win_emu, const analysis_options& options)
+        {
+            for (const auto& file : options.registry_files)
+            {
+                import_registry_file(win_emu.registry, file);
+            }
+        }
+
         std::unique_ptr<windows_emulator> setup_emulator(const analysis_options& options, const std::span<const std::string_view> args)
         {
             if (!options.dump.empty())
@@ -605,6 +615,7 @@ namespace sogen
 
             const auto concise_logging = options.concise_logging;
             const auto win_emu = setup_emulator(options, args);
+            apply_registry_files(*win_emu, options);
             context.win_emu = win_emu.get();
 
             std::vector<std::unique_ptr<analysis_reporter>> reporters{};
@@ -902,6 +913,10 @@ namespace sogen
                 ->capture_default_str()
                 ->check(CLI::IsMember({"auto", "int3"}));
             app.add_option("-r,--registry", options.registry_path, "Set registry path");
+            app.add_option("--reg-file", options.registry_files, "Import registry values from a .reg file")
+                ->type_name("FILE")
+                ->expected(1)
+                ->allow_extra_args(false);
 
             app.add_option("--vcpus", options.vcpu_count, "Number of virtual CPUs (requires a backend with multi-vCPU support)")
                 ->capture_default_str();

--- a/src/windows-emulator-test/registry_file_test.cpp
+++ b/src/windows-emulator-test/registry_file_test.cpp
@@ -1,0 +1,276 @@
+#include <gtest/gtest.h>
+
+#include <registry/registry_file.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <fstream>
+
+namespace sogen::test
+{
+    namespace
+    {
+        constexpr size_t hive_data_offset = 0x1000;
+        constexpr size_t root_key_offset = hive_data_offset + 0x20;
+
+        void write_uint16(std::vector<std::byte>& data, const size_t offset, const uint16_t value)
+        {
+            data[offset] = static_cast<std::byte>(value & 0xFF);
+            data[offset + 1] = static_cast<std::byte>(value >> 8);
+        }
+
+        void write_uint32(std::vector<std::byte>& data, const size_t offset, const uint32_t value)
+        {
+            data[offset] = static_cast<std::byte>(value & 0xFF);
+            data[offset + 1] = static_cast<std::byte>((value >> 8) & 0xFF);
+            data[offset + 2] = static_cast<std::byte>((value >> 16) & 0xFF);
+            data[offset + 3] = static_cast<std::byte>((value >> 24) & 0xFF);
+        }
+
+        void write_key(std::vector<std::byte>& data, const size_t offset, const std::string_view name, const uint32_t subkey_list_offset)
+        {
+            write_uint32(data, offset + 32, subkey_list_offset);
+            write_uint16(data, offset + 76, static_cast<uint16_t>(name.size()));
+            for (size_t i = 0; i < name.size(); ++i)
+            {
+                data[offset + 80 + i] = static_cast<std::byte>(name[i]);
+            }
+        }
+
+        void write_subkey_list(std::vector<std::byte>& data, const uint32_t list_offset, const uint32_t key_offset)
+        {
+            const auto offset = hive_data_offset + list_offset;
+            data[offset + 4] = static_cast<std::byte>('l');
+            data[offset + 5] = static_cast<std::byte>('f');
+            write_uint16(data, offset + 6, 1);
+            write_uint32(data, offset + 8, key_offset);
+        }
+
+        std::vector<std::byte> create_software_hive()
+        {
+            std::vector<std::byte> data(hive_data_offset + 0x1200);
+            data[0] = static_cast<std::byte>('r');
+            data[1] = static_cast<std::byte>('e');
+            data[2] = static_cast<std::byte>('g');
+            data[3] = static_cast<std::byte>('f');
+
+            write_key(data, root_key_offset, {}, 0x200);
+            write_subkey_list(data, 0x200, 0x400);
+            write_key(data, hive_data_offset + 0x400, "Microsoft", 0x600);
+            write_subkey_list(data, 0x600, 0x800);
+            write_key(data, hive_data_offset + 0x800, "Windows NT", 0xA00);
+            write_subkey_list(data, 0xA00, 0xC00);
+            write_key(data, hive_data_offset + 0xC00, "CurrentVersion", 0xE00);
+            write_subkey_list(data, 0xE00, 0x1000);
+            write_key(data, hive_data_offset + 0x1000, "ProfileList", 0);
+            return data;
+        }
+
+        bool write_hive(const std::filesystem::path& path, const std::span<const std::byte> data)
+        {
+            std::ofstream file(path, std::ios::binary);
+            file.write(reinterpret_cast<const char*>(data.data()), static_cast<std::streamsize>(data.size()));
+            return file.good();
+        }
+
+        std::vector<std::byte> encode_utf8_with_bom(const std::string_view text)
+        {
+            std::vector<std::byte> result{std::byte{0xEF}, std::byte{0xBB}, std::byte{0xBF}};
+            result.reserve(result.size() + text.size());
+            for (const auto character : text)
+            {
+                result.push_back(static_cast<std::byte>(static_cast<uint8_t>(character)));
+            }
+            return result;
+        }
+
+        std::vector<std::byte> encode_utf16(const std::u16string_view text, const bool big_endian)
+        {
+            std::vector<std::byte> result{};
+            result.reserve(2 + text.size() * 2);
+            result.push_back(big_endian ? std::byte{0xFE} : std::byte{0xFF});
+            result.push_back(big_endian ? std::byte{0xFF} : std::byte{0xFE});
+            for (const auto character : text)
+            {
+                const auto low = static_cast<std::byte>(character & 0xFF);
+                const auto high = static_cast<std::byte>(character >> 8);
+                result.push_back(big_endian ? high : low);
+                result.push_back(big_endian ? low : high);
+            }
+            return result;
+        }
+
+        class RegistryFileTest : public testing::Test
+        {
+          protected:
+            void SetUp() override
+            {
+                static std::atomic_uint64_t counter{};
+                const auto timestamp = std::chrono::steady_clock::now().time_since_epoch().count();
+                directory_ = std::filesystem::temp_directory_path() /
+                             ("sogen-registry-file-test-" + std::to_string(timestamp) + "-" + std::to_string(counter++));
+                ASSERT_TRUE(std::filesystem::create_directories(directory_));
+
+                const std::array<std::byte, 4> empty_hive{
+                    static_cast<std::byte>('r'),
+                    static_cast<std::byte>('e'),
+                    static_cast<std::byte>('g'),
+                    static_cast<std::byte>('f'),
+                };
+                for (const auto* name : {"SYSTEM", "SECURITY", "SAM", "NTUSER.DAT"})
+                {
+                    ASSERT_TRUE(write_hive(directory_ / name, empty_hive));
+                }
+
+                const auto software_hive = create_software_hive();
+                ASSERT_TRUE(write_hive(directory_ / "SOFTWARE", software_hive));
+                registry_.emplace(directory_);
+            }
+
+            void TearDown() override
+            {
+                registry_.reset();
+                std::error_code error{};
+                std::filesystem::remove_all(directory_, error);
+            }
+
+            registry_manager& registry()
+            {
+                return *registry_;
+            }
+
+            registry_key get_key(const std::filesystem::path& path)
+            {
+                auto key = registry().get_key(utils::path_key{path});
+                EXPECT_TRUE(key.has_value());
+                return key.value_or(registry_key{});
+            }
+
+          private:
+            std::filesystem::path directory_{};
+            std::optional<registry_manager> registry_{};
+        };
+    }
+
+    TEST_F(RegistryFileTest, ImportsUtf8BomStringsEscapesAndDword)
+    {
+        const auto contents = encode_utf8_with_bom(R"(Windows Registry Editor Version 5.00
+
+[HKLM\Software\ParserCase]
+@="Default"
+"Quoted\"Name"="Line\nQuote:\" Slash:\\"
+"Number"=dword:1234abcd
+)");
+        import_registry_file_contents(registry(), contents, "utf8.reg");
+
+        const auto key = get_key(uR"(\Registry\Machine\Software\ParserCase)");
+        const auto default_value = registry().get_value(key, "");
+        ASSERT_TRUE(default_value.has_value());
+        EXPECT_EQ(default_value->as_string(), u"Default");
+
+        const auto escaped_value = registry().get_value(key, "Quoted\"Name");
+        ASSERT_TRUE(escaped_value.has_value());
+        EXPECT_EQ(escaped_value->as_string(), u"Line\nQuote:\" Slash:\\");
+
+        const auto number = registry().get_value(key, "Number");
+        ASSERT_TRUE(number.has_value());
+        EXPECT_EQ(number->as_dword(), 0x1234ABCDu);
+    }
+
+    TEST_F(RegistryFileTest, ImportsUtf16LittleAndBigEndian)
+    {
+        const auto little_endian = encode_utf16(uR"(Windows Registry Editor Version 5.00
+
+[HKCU\Endian\Little]
+"Text"="Endian"
+)",
+                                                false);
+        const auto big_endian = encode_utf16(uR"(Windows Registry Editor Version 5.00
+
+[HKCU\Endian\Big]
+"Text"="Endian"
+)",
+                                             true);
+
+        import_registry_file_contents(registry(), little_endian, "little.reg");
+        import_registry_file_contents(registry(), big_endian, "big.reg");
+
+        for (const auto* name : {u"Little", u"Big"})
+        {
+            const auto key = get_key(std::filesystem::path{uR"(\Registry\User\Endian)"} / name);
+            const auto value = registry().get_value(key, "Text");
+            ASSERT_TRUE(value.has_value());
+            EXPECT_EQ(value->as_string(), u"Endian");
+        }
+    }
+
+    TEST_F(RegistryFileTest, ImportsContinuedHexAndExplicitHexType)
+    {
+        const auto contents = encode_utf8_with_bom(R"(Windows Registry Editor Version 5.00
+
+[HKLM\Software\HexCase]
+"Binary"=hex:01,02,\
+  03,04,\
+  05
+"Multi"=hex(7):41,00,00,00
+)");
+        import_registry_file_contents(registry(), contents, "hex.reg");
+
+        const auto key = get_key(uR"(\Registry\Machine\Software\HexCase)");
+        const auto binary = registry().get_value(key, "Binary");
+        ASSERT_TRUE(binary.has_value());
+        EXPECT_EQ(binary->type, REG_BINARY);
+        EXPECT_EQ(std::vector(binary->data.begin(), binary->data.end()),
+                  (std::vector{std::byte{1}, std::byte{2}, std::byte{3}, std::byte{4}, std::byte{5}}));
+
+        const auto multi = registry().get_value(key, "Multi");
+        ASSERT_TRUE(multi.has_value());
+        EXPECT_EQ(multi->type, REG_MULTI_SZ);
+        EXPECT_EQ(std::vector(multi->data.begin(), multi->data.end()),
+                  (std::vector{std::byte{0x41}, std::byte{0}, std::byte{0}, std::byte{0}}));
+    }
+
+    TEST_F(RegistryFileTest, NormalizesRootAliasesAndPreservesKeyDisplayCase)
+    {
+        const auto contents = encode_utf8_with_bom(R"(Windows Registry Editor Version 5.00
+
+[HKLM\Software\AliasL]
+[HKCU\AliasC]
+[HKU\AliasU]
+[HKCR\CLSID\MiXeD"Key]
+[HKCC\ConfigCase]
+)");
+        import_registry_file_contents(registry(), contents, "aliases.reg");
+
+        EXPECT_TRUE(registry().get_key(utils::path_key{uR"(\Registry\Machine\Software\AliasL)"}).has_value());
+        EXPECT_TRUE(registry().get_key(utils::path_key{uR"(\Registry\User\AliasC)"}).has_value());
+        EXPECT_TRUE(registry().get_key(utils::path_key{uR"(\Registry\User\AliasU)"}).has_value());
+        EXPECT_TRUE(registry().get_key(utils::path_key{uR"(\Registry\Machine\Software\Classes\CLSID\MiXeD"Key)"}).has_value());
+        EXPECT_TRUE(registry()
+                        .get_key(utils::path_key{uR"(\Registry\Machine\System\ControlSet001\Hardware Profiles\Current\ConfigCase)"})
+                        .has_value());
+
+        const auto clsid = get_key(uR"(\Registry\Machine\Software\Classes\CLSID)");
+        ASSERT_EQ(registry().get_sub_key_count(clsid), 1u);
+        const auto display_name = registry().get_sub_key_name(clsid, 0);
+        ASSERT_TRUE(display_name.has_value());
+        EXPECT_EQ(*display_name, "MiXeD\"Key");
+    }
+
+    TEST_F(RegistryFileTest, RejectsMalformedQuotedStringsHexTypesAndUtf16)
+    {
+        const auto unterminated_string = encode_utf8_with_bom(R"(Windows Registry Editor Version 5.00
+[HKLM\Software\Bad]
+"Value"="unterminated
+)");
+        const auto unterminated_type = encode_utf8_with_bom(R"(Windows Registry Editor Version 5.00
+[HKLM\Software\Bad]
+"Value"=hex(7:00
+)");
+        const std::vector odd_utf16{std::byte{0xFF}, std::byte{0xFE}, std::byte{0}};
+
+        EXPECT_THROW(import_registry_file_contents(registry(), unterminated_string, "string.reg"), std::runtime_error);
+        EXPECT_THROW(import_registry_file_contents(registry(), unterminated_type, "type.reg"), std::runtime_error);
+        EXPECT_THROW(import_registry_file_contents(registry(), odd_utf16, "utf16.reg"), std::runtime_error);
+    }
+} // namespace sogen::test

--- a/src/windows-emulator/registry/registry_file.cpp
+++ b/src/windows-emulator/registry/registry_file.cpp
@@ -1,0 +1,554 @@
+#include "../std_include.hpp"
+#include "registry_file.hpp"
+
+#include <charconv>
+
+#include <utils/io.hpp>
+#include <utils/string.hpp>
+
+namespace sogen
+{
+    namespace
+    {
+        struct parsed_registry_value
+        {
+            std::string name{};
+            uint32_t type{};
+            std::vector<std::byte> data{};
+        };
+
+        struct parsed_registry_key
+        {
+            utils::path_key path{};
+            size_t line{};
+            std::vector<parsed_registry_value> values{};
+        };
+
+        std::u16string_view trim_left(std::u16string_view value)
+        {
+            while (!value.empty() && (value.front() == u' ' || value.front() == u'\t'))
+            {
+                value.remove_prefix(1);
+            }
+
+            return value;
+        }
+
+        std::u16string_view trim_right(std::u16string_view value)
+        {
+            while (!value.empty() && (value.back() == u' ' || value.back() == u'\t'))
+            {
+                value.remove_suffix(1);
+            }
+
+            return value;
+        }
+
+        std::u16string_view trim(std::u16string_view value)
+        {
+            return trim_right(trim_left(value));
+        }
+
+        std::runtime_error parse_error(const std::string_view source_name, const size_t line, const std::string_view message)
+        {
+            return std::runtime_error(std::string{source_name} + ":" + std::to_string(line) + ": " + std::string{message});
+        }
+
+        std::u16string decode_registry_text(const std::span<const std::byte> contents, const std::string_view source_name)
+        {
+            const auto byte = [&](const size_t index) { return std::to_integer<uint8_t>(contents[index]); };
+
+            if (contents.size() >= 2 && byte(0) == 0xFF && byte(1) == 0xFE)
+            {
+                if ((contents.size() - 2) % 2 != 0)
+                {
+                    throw std::runtime_error(std::string{source_name} + ": invalid UTF-16 registry file length");
+                }
+
+                std::u16string result{};
+                result.reserve((contents.size() - 2) / 2);
+                for (size_t i = 2; i + 1 < contents.size(); i += 2)
+                {
+                    result.push_back(static_cast<char16_t>(byte(i) | (static_cast<uint16_t>(byte(i + 1)) << 8)));
+                }
+                return result;
+            }
+
+            if (contents.size() >= 2 && byte(0) == 0xFE && byte(1) == 0xFF)
+            {
+                if ((contents.size() - 2) % 2 != 0)
+                {
+                    throw std::runtime_error(std::string{source_name} + ": invalid UTF-16 registry file length");
+                }
+
+                std::u16string result{};
+                result.reserve((contents.size() - 2) / 2);
+                for (size_t i = 2; i + 1 < contents.size(); i += 2)
+                {
+                    result.push_back(static_cast<char16_t>((static_cast<uint16_t>(byte(i)) << 8) | byte(i + 1)));
+                }
+                return result;
+            }
+
+            size_t offset = 0;
+            if (contents.size() >= 3 && byte(0) == 0xEF && byte(1) == 0xBB && byte(2) == 0xBF)
+            {
+                offset = 3;
+            }
+
+            if (offset == contents.size())
+            {
+                return {};
+            }
+
+            const auto* data = reinterpret_cast<const char*>(contents.data() + offset);
+            return u8_to_u16(std::string_view{data, contents.size() - offset});
+        }
+
+        std::optional<size_t> find_assignment_separator(const std::u16string_view line)
+        {
+            bool quoted = false;
+            bool escaped = false;
+
+            for (size_t i = 0; i < line.size(); ++i)
+            {
+                const auto character = line[i];
+                if (escaped)
+                {
+                    escaped = false;
+                    continue;
+                }
+
+                if (quoted && character == u'\\')
+                {
+                    escaped = true;
+                    continue;
+                }
+
+                if (character == u'"')
+                {
+                    quoted = !quoted;
+                    continue;
+                }
+
+                if (!quoted && character == u'=')
+                {
+                    return i;
+                }
+            }
+
+            return std::nullopt;
+        }
+
+        std::vector<std::pair<size_t, std::u16string>> build_logical_lines(const std::u16string_view text)
+        {
+            std::vector<std::pair<size_t, std::u16string>> lines{};
+            size_t line_number = 1;
+            size_t start = 0;
+
+            while (start <= text.size())
+            {
+                const auto end = text.find_first_of(u"\r\n", start);
+                const auto line_end = end == std::u16string_view::npos ? text.size() : end;
+                auto line = std::u16string{text.substr(start, line_end - start)};
+
+                if (!lines.empty())
+                {
+                    auto previous = trim_right(lines.back().second);
+                    const auto equals = find_assignment_separator(previous);
+                    const auto value = equals ? trim_left(previous.substr(*equals + 1)) : std::u16string_view{};
+                    const auto is_hex_continuation = previous.ends_with(u'\\') && utils::string::starts_with_ignore_case(value, u"hex"sv);
+                    if (is_hex_continuation)
+                    {
+                        lines.back().second.resize(previous.size() - 1);
+                        const auto continuation = trim_left(line);
+                        lines.back().second.append(continuation.begin(), continuation.end());
+                    }
+                    else
+                    {
+                        lines.emplace_back(line_number, std::move(line));
+                    }
+                }
+                else
+                {
+                    lines.emplace_back(line_number, std::move(line));
+                }
+
+                if (end == std::u16string_view::npos)
+                {
+                    break;
+                }
+
+                start = end + 1;
+                if (text[end] == u'\r' && start < text.size() && text[start] == u'\n')
+                {
+                    ++start;
+                }
+                ++line_number;
+            }
+
+            return lines;
+        }
+
+        std::u16string parse_quoted_string(std::u16string_view& input, const std::string_view source_name, const size_t line)
+        {
+            input = trim_left(input);
+            if (input.empty() || input.front() != u'"')
+            {
+                throw parse_error(source_name, line, "expected a quoted string");
+            }
+
+            input.remove_prefix(1);
+            std::u16string result{};
+            while (!input.empty())
+            {
+                const auto current = input.front();
+                input.remove_prefix(1);
+
+                if (current == u'"')
+                {
+                    return result;
+                }
+
+                if (current != u'\\')
+                {
+                    result.push_back(current);
+                    continue;
+                }
+
+                if (input.empty())
+                {
+                    throw parse_error(source_name, line, "unterminated escape sequence");
+                }
+
+                const auto escaped = input.front();
+                input.remove_prefix(1);
+                switch (escaped)
+                {
+                case u'\\':
+                case u'"':
+                    result.push_back(escaped);
+                    break;
+                case u'n':
+                    result.push_back(u'\n');
+                    break;
+                case u'r':
+                    result.push_back(u'\r');
+                    break;
+                default:
+                    result.push_back(u'\\');
+                    result.push_back(escaped);
+                    break;
+                }
+            }
+
+            throw parse_error(source_name, line, "unterminated quoted string");
+        }
+
+        uint32_t parse_hex_number(const std::u16string_view value, const std::string_view source_name, const size_t line)
+        {
+            if (value.empty())
+            {
+                throw parse_error(source_name, line, "missing hexadecimal value");
+            }
+
+            const auto text = u16_to_u8(value);
+            uint32_t result{};
+            const auto [end, error] = std::from_chars(text.data(), text.data() + text.size(), result, 16);
+            if (error == std::errc::result_out_of_range)
+            {
+                throw parse_error(source_name, line, "hexadecimal value is too large");
+            }
+            if (error != std::errc{} || end != text.data() + text.size())
+            {
+                throw parse_error(source_name, line, "invalid hexadecimal digit");
+            }
+
+            return result;
+        }
+
+        uint8_t parse_hex_byte(const std::u16string_view value, const std::string_view source_name, const size_t line)
+        {
+            if (value.size() != 2)
+            {
+                throw parse_error(source_name, line, "hex byte must contain exactly two digits");
+            }
+
+            return static_cast<uint8_t>(parse_hex_number(value, source_name, line));
+        }
+
+        std::vector<std::byte> encode_registry_string(const std::u16string_view value)
+        {
+            std::vector<std::byte> data{};
+            data.reserve((value.size() + 1) * 2);
+            for (const auto character : value)
+            {
+                data.push_back(static_cast<std::byte>(character & 0xFF));
+                data.push_back(static_cast<std::byte>((character >> 8) & 0xFF));
+            }
+            data.push_back(std::byte{0});
+            data.push_back(std::byte{0});
+            return data;
+        }
+
+        parsed_registry_value parse_registry_value(std::u16string_view line_text, const std::string_view source_name, const size_t line)
+        {
+            parsed_registry_value result{};
+            line_text = trim(line_text);
+
+            if (line_text.front() == u'@')
+            {
+                line_text.remove_prefix(1);
+            }
+            else
+            {
+                auto name = parse_quoted_string(line_text, source_name, line);
+                result.name = u16_to_u8(name);
+            }
+
+            line_text = trim_left(line_text);
+            if (line_text.empty() || line_text.front() != u'=')
+            {
+                throw parse_error(source_name, line, "expected '=' after registry value name");
+            }
+            line_text = trim(line_text.substr(1));
+
+            if (line_text == u"-")
+            {
+                throw parse_error(source_name, line, "deleting registry values is not supported");
+            }
+
+            if (!line_text.empty() && line_text.front() == u'"')
+            {
+                const auto string_value = parse_quoted_string(line_text, source_name, line);
+                if (!trim(line_text).empty())
+                {
+                    throw parse_error(source_name, line, "unexpected characters after string value");
+                }
+
+                result.type = REG_SZ;
+                result.data = encode_registry_string(string_value);
+                return result;
+            }
+
+            if (utils::string::starts_with_ignore_case(line_text, u"dword:"sv))
+            {
+                const auto number = parse_hex_number(trim(line_text.substr(6)), source_name, line);
+                result.type = REG_DWORD;
+                result.data = {
+                    static_cast<std::byte>(number & 0xFF),
+                    static_cast<std::byte>((number >> 8) & 0xFF),
+                    static_cast<std::byte>((number >> 16) & 0xFF),
+                    static_cast<std::byte>((number >> 24) & 0xFF),
+                };
+                return result;
+            }
+
+            if (!utils::string::starts_with_ignore_case(line_text, u"hex"sv))
+            {
+                throw parse_error(source_name, line, "unsupported registry value syntax");
+            }
+
+            line_text.remove_prefix(3);
+            result.type = REG_BINARY;
+            if (!line_text.empty() && line_text.front() == u'(')
+            {
+                const auto close = line_text.find(u')');
+                if (close == std::u16string_view::npos)
+                {
+                    throw parse_error(source_name, line, "unterminated registry type");
+                }
+                result.type = parse_hex_number(line_text.substr(1, close - 1), source_name, line);
+                line_text.remove_prefix(close + 1);
+            }
+
+            line_text = trim_left(line_text);
+            if (line_text.empty() || line_text.front() != u':')
+            {
+                throw parse_error(source_name, line, "expected ':' before hexadecimal data");
+            }
+            line_text = trim(line_text.substr(1));
+
+            while (!line_text.empty())
+            {
+                const auto comma = line_text.find(u',');
+                const auto token = trim(line_text.substr(0, comma));
+                if (token.empty())
+                {
+                    throw parse_error(source_name, line, "empty hexadecimal byte");
+                }
+                result.data.push_back(static_cast<std::byte>(parse_hex_byte(token, source_name, line)));
+
+                if (comma == std::u16string_view::npos)
+                {
+                    break;
+                }
+                line_text = trim(line_text.substr(comma + 1));
+            }
+
+            return result;
+        }
+
+        std::u16string to_nt_registry_path(std::u16string_view path, const std::string_view source_name, const size_t line)
+        {
+            path = trim(path);
+            if (path.empty())
+            {
+                throw parse_error(source_name, line, "empty registry path");
+            }
+
+            std::u16string normalized{path};
+            std::ranges::replace(normalized, u'/', u'\\');
+            while (normalized.size() > 1 && normalized.back() == u'\\')
+            {
+                normalized.pop_back();
+            }
+
+            if (utils::string::starts_with_ignore_case(std::u16string_view{normalized}, u"\\Registry\\"sv))
+            {
+                return normalized;
+            }
+
+            const auto separator = normalized.find(u'\\');
+            const auto root = std::u16string_view{normalized}.substr(0, separator);
+            const auto suffix =
+                separator == std::u16string::npos ? std::u16string_view{} : std::u16string_view{normalized}.substr(separator);
+
+            std::u16string nt_root{};
+            if (utils::string::equals_ignore_case(root, u"HKEY_LOCAL_MACHINE"sv) || utils::string::equals_ignore_case(root, u"HKLM"sv))
+            {
+                nt_root = u"\\Registry\\Machine";
+            }
+            else if (utils::string::equals_ignore_case(root, u"HKEY_CURRENT_USER"sv) ||
+                     utils::string::equals_ignore_case(root, u"HKCU"sv) || utils::string::equals_ignore_case(root, u"HKEY_USERS"sv) ||
+                     utils::string::equals_ignore_case(root, u"HKU"sv))
+            {
+                nt_root = u"\\Registry\\User";
+            }
+            else if (utils::string::equals_ignore_case(root, u"HKEY_CLASSES_ROOT"sv) || utils::string::equals_ignore_case(root, u"HKCR"sv))
+            {
+                nt_root = u"\\Registry\\Machine\\Software\\Classes";
+            }
+            else if (utils::string::equals_ignore_case(root, u"HKEY_CURRENT_CONFIG"sv) ||
+                     utils::string::equals_ignore_case(root, u"HKCC"sv))
+            {
+                nt_root = u"\\Registry\\Machine\\System\\CurrentControlSet\\Hardware Profiles\\Current";
+            }
+            else
+            {
+                throw parse_error(source_name, line, "unsupported registry root");
+            }
+
+            nt_root.append(suffix.begin(), suffix.end());
+            return nt_root;
+        }
+
+        utils::path_key parse_registry_key_path(const std::u16string_view path, const std::string_view source_name, const size_t line)
+        {
+            const auto nt_path = to_nt_registry_path(path, source_name, line);
+            return utils::path_key{std::filesystem::path{std::u16string{nt_path}}};
+        }
+
+        std::vector<parsed_registry_key> parse_registry_file(const std::span<const std::byte> contents, const std::string_view source_name)
+        {
+            const auto text = decode_registry_text(contents, source_name);
+            const auto lines = build_logical_lines(text);
+
+            bool header_seen = false;
+            parsed_registry_key* current_key = nullptr;
+            std::vector<parsed_registry_key> keys{};
+
+            for (const auto& [line_number, storage] : lines)
+            {
+                auto line = trim(storage);
+                if (line.empty() || line.front() == u';' || line.front() == u'#')
+                {
+                    continue;
+                }
+
+                if (!header_seen)
+                {
+                    if (!utils::string::equals_ignore_case(line, u"Windows Registry Editor Version 5.00"sv))
+                    {
+                        throw parse_error(source_name, line_number, "missing or unsupported .reg file header");
+                    }
+                    header_seen = true;
+                    continue;
+                }
+
+                if (line.front() == u'[')
+                {
+                    if (line.back() != u']')
+                    {
+                        throw parse_error(source_name, line_number, "unterminated registry key section");
+                    }
+
+                    auto path = trim(line.substr(1, line.size() - 2));
+                    if (!path.empty() && path.front() == u'-')
+                    {
+                        throw parse_error(source_name, line_number, "deleting registry keys is not supported");
+                    }
+
+                    keys.push_back({
+                        .path = parse_registry_key_path(path, source_name, line_number),
+                        .line = line_number,
+                    });
+                    current_key = &keys.back();
+                    continue;
+                }
+
+                if (!current_key)
+                {
+                    throw parse_error(source_name, line_number, "registry value appears before a key section");
+                }
+
+                current_key->values.push_back(parse_registry_value(line, source_name, line_number));
+            }
+
+            if (!header_seen)
+            {
+                throw std::runtime_error(std::string{source_name} + ": missing or unsupported .reg file header");
+            }
+
+            return keys;
+        }
+    }
+
+    void import_registry_file_contents(registry_manager& registry, const std::span<const std::byte> contents,
+                                       const std::string_view source_name)
+    {
+        auto keys = parse_registry_file(contents, source_name);
+        for (const auto& key : keys)
+        {
+            if (!registry.can_create_key(key.path))
+            {
+                throw parse_error(source_name, key.line, "registry path does not belong to a loaded hive");
+            }
+        }
+
+        for (auto& key : keys)
+        {
+            auto registry_key = registry.create_key(key.path);
+            if (!registry_key)
+            {
+                throw parse_error(source_name, key.line, "registry path does not belong to a loaded hive");
+            }
+
+            for (auto& value : key.values)
+            {
+                registry.set_value(*registry_key, std::move(value.name), value.type, value.data);
+            }
+        }
+    }
+
+    void import_registry_file(registry_manager& registry, const std::filesystem::path& file)
+    {
+        std::vector<std::byte> contents{};
+        if (!utils::io::read_file(file, &contents))
+        {
+            throw std::runtime_error("Failed to read registry file: " + file.string());
+        }
+
+        import_registry_file_contents(registry, contents, file.string());
+    }
+}

--- a/src/windows-emulator/registry/registry_file.cpp
+++ b/src/windows-emulator/registry/registry_file.cpp
@@ -19,7 +19,7 @@ namespace sogen
 
         struct parsed_registry_key
         {
-            utils::path_key path{};
+            std::filesystem::path path{};
             size_t line{};
             std::vector<parsed_registry_value> values{};
         };
@@ -443,10 +443,9 @@ namespace sogen
             return nt_root;
         }
 
-        utils::path_key parse_registry_key_path(const std::u16string_view path, const std::string_view source_name, const size_t line)
+        std::filesystem::path parse_registry_key_path(const std::u16string_view path, const std::string_view source_name, const size_t line)
         {
-            const auto nt_path = to_nt_registry_path(path, source_name, line);
-            return utils::path_key{std::filesystem::path{std::u16string{nt_path}}};
+            return std::filesystem::path{to_nt_registry_path(path, source_name, line)};
         }
 
         std::vector<parsed_registry_key> parse_registry_file(const std::span<const std::byte> contents, const std::string_view source_name)

--- a/src/windows-emulator/registry/registry_file.hpp
+++ b/src/windows-emulator/registry/registry_file.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "registry_manager.hpp"
+
+namespace sogen
+{
+    void import_registry_file(registry_manager& registry, const std::filesystem::path& file);
+    void import_registry_file_contents(registry_manager& registry, std::span<const std::byte> contents,
+                                       std::string_view source_name = "<memory>");
+}

--- a/src/windows-emulator/registry/registry_manager.cpp
+++ b/src/windows-emulator/registry/registry_manager.cpp
@@ -314,9 +314,9 @@ namespace sogen
         return {std::move(reg_key)};
     }
 
-    std::optional<registry_key> registry_manager::create_key(const utils::path_key& key)
+    std::optional<registry_key> registry_manager::create_key(const std::filesystem::path& key)
     {
-        const auto normal_key = this->normalize_path(key);
+        const auto normal_key = this->normalize_path(utils::path_key{key});
         const auto iterator = this->find_hive(normal_key);
         if (iterator == this->hives_.end())
         {
@@ -332,19 +332,48 @@ namespace sogen
         reg_key.hive = iterator->first.get();
         reg_key.path = normal_key.get().lexically_relative(reg_key.hive.get());
 
+        auto display_path_string = key.u16string();
+        std::ranges::replace(display_path_string, u'\\', u'/');
+        const auto display_path = std::filesystem::path{display_path_string}.lexically_normal();
+
+        std::vector<std::filesystem::path> display_components{};
+        for (const auto& component : display_path)
+        {
+            if (!component.empty() && component != display_path.root_directory())
+            {
+                display_components.push_back(component);
+            }
+        }
+
+        const auto component_count = static_cast<size_t>(std::ranges::distance(reg_key.path.get()));
+        const auto display_offset = display_components.size() >= component_count ? display_components.size() - component_count : 0;
+
         auto current_path = reg_key.hive.get();
+        size_t component_index = 0;
         for (const auto& component : reg_key.path.get())
         {
+            const auto parent_path = current_path;
             current_path /= component;
-            this->overlay_values_.try_emplace(utils::path_key{current_path});
+
+            const auto display_component_index = display_offset + component_index;
+            const auto& display_component =
+                display_component_index < display_components.size() ? display_components[display_component_index] : component;
+            const utils::path_key current_key{current_path};
+            if (!this->get_key(current_key))
+            {
+                auto& parent_bucket = this->overlay_values_[utils::path_key{parent_path}];
+                parent_bucket.sub_keys.try_emplace(u16_to_u8(display_component.u16string()), true);
+                this->overlay_values_.try_emplace(current_key);
+            }
+            ++component_index;
         }
 
         return {std::move(reg_key)};
     }
 
-    bool registry_manager::can_create_key(const utils::path_key& key) const
+    bool registry_manager::can_create_key(const std::filesystem::path& key) const
     {
-        const auto normal_key = this->normalize_path(key);
+        const auto normal_key = this->normalize_path(utils::path_key{key});
         return this->find_hive(normal_key) != this->hives_.end();
     }
 
@@ -386,24 +415,82 @@ namespace sogen
 
     std::optional<registry_value> registry_manager::get_value(const registry_key& key, const size_t index)
     {
-        const auto iterator = this->hives_.find(key.hive);
-        if (iterator == this->hives_.end())
+        hive_key* backing_key = nullptr;
+        std::ifstream* hive_file = nullptr;
+        size_t backing_count = 0;
+        if (const auto iterator = this->hives_.find(key.hive); iterator != this->hives_.end())
+        {
+            backing_key = iterator->second->get_sub_key(key.path.get());
+            hive_file = &iterator->second->get_file();
+            if (backing_key)
+            {
+                backing_count = backing_key->get_value_count(*hive_file);
+                if (index < backing_count)
+                {
+                    const auto* entry = backing_key->get_value(*hive_file, index);
+                    return entry ? this->get_value(key, entry->name) : std::nullopt;
+                }
+            }
+        }
+
+        const auto overlay_entry = this->overlay_values_.find(registry_manager::get_full_key_path(key));
+        if (overlay_entry == this->overlay_values_.end())
         {
             return std::nullopt;
         }
 
-        const auto* entry = iterator->second->get_value(key.path.get(), index);
-        if (!entry)
+        auto overlay_index = index - backing_count;
+        for (const auto& [name, value] : overlay_entry->second.values)
         {
-            return std::nullopt;
+            if (backing_key && backing_key->get_value(*hive_file, name))
+            {
+                continue;
+            }
+
+            if (overlay_index == 0)
+            {
+                return registry_value{
+                    .type = value.type,
+                    .name = name,
+                    .data = value.data,
+                };
+            }
+            --overlay_index;
         }
 
-        registry_value v{};
-        v.type = entry->type;
-        v.name = entry->name;
-        v.data = entry->data;
+        return std::nullopt;
+    }
 
-        return v;
+    size_t registry_manager::get_value_count(const registry_key& key)
+    {
+        hive_key* backing_key = nullptr;
+        std::ifstream* hive_file = nullptr;
+        size_t result = 0;
+        if (const auto iterator = this->hives_.find(key.hive); iterator != this->hives_.end())
+        {
+            backing_key = iterator->second->get_sub_key(key.path.get());
+            hive_file = &iterator->second->get_file();
+            if (backing_key)
+            {
+                result = backing_key->get_value_count(*hive_file);
+            }
+        }
+
+        const auto overlay_entry = this->overlay_values_.find(registry_manager::get_full_key_path(key));
+        if (overlay_entry == this->overlay_values_.end())
+        {
+            return result;
+        }
+
+        for (const auto& [name, _] : overlay_entry->second.values)
+        {
+            if (!backing_key || !backing_key->get_value(*hive_file, name))
+            {
+                ++result;
+            }
+        }
+
+        return result;
     }
 
     void registry_manager::set_value(const registry_key& key, std::string name, const uint32_t type, const std::span<const std::byte> data)
@@ -472,19 +559,81 @@ namespace sogen
 
     std::optional<std::string_view> registry_manager::get_sub_key_name(const registry_key& key, const size_t index)
     {
-        const auto iterator = this->hives_.find(key.hive);
-        if (iterator == this->hives_.end())
+        hive_key* backing_key = nullptr;
+        std::ifstream* hive_file = nullptr;
+        size_t backing_count = 0;
+        if (const auto iterator = this->hives_.find(key.hive); iterator != this->hives_.end())
+        {
+            backing_key = iterator->second->get_sub_key(key.path.get());
+            hive_file = &iterator->second->get_file();
+            if (backing_key)
+            {
+                backing_count = backing_key->get_sub_key_count(*hive_file);
+                if (index < backing_count)
+                {
+                    if (const auto* name = backing_key->get_sub_key_name(*hive_file, index))
+                    {
+                        return *name;
+                    }
+                    return std::nullopt;
+                }
+            }
+        }
+
+        const auto overlay_entry = this->overlay_values_.find(registry_manager::get_full_key_path(key));
+        if (overlay_entry == this->overlay_values_.end())
         {
             return std::nullopt;
         }
 
-        const auto* name = iterator->second->get_sub_key_name(key.path.get(), index);
-        if (!name)
+        auto overlay_index = index - backing_count;
+        for (const auto& [name, _] : overlay_entry->second.sub_keys)
         {
-            return std::nullopt;
+            if (backing_key && backing_key->get_sub_key(*hive_file, name))
+            {
+                continue;
+            }
+
+            if (overlay_index == 0)
+            {
+                return name;
+            }
+            --overlay_index;
         }
 
-        return *name;
+        return std::nullopt;
+    }
+
+    size_t registry_manager::get_sub_key_count(const registry_key& key)
+    {
+        hive_key* backing_key = nullptr;
+        std::ifstream* hive_file = nullptr;
+        size_t result = 0;
+        if (const auto iterator = this->hives_.find(key.hive); iterator != this->hives_.end())
+        {
+            backing_key = iterator->second->get_sub_key(key.path.get());
+            hive_file = &iterator->second->get_file();
+            if (backing_key)
+            {
+                result = backing_key->get_sub_key_count(*hive_file);
+            }
+        }
+
+        const auto overlay_entry = this->overlay_values_.find(registry_manager::get_full_key_path(key));
+        if (overlay_entry == this->overlay_values_.end())
+        {
+            return result;
+        }
+
+        for (const auto& [name, _] : overlay_entry->second.sub_keys)
+        {
+            if (!backing_key || !backing_key->get_sub_key(*hive_file, name))
+            {
+                ++result;
+            }
+        }
+
+        return result;
     }
 
     std::optional<std::u16string> registry_manager::read_u16string(const registry_key& key, size_t index)

--- a/src/windows-emulator/registry/registry_manager.cpp
+++ b/src/windows-emulator/registry/registry_manager.cpp
@@ -345,8 +345,15 @@ namespace sogen
             }
         }
 
+        const auto normalized_component_count = static_cast<size_t>(std::ranges::count_if(
+            normal_key.get(), [&](const auto& component) { return !component.empty() && component != normal_key.get().root_directory(); }));
+        if (display_components.size() != normalized_component_count)
+        {
+            throw std::logic_error("Registry path normalization changed the component count");
+        }
+
         const auto component_count = static_cast<size_t>(std::ranges::distance(reg_key.path.get()));
-        const auto display_offset = display_components.size() >= component_count ? display_components.size() - component_count : 0;
+        const auto display_offset = display_components.size() - component_count;
 
         auto current_path = reg_key.hive.get();
         size_t component_index = 0;
@@ -356,8 +363,7 @@ namespace sogen
             current_path /= component;
 
             const auto display_component_index = display_offset + component_index;
-            const auto& display_component =
-                display_component_index < display_components.size() ? display_components[display_component_index] : component;
+            const auto& display_component = display_components[display_component_index];
             const utils::path_key current_key{current_path};
             if (!this->get_key(current_key))
             {

--- a/src/windows-emulator/registry/registry_manager.cpp
+++ b/src/windows-emulator/registry/registry_manager.cpp
@@ -298,6 +298,11 @@ namespace sogen
             return {std::move(reg_key)};
         }
 
+        if (this->overlay_values_.contains(normal_key))
+        {
+            return {std::move(reg_key)};
+        }
+
         auto path = reg_key.path.get();
         const auto* entry = iterator->second->get_sub_key(path);
 
@@ -307,6 +312,40 @@ namespace sogen
         }
 
         return {std::move(reg_key)};
+    }
+
+    std::optional<registry_key> registry_manager::create_key(const utils::path_key& key)
+    {
+        const auto normal_key = this->normalize_path(key);
+        const auto iterator = this->find_hive(normal_key);
+        if (iterator == this->hives_.end())
+        {
+            return std::nullopt;
+        }
+
+        if (auto existing = this->get_key(normal_key))
+        {
+            return existing;
+        }
+
+        registry_key reg_key{};
+        reg_key.hive = iterator->first.get();
+        reg_key.path = normal_key.get().lexically_relative(reg_key.hive.get());
+
+        auto current_path = reg_key.hive.get();
+        for (const auto& component : reg_key.path.get())
+        {
+            current_path /= component;
+            this->overlay_values_.try_emplace(utils::path_key{current_path});
+        }
+
+        return {std::move(reg_key)};
+    }
+
+    bool registry_manager::can_create_key(const utils::path_key& key) const
+    {
+        const auto normal_key = this->normalize_path(key);
+        return this->find_hive(normal_key) != this->hives_.end();
     }
 
     std::optional<registry_value> registry_manager::get_value(const registry_key& key, const std::string_view name)
@@ -386,6 +425,19 @@ namespace sogen
     }
 
     registry_manager::hive_map::iterator registry_manager::find_hive(const utils::path_key& key)
+    {
+        for (auto i = this->hives_.begin(); i != this->hives_.end(); ++i)
+        {
+            if (is_subpath(i->first, key))
+            {
+                return i;
+            }
+        }
+
+        return this->hives_.end();
+    }
+
+    registry_manager::hive_map::const_iterator registry_manager::find_hive(const utils::path_key& key) const
     {
         for (auto i = this->hives_.begin(); i != this->hives_.end(); ++i)
         {

--- a/src/windows-emulator/registry/registry_manager.hpp
+++ b/src/windows-emulator/registry/registry_manager.hpp
@@ -118,6 +118,8 @@ namespace sogen
         registry_manager& operator=(const registry_manager&) = delete;
 
         std::optional<registry_key> get_key(const utils::path_key& key);
+        bool can_create_key(const utils::path_key& key) const;
+        std::optional<registry_key> create_key(const utils::path_key& key);
         std::optional<registry_value> get_value(const registry_key& key, std::string_view name);
         std::optional<registry_value> get_value(const registry_key& key, size_t index);
         void set_value(const registry_key& key, std::string name, uint32_t type, std::span<const std::byte> data);
@@ -174,6 +176,7 @@ namespace sogen
         void add_path_mapping(const utils::path_key& key, const utils::path_key& value);
 
         hive_map::iterator find_hive(const utils::path_key& key);
+        hive_map::const_iterator find_hive(const utils::path_key& key) const;
 
         void setup();
     };

--- a/src/windows-emulator/registry/registry_manager.hpp
+++ b/src/windows-emulator/registry/registry_manager.hpp
@@ -118,13 +118,15 @@ namespace sogen
         registry_manager& operator=(const registry_manager&) = delete;
 
         std::optional<registry_key> get_key(const utils::path_key& key);
-        bool can_create_key(const utils::path_key& key) const;
-        std::optional<registry_key> create_key(const utils::path_key& key);
+        bool can_create_key(const std::filesystem::path& key) const;
+        std::optional<registry_key> create_key(const std::filesystem::path& key);
         std::optional<registry_value> get_value(const registry_key& key, std::string_view name);
         std::optional<registry_value> get_value(const registry_key& key, size_t index);
+        size_t get_value_count(const registry_key& key);
         void set_value(const registry_key& key, std::string name, uint32_t type, std::span<const std::byte> data);
 
         std::optional<std::string_view> get_sub_key_name(const registry_key& key, size_t index);
+        size_t get_sub_key_count(const registry_key& key);
 
         std::optional<exposed_hive_key> get_hive_key(const registry_key& key);
 
@@ -153,15 +155,18 @@ namespace sogen
 
         struct overlay_bucket
         {
+            utils::insensitive_string_map<bool> sub_keys{};
             utils::insensitive_string_map<overlay_value> values{};
 
             void serialize(utils::buffer_serializer& buffer) const
             {
+                buffer.write_map(this->sub_keys);
                 buffer.write_map(this->values);
             }
 
             void deserialize(utils::buffer_deserializer& buffer)
             {
+                buffer.read_map(this->sub_keys);
                 buffer.read_map(this->values);
             }
         };

--- a/src/windows-emulator/syscalls/registry.cpp
+++ b/src/windows-emulator/syscalls/registry.cpp
@@ -120,12 +120,6 @@ namespace sogen
 
             if (key_information_class == KeyFullInformation)
             {
-                const auto hive_key = c.win_emu.registry.get_hive_key(*key);
-                if (!hive_key.has_value())
-                {
-                    return STATUS_OBJECT_NAME_NOT_FOUND;
-                }
-
                 constexpr auto required_size = offsetof(KEY_FULL_INFORMATION, Class);
                 result_length.write(static_cast<ULONG>(required_size));
 
@@ -136,28 +130,11 @@ namespace sogen
 
                 KEY_FULL_INFORMATION info{};
                 info.ClassOffset = 0xFFFFFFFFu;
-                info.SubKeys = static_cast<ULONG>(hive_key->key.get_sub_key_count(hive_key->file));
-                info.Values = static_cast<ULONG>(hive_key->key.get_value_count(hive_key->file));
-
-                for (size_t i = 0; i < info.SubKeys; ++i)
-                {
-                    const auto* name = hive_key->key.get_sub_key_name(hive_key->file, i);
-                    if (name)
-                    {
-                        info.MaxNameLength = std::max(info.MaxNameLength, static_cast<ULONG>(u8_to_u16(*name).size() * sizeof(char16_t)));
-                    }
-                }
-
-                for (size_t i = 0; i < info.Values; ++i)
-                {
-                    const auto* value = hive_key->key.get_value(hive_key->file, i);
-                    if (value)
-                    {
-                        info.MaxValueNameLength =
-                            std::max(info.MaxValueNameLength, static_cast<ULONG>(u8_to_u16(value->name).size() * sizeof(char16_t)));
-                        info.MaxValueDataLength = std::max(info.MaxValueDataLength, static_cast<ULONG>(value->data.size()));
-                    }
-                }
+                info.SubKeys = static_cast<ULONG>(c.win_emu.registry.get_sub_key_count(*key));
+                info.Values = static_cast<ULONG>(c.win_emu.registry.get_value_count(*key));
+                info.MaxNameLength = 0x1000;
+                info.MaxValueNameLength = 0x1000;
+                info.MaxValueDataLength = 0x1000;
 
                 c.emu.write_memory(key_information, &info, required_size);
                 return STATUS_SUCCESS;
@@ -173,12 +150,6 @@ namespace sogen
                     key_name.pop_back();
                 }
 
-                const auto hive_key = c.win_emu.registry.get_hive_key(*key);
-                if (!hive_key.has_value())
-                {
-                    return STATUS_OBJECT_NAME_NOT_FOUND;
-                }
-
                 constexpr auto required_size = sizeof(KEY_CACHED_INFORMATION);
                 result_length.write(required_size);
 
@@ -188,8 +159,8 @@ namespace sogen
                 }
 
                 KEY_CACHED_INFORMATION info{};
-                info.SubKeys = static_cast<ULONG>(hive_key->key.get_sub_key_count(hive_key->file));
-                info.Values = static_cast<ULONG>(hive_key->key.get_value_count(hive_key->file));
+                info.SubKeys = static_cast<ULONG>(c.win_emu.registry.get_sub_key_count(*key));
+                info.Values = static_cast<ULONG>(c.win_emu.registry.get_value_count(*key));
                 info.NameLength = static_cast<ULONG>(key_name.size() * 2);
                 info.MaxValueDataLen = 0x1000;
                 info.MaxValueNameLen = 0x1000;
@@ -248,7 +219,7 @@ namespace sogen
                 return STATUS_OBJECT_NAME_NOT_FOUND;
             }
 
-            const std::u16string original_name(value->name.begin(), value->name.end());
+            const auto original_name = u8_to_u16(value->name);
 
             if (key_value_information_class == KeyValueBasicInformation)
             {
@@ -531,7 +502,7 @@ namespace sogen
                 return STATUS_NO_MORE_ENTRIES;
             }
 
-            const std::u16string subkey_name_u16(subkey_name->begin(), subkey_name->end());
+            const auto subkey_name_u16 = u8_to_u16(*subkey_name);
 
             if (key_information_class == KeyBasicInformation)
             {
@@ -612,7 +583,7 @@ namespace sogen
                 return STATUS_NO_MORE_ENTRIES;
             }
 
-            const std::u16string value_name_u16(value->name.begin(), value->name.end());
+            const auto value_name_u16 = u8_to_u16(value->name);
 
             if (key_value_information_class == KeyValueBasicInformation)
             {


### PR DESCRIPTION
This PR adds support for importing Windows Registry Editor (`.reg`) files into the emulated registry.

A new `--reg-file` option can be used to import registry values, and it can be specified multiple times to apply multiple registry files.

The importer currently supports:

* `Windows Registry Editor Version 5.00` files
* UTF-8 and UTF-16 encoded files
* `REG_SZ`
* `REG_DWORD`
* `REG_BINARY`
* Explicit `hex(type)` values
* Multi-line hex values
* The common registry roots (`HKLM`, `HKCU`, `HKU`, `HKCR`, and `HKCC`)

This PR also extends the registry overlay implementation so that imported keys participate in key/value lookup and enumeration. Registry syscalls now account for overlay-created subkeys and values when reporting counts and enumerating entries. Registry key or value deletion through `.reg` files is not supported.

Additionally, `KeyFullInformation` was regressed to reporting `0x1000` for its maximum length fields, matching the existing behavior of `KeyCachedInformation`.
