### PR TITLE
VKD3D bring-up (Part 2)

### DIFF
--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -182,6 +182,12 @@ namespace sogen::gpu_bridge
         cmd_next_subpass = 0x88F,
         free_descriptor_sets = 0x890,
         get_descriptor_set_layout_support = 0x893,
+        cmd_bind_transform_feedback_buffers = 0x894,
+        cmd_begin_transform_feedback = 0x895,
+        cmd_end_transform_feedback = 0x896,
+        cmd_begin_query_indexed = 0x897,
+        cmd_end_query_indexed = 0x898,
+        cmd_draw_indirect_byte_count = 0x899,
         cmd_write_timestamp2 = 0x89A,
         get_physical_device_cooperative_matrix_properties = 0x89B,
         get_physical_device_fragment_shading_rates = 0x89C,
@@ -1470,12 +1476,70 @@ namespace sogen::gpu_bridge
         uint32_t reserved;
     };
 
+    struct cmd_begin_query_indexed_request
+    {
+        object_id command_buffer;
+        object_id query_pool;
+        uint32_t query;
+        uint32_t flags;
+        uint32_t index;
+        uint32_t reserved;
+    };
+
+    struct cmd_end_query_indexed_request
+    {
+        object_id command_buffer;
+        object_id query_pool;
+        uint32_t query;
+        uint32_t index;
+    };
+
     struct cmd_write_timestamp_request
     {
         object_id command_buffer;
         object_id query_pool;
         uint32_t query;
         uint32_t pipeline_stage; // VkPipelineStageFlagBits
+    };
+
+    struct transform_feedback_buffer_binding
+    {
+        object_id buffer;
+        uint64_t offset;
+        uint64_t size;
+    };
+
+    struct cmd_bind_transform_feedback_buffers_request
+    {
+        object_id command_buffer;
+        uint32_t first_binding;
+        uint32_t binding_count;
+    };
+
+    struct transform_feedback_counter_buffer
+    {
+        object_id buffer;
+        uint64_t offset;
+    };
+
+    struct cmd_transform_feedback_request
+    {
+        object_id command_buffer;
+        uint32_t first_counter_buffer;
+        uint32_t counter_buffer_count;
+        uint32_t has_counter_buffers;
+        uint32_t has_counter_buffer_offsets;
+    };
+
+    struct cmd_draw_indirect_byte_count_request
+    {
+        object_id command_buffer;
+        object_id counter_buffer;
+        uint64_t counter_buffer_offset;
+        uint32_t counter_offset;
+        uint32_t vertex_stride;
+        uint32_t instance_count;
+        uint32_t first_instance;
     };
 
     struct cmd_write_timestamp2_request
@@ -1682,6 +1746,8 @@ namespace sogen::gpu_bridge
         uint32_t dynamic_state_count;                                // number of uint32 VkDynamicState values that follow the attributes
         uint32_t primitive_topology;
         uint32_t primitive_restart_enable;
+        uint32_t rasterization_stream;
+        uint32_t rasterization_stream_flags;
         // Per-stage specialization constants (DXVK bakes d3d9 render state into the shaders this way).
         uint32_t vs_spec_entry_count;
         uint32_t vs_spec_data_size;
@@ -2170,7 +2236,7 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(create_shader_module_request) == 16, "wire layout drift");
     static_assert(sizeof(vertex_input_divisor) == 8, "wire layout drift");
     static_assert(sizeof(create_compute_pipeline_request) == 32, "wire layout drift");
-    static_assert(sizeof(create_graphics_pipeline_request) == 416, "wire layout drift");
+    static_assert(sizeof(create_graphics_pipeline_request) == 424, "wire layout drift");
     static_assert(sizeof(buffer_copy_region) == 24, "wire layout drift");
     static_assert(sizeof(cmd_copy_buffer_request) == 32, "wire layout drift");
     static_assert(sizeof(create_query_pool_request) == 24, "wire layout drift");
@@ -2179,6 +2245,13 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(cmd_reset_query_pool_request) == 24, "wire layout drift");
     static_assert(sizeof(cmd_begin_query_request) == 24, "wire layout drift");
     static_assert(sizeof(cmd_end_query_request) == 24, "wire layout drift");
+    static_assert(sizeof(cmd_begin_query_indexed_request) == 32, "wire layout drift");
+    static_assert(sizeof(cmd_end_query_indexed_request) == 24, "wire layout drift");
+    static_assert(sizeof(transform_feedback_buffer_binding) == 24, "wire layout drift");
+    static_assert(sizeof(cmd_bind_transform_feedback_buffers_request) == 16, "wire layout drift");
+    static_assert(sizeof(transform_feedback_counter_buffer) == 16, "wire layout drift");
+    static_assert(sizeof(cmd_transform_feedback_request) == 24, "wire layout drift");
+    static_assert(sizeof(cmd_draw_indirect_byte_count_request) == 40, "wire layout drift");
     static_assert(sizeof(cmd_write_timestamp2_request) == 32, "wire layout drift");
     static_assert(sizeof(cmd_write_timestamp_request) == 24, "wire layout drift");
     static_assert(sizeof(cmd_copy_query_pool_results_request) == 56, "wire layout drift");

--- a/src/gpu-bridge-protocol/vk_feature_chain.hpp
+++ b/src/gpu-bridge-protocol/vk_feature_chain.hpp
@@ -34,6 +34,8 @@ namespace sogen::gpu_bridge
             return sizeof(VkPhysicalDeviceVulkan13Features);
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT:
             return sizeof(VkPhysicalDeviceDepthClipEnableFeaturesEXT);
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT:
+            return sizeof(VkPhysicalDeviceTransformFeedbackFeaturesEXT);
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT:
             return sizeof(VkPhysicalDeviceExtendedDynamicState3FeaturesEXT);
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT:
@@ -79,6 +81,8 @@ namespace sogen::gpu_bridge
             return sizeof(VkPhysicalDeviceVulkan13Properties);
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_EXT:
             return sizeof(VkPhysicalDeviceRobustness2PropertiesEXT);
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT:
+            return sizeof(VkPhysicalDeviceTransformFeedbackPropertiesEXT);
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES:
             return sizeof(VkPhysicalDeviceDescriptorIndexingProperties);
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES:

--- a/src/samples/vulkan-shim-test/vulkan-shim-test.cpp
+++ b/src/samples/vulkan-shim-test/vulkan-shim-test.cpp
@@ -809,10 +809,6 @@ int main(int argc, char** argv)
         const auto create_device = reinterpret_cast<PFN_vkCreateDevice>(get_instance_proc(instance, "vkCreateDevice"));
         const auto get_device_queue = reinterpret_cast<PFN_vkGetDeviceQueue>(get_instance_proc(instance, "vkGetDeviceQueue"));
         const auto destroy_device = reinterpret_cast<PFN_vkDestroyDevice>(get_instance_proc(instance, "vkDestroyDevice"));
-        const auto enumerate_device_extensions =
-            reinterpret_cast<PFN_vkEnumerateDeviceExtensionProperties>(get_instance_proc(instance, "vkEnumerateDeviceExtensionProperties"));
-        const auto get_features2 =
-            reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2>(get_instance_proc(instance, "vkGetPhysicalDeviceFeatures2"));
         const auto get_properties2 =
             reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2>(get_instance_proc(instance, "vkGetPhysicalDeviceProperties2"));
 

--- a/src/samples/vulkan-shim-test/vulkan-shim-test.cpp
+++ b/src/samples/vulkan-shim-test/vulkan-shim-test.cpp
@@ -216,6 +216,127 @@ namespace
         return UINT32_MAX;
     }
 
+    bool test_transform_feedback(PFN_vkGetInstanceProcAddr get_instance_proc, VkInstance instance, VkPhysicalDevice physical_device,
+                                 VkDevice device, uint32_t queue_family)
+    {
+        const auto get_memory_properties =
+            reinterpret_cast<PFN_vkGetPhysicalDeviceMemoryProperties>(get_instance_proc(instance, "vkGetPhysicalDeviceMemoryProperties"));
+        const auto create_buffer = reinterpret_cast<PFN_vkCreateBuffer>(get_instance_proc(instance, "vkCreateBuffer"));
+        const auto destroy_buffer = reinterpret_cast<PFN_vkDestroyBuffer>(get_instance_proc(instance, "vkDestroyBuffer"));
+        const auto get_buffer_requirements =
+            reinterpret_cast<PFN_vkGetBufferMemoryRequirements>(get_instance_proc(instance, "vkGetBufferMemoryRequirements"));
+        const auto allocate_memory = reinterpret_cast<PFN_vkAllocateMemory>(get_instance_proc(instance, "vkAllocateMemory"));
+        const auto free_memory = reinterpret_cast<PFN_vkFreeMemory>(get_instance_proc(instance, "vkFreeMemory"));
+        const auto bind_buffer_memory = reinterpret_cast<PFN_vkBindBufferMemory>(get_instance_proc(instance, "vkBindBufferMemory"));
+        const auto create_command_pool = reinterpret_cast<PFN_vkCreateCommandPool>(get_instance_proc(instance, "vkCreateCommandPool"));
+        const auto destroy_command_pool = reinterpret_cast<PFN_vkDestroyCommandPool>(get_instance_proc(instance, "vkDestroyCommandPool"));
+        const auto allocate_command_buffers =
+            reinterpret_cast<PFN_vkAllocateCommandBuffers>(get_instance_proc(instance, "vkAllocateCommandBuffers"));
+        const auto begin_command_buffer = reinterpret_cast<PFN_vkBeginCommandBuffer>(get_instance_proc(instance, "vkBeginCommandBuffer"));
+        const auto end_command_buffer = reinterpret_cast<PFN_vkEndCommandBuffer>(get_instance_proc(instance, "vkEndCommandBuffer"));
+        const auto bind_transform_feedback =
+            reinterpret_cast<PFN_vkCmdBindTransformFeedbackBuffersEXT>(get_instance_proc(instance, "vkCmdBindTransformFeedbackBuffersEXT"));
+        const auto begin_transform_feedback =
+            reinterpret_cast<PFN_vkCmdBeginTransformFeedbackEXT>(get_instance_proc(instance, "vkCmdBeginTransformFeedbackEXT"));
+        const auto end_transform_feedback =
+            reinterpret_cast<PFN_vkCmdEndTransformFeedbackEXT>(get_instance_proc(instance, "vkCmdEndTransformFeedbackEXT"));
+        if (!get_memory_properties || !create_buffer || !destroy_buffer || !get_buffer_requirements || !allocate_memory || !free_memory ||
+            !bind_buffer_memory || !create_command_pool || !destroy_command_pool || !allocate_command_buffers || !begin_command_buffer ||
+            !end_command_buffer || !bind_transform_feedback || !begin_transform_feedback || !end_transform_feedback)
+        {
+            std::printf("[shim-test] transform feedback entry point missing\n");
+            return false;
+        }
+
+        constexpr VkDeviceSize buffer_size = 256;
+        VkBufferCreateInfo buffer_info{};
+        buffer_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+        buffer_info.size = buffer_size;
+        buffer_info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT | VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT;
+        buffer_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+        VkBuffer buffer = VK_NULL_HANDLE;
+        const VkResult create_result = create_buffer(device, &buffer_info, nullptr, &buffer);
+        VkDeviceMemory memory = VK_NULL_HANDLE;
+        VkResult memory_result = VK_ERROR_INITIALIZATION_FAILED;
+        VkResult bind_result = VK_ERROR_INITIALIZATION_FAILED;
+        if (create_result == VK_SUCCESS)
+        {
+            VkMemoryRequirements requirements{};
+            get_buffer_requirements(device, buffer, &requirements);
+            VkPhysicalDeviceMemoryProperties memory_properties{};
+            get_memory_properties(physical_device, &memory_properties);
+            const uint32_t memory_type = find_memory_type(memory_properties, requirements.memoryTypeBits, 0);
+            if (memory_type != UINT32_MAX)
+            {
+                VkMemoryAllocateInfo allocate_info{};
+                allocate_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+                allocate_info.allocationSize = requirements.size;
+                allocate_info.memoryTypeIndex = memory_type;
+                memory_result = allocate_memory(device, &allocate_info, nullptr, &memory);
+                if (memory_result == VK_SUCCESS)
+                {
+                    bind_result = bind_buffer_memory(device, buffer, memory, 0);
+                }
+            }
+        }
+
+        VkCommandPool pool = VK_NULL_HANDLE;
+        VkCommandBuffer command_buffer = VK_NULL_HANDLE;
+        VkResult pool_result = VK_ERROR_INITIALIZATION_FAILED;
+        VkResult allocate_result = VK_ERROR_INITIALIZATION_FAILED;
+        VkResult begin_result = VK_ERROR_INITIALIZATION_FAILED;
+        VkResult end_result = VK_ERROR_INITIALIZATION_FAILED;
+        if (bind_result == VK_SUCCESS)
+        {
+            VkCommandPoolCreateInfo pool_info{};
+            pool_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+            pool_info.queueFamilyIndex = queue_family;
+            pool_result = create_command_pool(device, &pool_info, nullptr, &pool);
+            if (pool_result == VK_SUCCESS)
+            {
+                VkCommandBufferAllocateInfo allocate_info{};
+                allocate_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+                allocate_info.commandPool = pool;
+                allocate_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+                allocate_info.commandBufferCount = 1;
+                allocate_result = allocate_command_buffers(device, &allocate_info, &command_buffer);
+                if (allocate_result == VK_SUCCESS)
+                {
+                    VkCommandBufferBeginInfo begin_info{};
+                    begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+                    begin_result = begin_command_buffer(command_buffer, &begin_info);
+                    if (begin_result == VK_SUCCESS)
+                    {
+                        constexpr VkDeviceSize offset = 0;
+                        bind_transform_feedback(command_buffer, 0, 1, &buffer, &offset, &buffer_size);
+                        begin_transform_feedback(command_buffer, 0, 1, &buffer, &offset);
+                        end_transform_feedback(command_buffer, 0, 1, &buffer, &offset);
+                        end_result = end_command_buffer(command_buffer);
+                    }
+                }
+            }
+        }
+
+        const bool ok = create_result == VK_SUCCESS && memory_result == VK_SUCCESS && bind_result == VK_SUCCESS &&
+                        pool_result == VK_SUCCESS && allocate_result == VK_SUCCESS && begin_result == VK_SUCCESS &&
+                        end_result == VK_SUCCESS;
+        std::printf("[shim-test] transform feedback command recording -> %s\n", ok ? "PASS" : "FAIL");
+        if (pool != VK_NULL_HANDLE)
+        {
+            destroy_command_pool(device, pool, nullptr);
+        }
+        if (buffer != VK_NULL_HANDLE)
+        {
+            destroy_buffer(device, buffer, nullptr);
+        }
+        if (memory != VK_NULL_HANDLE)
+        {
+            free_memory(device, memory, nullptr);
+        }
+        return ok;
+    }
+
     // Allocates a host-visible buffer, has the GPU fill it with a known pattern via vkCmdFillBuffer,
     // then maps it back and verifies the bytes -- the first end-to-end "GPU produces data the guest
     // reads back" path across the bridge.
@@ -658,6 +779,8 @@ int main(int argc, char** argv)
         reinterpret_cast<PFN_vkGetPhysicalDeviceProperties>(get_instance_proc(instance, "vkGetPhysicalDeviceProperties"));
     const auto destroy_instance = reinterpret_cast<PFN_vkDestroyInstance>(get_instance_proc(instance, "vkDestroyInstance"));
 
+    bool transform_feedback_test_ok = true;
+    bool transform_feedback_capabilities_ok = true;
     uint32_t count = 0;
     result = enumerate(instance, &count, nullptr);
     std::printf("[shim-test] vkEnumeratePhysicalDevices -> %d, count=%u\n", result, count);
@@ -686,6 +809,62 @@ int main(int argc, char** argv)
         const auto create_device = reinterpret_cast<PFN_vkCreateDevice>(get_instance_proc(instance, "vkCreateDevice"));
         const auto get_device_queue = reinterpret_cast<PFN_vkGetDeviceQueue>(get_instance_proc(instance, "vkGetDeviceQueue"));
         const auto destroy_device = reinterpret_cast<PFN_vkDestroyDevice>(get_instance_proc(instance, "vkDestroyDevice"));
+        const auto enumerate_device_extensions =
+            reinterpret_cast<PFN_vkEnumerateDeviceExtensionProperties>(get_instance_proc(instance, "vkEnumerateDeviceExtensionProperties"));
+        const auto get_features2 =
+            reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2>(get_instance_proc(instance, "vkGetPhysicalDeviceFeatures2"));
+        const auto get_properties2 =
+            reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2>(get_instance_proc(instance, "vkGetPhysicalDeviceProperties2"));
+
+        bool transform_feedback_extension_present = false;
+        if (enumerate_device_extensions)
+        {
+            uint32_t extension_count = 0;
+            enumerate_device_extensions(devices[0], nullptr, &extension_count, nullptr);
+            std::vector<VkExtensionProperties> extensions(extension_count);
+            enumerate_device_extensions(devices[0], nullptr, &extension_count, extensions.data());
+            for (const auto& extension : extensions)
+            {
+                if (std::strcmp(extension.extensionName, VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME) == 0)
+                {
+                    transform_feedback_extension_present = true;
+                    break;
+                }
+            }
+        }
+
+        VkPhysicalDeviceTransformFeedbackFeaturesEXT available_transform_feedback_features{};
+        available_transform_feedback_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT;
+        if (transform_feedback_extension_present && get_features2)
+        {
+            VkPhysicalDeviceFeatures2 features2{};
+            features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+            features2.pNext = &available_transform_feedback_features;
+            get_features2(devices[0], &features2);
+        }
+
+        VkPhysicalDeviceTransformFeedbackPropertiesEXT available_transform_feedback_properties{};
+        available_transform_feedback_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT;
+        if (transform_feedback_extension_present && get_properties2)
+        {
+            VkPhysicalDeviceProperties2 properties2{};
+            properties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+            properties2.pNext = &available_transform_feedback_properties;
+            get_properties2(devices[0], &properties2);
+        }
+        if (transform_feedback_extension_present)
+        {
+            transform_feedback_capabilities_ok =
+                get_features2 && get_properties2 && available_transform_feedback_features.geometryStreams == VK_FALSE &&
+                available_transform_feedback_properties.maxTransformFeedbackStreams <= 1 &&
+                available_transform_feedback_properties.transformFeedbackStreamsLinesTriangles == VK_FALSE &&
+                available_transform_feedback_properties.transformFeedbackRasterizationStreamSelect == VK_FALSE;
+        }
+        const bool transform_feedback_supported =
+            transform_feedback_extension_present && available_transform_feedback_features.transformFeedback == VK_TRUE;
+        std::printf("[shim-test] %s advertised=%s feature=%u capability mask=%s\n", VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME,
+                    transform_feedback_extension_present ? "yes" : "no", available_transform_feedback_features.transformFeedback,
+                    transform_feedback_capabilities_ok ? "PASS" : "FAIL");
 
         const char* calibrated_timestamps_extension = nullptr;
         if (enumerate_device_extensions)
@@ -772,11 +951,30 @@ int main(int argc, char** argv)
             device_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
             device_info.queueCreateInfoCount = queue_info_count;
             device_info.pQueueCreateInfos = queue_infos.data();
-            device_info.pNext = timestamp2_test_supported ? &enabled_vulkan13_features : nullptr;
+
+            VkPhysicalDeviceTransformFeedbackFeaturesEXT transform_feedback_features{};
+            void* enabled_feature_chain = nullptr;
+            if (transform_feedback_supported)
+            {
+                transform_feedback_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT;
+                transform_feedback_features.transformFeedback = VK_TRUE;
+                transform_feedback_features.pNext = enabled_feature_chain;
+                enabled_feature_chain = &transform_feedback_features;
+            }
+            if (timestamp2_test_supported)
+            {
+                enabled_vulkan13_features.pNext = enabled_feature_chain;
+                enabled_feature_chain = &enabled_vulkan13_features;
+            }
+            device_info.pNext = enabled_feature_chain;
             std::vector<const char*> enabled_extensions;
             if (calibrated_timestamps_extension)
             {
                 enabled_extensions.push_back(calibrated_timestamps_extension);
+            }
+            if (transform_feedback_supported)
+            {
+                enabled_extensions.push_back(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
             }
             device_info.enabledExtensionCount = static_cast<uint32_t>(enabled_extensions.size());
             device_info.ppEnabledExtensionNames = enabled_extensions.data();
@@ -811,6 +1009,14 @@ int main(int argc, char** argv)
                     std::printf("[shim-test] calibrated timestamps -> SKIP (extension unavailable)\n");
                 }
 
+                if (transform_feedback_supported)
+                {
+                    transform_feedback_test_ok = test_transform_feedback(get_instance_proc, instance, devices[0], device, graphics_family);
+                }
+                else
+                {
+                    std::printf("[shim-test] transform feedback command recording -> SKIP (feature unavailable)\n");
+                }
                 submit_and_wait(get_instance_proc, instance, device, queue, graphics_family);
                 fill_buffer_and_readback(get_instance_proc, instance, devices[0], device, queue, graphics_family);
                 clear_image_and_readback(get_instance_proc, instance, devices[0], device, queue, graphics_family);
@@ -825,7 +1031,8 @@ int main(int argc, char** argv)
         destroy_instance(instance, nullptr);
     }
 
-    const bool all_ok = timestamp2_test_ok && calibrated_timestamps_test_ok;
+    const bool all_ok =
+        timestamp2_test_ok && calibrated_timestamps_test_ok && transform_feedback_test_ok && transform_feedback_capabilities_ok;
     std::printf("[shim-test] %s\n", all_ok ? "ok" : "FAILED");
     return all_ok ? 0 : 6;
 }

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -1773,6 +1773,114 @@ extern "C"
         record_command(request.command_buffer, gb::command::cmd_end_query, &request, sizeof(request));
     }
 
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
+                                                                               uint32_t query, VkQueryControlFlags flags, uint32_t index)
+    {
+        gb::cmd_begin_query_indexed_request request{};
+        request.command_buffer = to_object_id(commandBuffer);
+        request.query_pool = to_object_id(queryPool);
+        request.query = query;
+        request.flags = static_cast<uint32_t>(flags);
+        request.index = index;
+        record_command(request.command_buffer, gb::command::cmd_begin_query_indexed, &request, sizeof(request));
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
+                                                                             uint32_t query, uint32_t index)
+    {
+        gb::cmd_end_query_indexed_request request{};
+        request.command_buffer = to_object_id(commandBuffer);
+        request.query_pool = to_object_id(queryPool);
+        request.query = query;
+        request.index = index;
+        record_command(request.command_buffer, gb::command::cmd_end_query_indexed, &request, sizeof(request));
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdBindTransformFeedbackBuffersEXT(VkCommandBuffer commandBuffer,
+                                                                                          uint32_t firstBinding, uint32_t bindingCount,
+                                                                                          const VkBuffer* pBuffers,
+                                                                                          const VkDeviceSize* pOffsets,
+                                                                                          const VkDeviceSize* pSizes)
+    {
+        gb::cmd_bind_transform_feedback_buffers_request request{};
+        request.command_buffer = to_object_id(commandBuffer);
+        request.first_binding = firstBinding;
+        request.binding_count = bindingCount;
+
+        std::vector<uint8_t> message(sizeof(request) + static_cast<size_t>(bindingCount) * sizeof(gb::transform_feedback_buffer_binding));
+        std::memcpy(message.data(), &request, sizeof(request));
+        size_t cursor = sizeof(request);
+        for (uint32_t i = 0; i < bindingCount; ++i)
+        {
+            const gb::transform_feedback_buffer_binding binding{
+                .buffer = to_object_id(pBuffers[i]), .offset = pOffsets[i], .size = pSizes ? pSizes[i] : VK_WHOLE_SIZE};
+            std::memcpy(message.data() + cursor, &binding, sizeof(binding));
+            cursor += sizeof(binding);
+        }
+        record_command(request.command_buffer, gb::command::cmd_bind_transform_feedback_buffers, message.data(), message.size());
+    }
+
+    static void record_transform_feedback_command(gb::command command, VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer,
+                                                  uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
+                                                  const VkDeviceSize* pCounterBufferOffsets)
+    {
+        gb::cmd_transform_feedback_request request{};
+        request.command_buffer = to_object_id(commandBuffer);
+        request.first_counter_buffer = firstCounterBuffer;
+        request.counter_buffer_count = counterBufferCount;
+        request.has_counter_buffers = pCounterBuffers ? 1u : 0u;
+        request.has_counter_buffer_offsets = pCounterBufferOffsets ? 1u : 0u;
+
+        std::vector<uint8_t> message(sizeof(request) +
+                                     static_cast<size_t>(counterBufferCount) * sizeof(gb::transform_feedback_counter_buffer));
+        std::memcpy(message.data(), &request, sizeof(request));
+        size_t cursor = sizeof(request);
+        for (uint32_t i = 0; i < counterBufferCount; ++i)
+        {
+            const gb::transform_feedback_counter_buffer counter{.buffer =
+                                                                    pCounterBuffers ? to_object_id(pCounterBuffers[i]) : gb::null_object,
+                                                                .offset = pCounterBufferOffsets ? pCounterBufferOffsets[i] : 0};
+            std::memcpy(message.data() + cursor, &counter, sizeof(counter));
+            cursor += sizeof(counter);
+        }
+        record_command(request.command_buffer, command, message.data(), message.size());
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdBeginTransformFeedbackEXT(VkCommandBuffer commandBuffer,
+                                                                                    uint32_t firstCounterBuffer,
+                                                                                    uint32_t counterBufferCount,
+                                                                                    const VkBuffer* pCounterBuffers,
+                                                                                    const VkDeviceSize* pCounterBufferOffsets)
+    {
+        record_transform_feedback_command(gb::command::cmd_begin_transform_feedback, commandBuffer, firstCounterBuffer, counterBufferCount,
+                                          pCounterBuffers, pCounterBufferOffsets);
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdEndTransformFeedbackEXT(VkCommandBuffer commandBuffer,
+                                                                                  uint32_t firstCounterBuffer, uint32_t counterBufferCount,
+                                                                                  const VkBuffer* pCounterBuffers,
+                                                                                  const VkDeviceSize* pCounterBufferOffsets)
+    {
+        record_transform_feedback_command(gb::command::cmd_end_transform_feedback, commandBuffer, firstCounterBuffer, counterBufferCount,
+                                          pCounterBuffers, pCounterBufferOffsets);
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t instanceCount,
+                                                                                   uint32_t firstInstance, VkBuffer counterBuffer,
+                                                                                   VkDeviceSize counterBufferOffset, uint32_t counterOffset,
+                                                                                   uint32_t vertexStride)
+    {
+        gb::cmd_draw_indirect_byte_count_request request{};
+        request.command_buffer = to_object_id(commandBuffer);
+        request.counter_buffer = to_object_id(counterBuffer);
+        request.counter_buffer_offset = counterBufferOffset;
+        request.counter_offset = counterOffset;
+        request.vertex_stride = vertexStride;
+        request.instance_count = instanceCount;
+        request.first_instance = firstInstance;
+        record_command(request.command_buffer, gb::command::cmd_draw_indirect_byte_count, &request, sizeof(request));
+    }
+
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkCmdWriteTimestamp(VkCommandBuffer commandBuffer,
                                                                          VkPipelineStageFlagBits pipelineStage, VkQueryPool queryPool,
                                                                          uint32_t query)
@@ -4683,6 +4791,23 @@ extern "C"
             request.primitive_topology = static_cast<uint32_t>(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST);
 
             request.primitive_restart_enable = 0;
+            request.rasterization_stream = UINT32_MAX;
+
+            if (ci.pRasterizationState)
+            {
+                for (const auto* base = static_cast<const VkBaseInStructure*>(ci.pRasterizationState->pNext); base != nullptr;
+                     base = base->pNext)
+                {
+                    if (base->sType != VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT)
+                    {
+                        continue;
+                    }
+                    const auto* stream = reinterpret_cast<const VkPipelineRasterizationStateStreamCreateInfoEXT*>(base);
+                    request.rasterization_stream = stream->rasterizationStream;
+                    request.rasterization_stream_flags = static_cast<uint32_t>(stream->flags);
+                    break;
+                }
+            }
 
             if (ci.pInputAssemblyState)
             {
@@ -5447,8 +5572,15 @@ extern "C"
             {.name = "vkGetQueryPoolResults", .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetQueryPoolResults)},
             {.name = "vkCmdResetQueryPool", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdResetQueryPool)},
             {.name = "vkCmdBeginQuery", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBeginQuery)},
+            {.name = "vkCmdBeginQueryIndexedEXT", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBeginQueryIndexedEXT)},
             {.name = "vkCmdEndQuery", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdEndQuery)},
             {.name = "vkCmdCopyQueryPoolResults", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdCopyQueryPoolResults)},
+            {.name = "vkCmdEndQueryIndexedEXT", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdEndQueryIndexedEXT)},
+            {.name = "vkCmdBindTransformFeedbackBuffersEXT",
+             .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBindTransformFeedbackBuffersEXT)},
+            {.name = "vkCmdBeginTransformFeedbackEXT", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBeginTransformFeedbackEXT)},
+            {.name = "vkCmdEndTransformFeedbackEXT", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdEndTransformFeedbackEXT)},
+            {.name = "vkCmdDrawIndirectByteCountEXT", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdDrawIndirectByteCountEXT)},
             {.name = "vkCmdWriteTimestamp", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdWriteTimestamp)},
             {.name = "vkCmdWriteTimestamp2", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdWriteTimestamp2)},
             {.name = "vkCmdWriteTimestamp2KHR", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdWriteTimestamp2KHR)},

--- a/src/samples/vulkan-shim/vulkan_shim.def
+++ b/src/samples/vulkan-shim/vulkan_shim.def
@@ -14,6 +14,7 @@ EXPORTS
     vkBindBufferMemory
     vkBindImageMemory
     vkCmdBeginRenderPass
+    vkCmdBeginTransformFeedbackEXT
     vkCmdBeginRendering
     vkCmdBindDescriptorSets
     vkCmdBindDescriptorSets2KHR
@@ -23,6 +24,7 @@ EXPORTS
     vkCmdBeginDebugUtilsLabelEXT
     vkCmdBindVertexBuffers
     vkCmdBindVertexBuffers2
+    vkCmdBindTransformFeedbackBuffersEXT
     vkCmdBlitImage2
     vkCmdBlitImage
     vkCmdBlitImage2KHR
@@ -30,6 +32,7 @@ EXPORTS
     vkCmdClearColorImage
     vkCmdClearDepthStencilImage
     vkCmdBeginQuery
+    vkCmdBeginQueryIndexedEXT
     vkCmdCopyBuffer
     vkCmdCopyQueryPoolResults
     vkCmdCopyBufferToImage
@@ -51,7 +54,10 @@ EXPORTS
     vkCmdDrawIndirect
     vkCmdDrawIndirectCount
     vkCmdDrawIndirectCountKHR
+    vkCmdDrawIndirectByteCountEXT
     vkCmdEndQuery
+    vkCmdEndQueryIndexedEXT
+    vkCmdEndTransformFeedbackEXT
     vkCmdResetQueryPool
     vkCmdWriteTimestamp
     vkCmdWriteTimestamp2

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -2292,7 +2292,8 @@ namespace sogen
                     request.device, request.render_pass, request.pipeline_layout, request.vertex_shader, request.fragment_shader,
                     request.flags, request.width, request.height, bindings, attributes, divisors, depth, color_formats,
                     request.depth_format, request.stencil_format, request.rasterization_samples, request.primitive_topology,
-                    request.primitive_restart_enable, dynamic_states, vs_spec, fs_spec, blend_attachments, pipeline);
+                    request.primitive_restart_enable, request.rasterization_stream, request.rasterization_stream_flags, dynamic_states,
+                    vs_spec, fs_spec, blend_attachments, pipeline);
                 if (result != 0)
                 {
                     win_emu.log.error(
@@ -2866,6 +2867,93 @@ namespace sogen
                         return vk_error_initialization_failed;
                     }
                     return this->vulkan_.cmd_end_query(req.command_buffer, req.query_pool, req.query);
+                }
+                case gpu_bridge::command::cmd_begin_query_indexed: {
+                    gpu_bridge::cmd_begin_query_indexed_request req{};
+                    if (!read(req))
+                    {
+                        return vk_error_initialization_failed;
+                    }
+                    return this->vulkan_.cmd_begin_query_indexed(req.command_buffer, req.query_pool, req.query, req.flags, req.index);
+                }
+                case gpu_bridge::command::cmd_end_query_indexed: {
+                    gpu_bridge::cmd_end_query_indexed_request req{};
+                    if (!read(req))
+                    {
+                        return vk_error_initialization_failed;
+                    }
+                    return this->vulkan_.cmd_end_query_indexed(req.command_buffer, req.query_pool, req.query, req.index);
+                }
+                case gpu_bridge::command::cmd_bind_transform_feedback_buffers: {
+                    gpu_bridge::cmd_bind_transform_feedback_buffers_request req{};
+                    if (!read(req))
+                    {
+                        return vk_error_initialization_failed;
+                    }
+                    const size_t bindings_bytes = size - sizeof(req);
+                    if (bindings_bytes % sizeof(gpu_bridge::transform_feedback_buffer_binding) != 0 ||
+                        req.binding_count != bindings_bytes / sizeof(gpu_bridge::transform_feedback_buffer_binding))
+                    {
+                        return vk_error_initialization_failed;
+                    }
+                    std::vector<uint64_t> buffers(req.binding_count);
+                    std::vector<uint64_t> offsets(req.binding_count);
+                    std::vector<uint64_t> sizes(req.binding_count);
+                    size_t cursor = sizeof(req);
+                    for (uint32_t i = 0; i < req.binding_count; ++i)
+                    {
+                        gpu_bridge::transform_feedback_buffer_binding binding{};
+                        std::memcpy(&binding, payload + cursor, sizeof(binding));
+                        cursor += sizeof(binding);
+                        buffers[i] = binding.buffer;
+                        offsets[i] = binding.offset;
+                        sizes[i] = binding.size;
+                    }
+                    return this->vulkan_.cmd_bind_transform_feedback_buffers(req.command_buffer, req.first_binding, buffers, offsets,
+                                                                             sizes);
+                }
+                case gpu_bridge::command::cmd_begin_transform_feedback:
+                case gpu_bridge::command::cmd_end_transform_feedback: {
+                    gpu_bridge::cmd_transform_feedback_request req{};
+                    if (!read(req) || req.has_counter_buffers > 1 || req.has_counter_buffer_offsets > 1)
+                    {
+                        return vk_error_initialization_failed;
+                    }
+                    const size_t counters_bytes = size - sizeof(req);
+                    if (counters_bytes % sizeof(gpu_bridge::transform_feedback_counter_buffer) != 0 ||
+                        req.counter_buffer_count != counters_bytes / sizeof(gpu_bridge::transform_feedback_counter_buffer))
+                    {
+                        return vk_error_initialization_failed;
+                    }
+                    std::vector<uint64_t> buffers(req.counter_buffer_count);
+                    std::vector<uint64_t> offsets(req.counter_buffer_count);
+                    size_t cursor = sizeof(req);
+                    for (uint32_t i = 0; i < req.counter_buffer_count; ++i)
+                    {
+                        gpu_bridge::transform_feedback_counter_buffer counter{};
+                        std::memcpy(&counter, payload + cursor, sizeof(counter));
+                        cursor += sizeof(counter);
+                        buffers[i] = counter.buffer;
+                        offsets[i] = counter.offset;
+                    }
+                    if (static_cast<gpu_bridge::command>(command) == gpu_bridge::command::cmd_begin_transform_feedback)
+                    {
+                        return this->vulkan_.cmd_begin_transform_feedback(req.command_buffer, req.first_counter_buffer, buffers, offsets,
+                                                                          req.has_counter_buffers != 0,
+                                                                          req.has_counter_buffer_offsets != 0);
+                    }
+                    return this->vulkan_.cmd_end_transform_feedback(req.command_buffer, req.first_counter_buffer, buffers, offsets,
+                                                                    req.has_counter_buffers != 0, req.has_counter_buffer_offsets != 0);
+                }
+                case gpu_bridge::command::cmd_draw_indirect_byte_count: {
+                    gpu_bridge::cmd_draw_indirect_byte_count_request req{};
+                    if (!read(req))
+                    {
+                        return vk_error_initialization_failed;
+                    }
+                    return this->vulkan_.cmd_draw_indirect_byte_count(req.command_buffer, req.instance_count, req.first_instance,
+                                                                      req.counter_buffer, req.counter_buffer_offset, req.counter_offset,
+                                                                      req.vertex_stride);
                 }
                 case gpu_bridge::command::cmd_write_timestamp: {
                     gpu_bridge::cmd_write_timestamp_request req{};

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -306,6 +306,12 @@ namespace sogen
             PFN_vkCmdResetQueryPool cmd_reset_query_pool{};
             PFN_vkCmdBeginQuery cmd_begin_query{};
             PFN_vkCmdEndQuery cmd_end_query{};
+            PFN_vkCmdBeginQueryIndexedEXT cmd_begin_query_indexed{};
+            PFN_vkCmdEndQueryIndexedEXT cmd_end_query_indexed{};
+            PFN_vkCmdBindTransformFeedbackBuffersEXT cmd_bind_transform_feedback_buffers{};
+            PFN_vkCmdBeginTransformFeedbackEXT cmd_begin_transform_feedback{};
+            PFN_vkCmdEndTransformFeedbackEXT cmd_end_transform_feedback{};
+            PFN_vkCmdDrawIndirectByteCountEXT cmd_draw_indirect_byte_count{};
             PFN_vkCmdWriteTimestamp cmd_write_timestamp{};
             PFN_vkCmdWriteTimestamp2 cmd_write_timestamp2{};
             PFN_vkCmdCopyQueryPoolResults cmd_copy_query_pool_results{};
@@ -1640,6 +1646,16 @@ namespace sogen
 
         instance->second.get_physical_device_features2(pd->second.handle, &features2);
 
+        for (auto& buffer : chained)
+        {
+            auto* base = reinterpret_cast<VkBaseOutStructure*>(buffer.data());
+            if (base->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT)
+            {
+                auto* features = reinterpret_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(buffer.data());
+                features->geometryStreams = VK_FALSE;
+            }
+        }
+
         // Serialize one record + body per requested struct, in request order. The body is the guest's
         // pad-free VkBool32 run copied from after the (ABI-specific) header.
         for (uint32_t i = 0; i < struct_count; ++i)
@@ -1730,6 +1746,18 @@ namespace sogen
         }
 
         instance->second.get_physical_device_properties2(pd->second.handle, &properties2);
+
+        for (auto& buffer : chained)
+        {
+            auto* base = reinterpret_cast<VkBaseOutStructure*>(buffer.data());
+            if (base->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT)
+            {
+                auto* properties = reinterpret_cast<VkPhysicalDeviceTransformFeedbackPropertiesEXT*>(buffer.data());
+                properties->maxTransformFeedbackStreams = std::min(properties->maxTransformFeedbackStreams, 1u);
+                properties->transformFeedbackStreamsLinesTriangles = VK_FALSE;
+                properties->transformFeedbackRasterizationStreamSelect = VK_FALSE;
+            }
+        }
 
         for (uint32_t i = 0; i < struct_count; ++i)
         {
@@ -1881,6 +1909,11 @@ namespace sogen
                         base->sType = type;
                         base->pNext = nullptr;
                         std::memcpy(buffer.data() + gpu_bridge::feature_chain_header_size, cursor, copy);
+                        if (type == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT)
+                        {
+                            auto* transform_feedback = reinterpret_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(buffer.data());
+                            transform_feedback->geometryStreams = VK_FALSE;
+                        }
                         feature_tail->pNext = base;
                         feature_tail = base;
                     }
@@ -2000,6 +2033,15 @@ namespace sogen
             data.cmd_reset_query_pool = reinterpret_cast<PFN_vkCmdResetQueryPool>(resolve("vkCmdResetQueryPool"));
             data.cmd_begin_query = reinterpret_cast<PFN_vkCmdBeginQuery>(resolve("vkCmdBeginQuery"));
             data.cmd_end_query = reinterpret_cast<PFN_vkCmdEndQuery>(resolve("vkCmdEndQuery"));
+            data.cmd_begin_query_indexed = reinterpret_cast<PFN_vkCmdBeginQueryIndexedEXT>(resolve("vkCmdBeginQueryIndexedEXT"));
+            data.cmd_end_query_indexed = reinterpret_cast<PFN_vkCmdEndQueryIndexedEXT>(resolve("vkCmdEndQueryIndexedEXT"));
+            data.cmd_bind_transform_feedback_buffers =
+                reinterpret_cast<PFN_vkCmdBindTransformFeedbackBuffersEXT>(resolve("vkCmdBindTransformFeedbackBuffersEXT"));
+            data.cmd_begin_transform_feedback =
+                reinterpret_cast<PFN_vkCmdBeginTransformFeedbackEXT>(resolve("vkCmdBeginTransformFeedbackEXT"));
+            data.cmd_end_transform_feedback = reinterpret_cast<PFN_vkCmdEndTransformFeedbackEXT>(resolve("vkCmdEndTransformFeedbackEXT"));
+            data.cmd_draw_indirect_byte_count =
+                reinterpret_cast<PFN_vkCmdDrawIndirectByteCountEXT>(resolve("vkCmdDrawIndirectByteCountEXT"));
             data.cmd_write_timestamp = reinterpret_cast<PFN_vkCmdWriteTimestamp>(resolve("vkCmdWriteTimestamp"));
             data.cmd_write_timestamp2 = reinterpret_cast<PFN_vkCmdWriteTimestamp2>(resolve("vkCmdWriteTimestamp2"));
             if (!data.cmd_write_timestamp2)
@@ -4553,6 +4595,174 @@ namespace sogen
         return VK_SUCCESS;
     }
 
+    int32_t vulkan_host::cmd_begin_query_indexed(uint64_t command_buffer, uint64_t query_pool, uint32_t query, uint32_t flags,
+                                                 uint32_t index)
+    {
+        const auto cb = this->impl_->command_buffers.find(command_buffer);
+        const auto qp = this->impl_->query_pools.find(query_pool);
+        if (cb == this->impl_->command_buffers.end() || qp == this->impl_->query_pools.end() ||
+            qp->second.device_id != cb->second.device_id)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        const auto dev = this->impl_->devices.find(cb->second.device_id);
+        if (dev == this->impl_->devices.end() || !dev->second.cmd_begin_query_indexed)
+        {
+            return VK_ERROR_FEATURE_NOT_PRESENT;
+        }
+        dev->second.cmd_begin_query_indexed(cb->second.handle, qp->second.handle, query, static_cast<VkQueryControlFlags>(flags), index);
+        return VK_SUCCESS;
+    }
+
+    int32_t vulkan_host::cmd_end_query_indexed(uint64_t command_buffer, uint64_t query_pool, uint32_t query, uint32_t index)
+    {
+        const auto cb = this->impl_->command_buffers.find(command_buffer);
+        const auto qp = this->impl_->query_pools.find(query_pool);
+        if (cb == this->impl_->command_buffers.end() || qp == this->impl_->query_pools.end() ||
+            qp->second.device_id != cb->second.device_id)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        const auto dev = this->impl_->devices.find(cb->second.device_id);
+        if (dev == this->impl_->devices.end() || !dev->second.cmd_end_query_indexed)
+        {
+            return VK_ERROR_FEATURE_NOT_PRESENT;
+        }
+        dev->second.cmd_end_query_indexed(cb->second.handle, qp->second.handle, query, index);
+        return VK_SUCCESS;
+    }
+
+    int32_t vulkan_host::cmd_bind_transform_feedback_buffers(uint64_t command_buffer, uint32_t first_binding,
+                                                             std::span<const uint64_t> buffer_ids, std::span<const uint64_t> offsets,
+                                                             std::span<const uint64_t> sizes)
+    {
+        const auto cb = this->impl_->command_buffers.find(command_buffer);
+        if (cb == this->impl_->command_buffers.end() || buffer_ids.empty() || buffer_ids.size() != offsets.size() ||
+            buffer_ids.size() != sizes.size())
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        const auto dev = this->impl_->devices.find(cb->second.device_id);
+        if (dev == this->impl_->devices.end() || !dev->second.cmd_bind_transform_feedback_buffers)
+        {
+            return VK_ERROR_FEATURE_NOT_PRESENT;
+        }
+
+        std::vector<VkBuffer> buffers;
+        buffers.reserve(buffer_ids.size());
+        for (size_t i = 0; i < buffer_ids.size(); ++i)
+        {
+            const auto buffer = this->impl_->buffers.find(buffer_ids[i]);
+            if (buffer == this->impl_->buffers.end() || buffer->second.device_id != cb->second.device_id ||
+                offsets[i] >= buffer->second.size || (sizes[i] != VK_WHOLE_SIZE && sizes[i] > buffer->second.size - offsets[i]))
+            {
+                return VK_ERROR_INITIALIZATION_FAILED;
+            }
+            buffers.push_back(buffer->second.handle);
+        }
+        dev->second.cmd_bind_transform_feedback_buffers(cb->second.handle, first_binding, static_cast<uint32_t>(buffers.size()),
+                                                        buffers.data(), offsets.data(), sizes.data());
+        return VK_SUCCESS;
+    }
+
+    int32_t vulkan_host::cmd_transform_feedback(uint64_t command_buffer, uint32_t first_counter_buffer,
+                                                std::span<const uint64_t> counter_buffer_ids,
+                                                std::span<const uint64_t> counter_buffer_offsets, bool has_counter_buffers,
+                                                bool has_counter_buffer_offsets, bool begin)
+    {
+        const auto cb = this->impl_->command_buffers.find(command_buffer);
+        if (cb == this->impl_->command_buffers.end() || counter_buffer_ids.size() != counter_buffer_offsets.size() ||
+            (!has_counter_buffers && has_counter_buffer_offsets))
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        const auto dev = this->impl_->devices.find(cb->second.device_id);
+        if (dev == this->impl_->devices.end() ||
+            (begin ? !dev->second.cmd_begin_transform_feedback : !dev->second.cmd_end_transform_feedback))
+        {
+            return VK_ERROR_FEATURE_NOT_PRESENT;
+        }
+
+        std::vector<VkBuffer> counter_buffers;
+        if (has_counter_buffers)
+        {
+            counter_buffers.reserve(counter_buffer_ids.size());
+            for (size_t i = 0; i < counter_buffer_ids.size(); ++i)
+            {
+                if (counter_buffer_ids[i] == gpu_bridge::null_object)
+                {
+                    counter_buffers.push_back(VK_NULL_HANDLE);
+                    continue;
+                }
+
+                const auto buffer = this->impl_->buffers.find(counter_buffer_ids[i]);
+                const uint64_t offset = has_counter_buffer_offsets ? counter_buffer_offsets[i] : 0;
+                if (buffer == this->impl_->buffers.end() || buffer->second.device_id != cb->second.device_id ||
+                    offset > buffer->second.size || buffer->second.size - offset < sizeof(uint32_t))
+                {
+                    return VK_ERROR_INITIALIZATION_FAILED;
+                }
+                counter_buffers.push_back(buffer->second.handle);
+            }
+        }
+
+        const bool has_entries = !counter_buffer_ids.empty();
+        const VkBuffer* buffers = has_counter_buffers && has_entries ? counter_buffers.data() : nullptr;
+        const VkDeviceSize* offsets =
+            has_counter_buffers && has_counter_buffer_offsets && has_entries ? counter_buffer_offsets.data() : nullptr;
+        if (begin)
+        {
+            dev->second.cmd_begin_transform_feedback(cb->second.handle, first_counter_buffer,
+                                                     static_cast<uint32_t>(counter_buffer_ids.size()), buffers, offsets);
+        }
+        else
+        {
+            dev->second.cmd_end_transform_feedback(cb->second.handle, first_counter_buffer,
+                                                   static_cast<uint32_t>(counter_buffer_ids.size()), buffers, offsets);
+        }
+        return VK_SUCCESS;
+    }
+
+    int32_t vulkan_host::cmd_begin_transform_feedback(uint64_t command_buffer, uint32_t first_counter_buffer,
+                                                      std::span<const uint64_t> counter_buffers,
+                                                      std::span<const uint64_t> counter_buffer_offsets, bool has_counter_buffers,
+                                                      bool has_counter_buffer_offsets)
+    {
+        return this->cmd_transform_feedback(command_buffer, first_counter_buffer, counter_buffers, counter_buffer_offsets,
+                                            has_counter_buffers, has_counter_buffer_offsets, true);
+    }
+
+    int32_t vulkan_host::cmd_end_transform_feedback(uint64_t command_buffer, uint32_t first_counter_buffer,
+                                                    std::span<const uint64_t> counter_buffers,
+                                                    std::span<const uint64_t> counter_buffer_offsets, bool has_counter_buffers,
+                                                    bool has_counter_buffer_offsets)
+    {
+        return this->cmd_transform_feedback(command_buffer, first_counter_buffer, counter_buffers, counter_buffer_offsets,
+                                            has_counter_buffers, has_counter_buffer_offsets, false);
+    }
+
+    int32_t vulkan_host::cmd_draw_indirect_byte_count(uint64_t command_buffer, uint32_t instance_count, uint32_t first_instance,
+                                                      uint64_t counter_buffer, uint64_t counter_buffer_offset, uint32_t counter_offset,
+                                                      uint32_t vertex_stride)
+    {
+        const auto cb = this->impl_->command_buffers.find(command_buffer);
+        const auto buffer = this->impl_->buffers.find(counter_buffer);
+        if (cb == this->impl_->command_buffers.end() || buffer == this->impl_->buffers.end() ||
+            buffer->second.device_id != cb->second.device_id || counter_buffer_offset > buffer->second.size ||
+            buffer->second.size - counter_buffer_offset < 4 || vertex_stride == 0)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        const auto dev = this->impl_->devices.find(cb->second.device_id);
+        if (dev == this->impl_->devices.end() || !dev->second.cmd_draw_indirect_byte_count)
+        {
+            return VK_ERROR_FEATURE_NOT_PRESENT;
+        }
+        dev->second.cmd_draw_indirect_byte_count(cb->second.handle, instance_count, first_instance, buffer->second.handle,
+                                                 counter_buffer_offset, counter_offset, vertex_stride);
+        return VK_SUCCESS;
+    }
+
     int32_t vulkan_host::cmd_write_timestamp(uint64_t command_buffer, uint64_t query_pool, uint32_t query, uint32_t pipeline_stage)
     {
         const auto cb = this->impl_->command_buffers.find(command_buffer);
@@ -5227,7 +5437,8 @@ namespace sogen
                                                   std::span<const vertex_divisor> divisors, const depth_state& depth,
                                                   std::span<const uint32_t> color_formats, uint32_t depth_format, uint32_t stencil_format,
                                                   uint32_t rasterization_samples, uint32_t primitive_topology,
-                                                  uint32_t primitive_restart_enable, std::span<const uint32_t> dynamic_states,
+                                                  uint32_t primitive_restart_enable, uint32_t rasterization_stream,
+                                                  uint32_t rasterization_stream_flags, std::span<const uint32_t> dynamic_states,
                                                   const specialization& vs_spec, const specialization& fs_spec,
                                                   std::span<const color_blend_attachment> blend_attachments_in, uint64_t& out_pipeline)
     {
@@ -5405,8 +5616,17 @@ namespace sogen
         dynamic_state.dynamicStateCount = static_cast<uint32_t>(dynamic_state_list.size());
         dynamic_state.pDynamicStates = dynamic_state_list.data();
 
+        VkPipelineRasterizationStateStreamCreateInfoEXT rasterization_stream_info{};
+        if (rasterization_stream != UINT32_MAX)
+        {
+            rasterization_stream_info.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT;
+            rasterization_stream_info.flags = static_cast<VkPipelineRasterizationStateStreamCreateFlagsEXT>(rasterization_stream_flags);
+            rasterization_stream_info.rasterizationStream = rasterization_stream;
+        }
+
         VkPipelineRasterizationStateCreateInfo rasterization{};
         rasterization.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+        rasterization.pNext = rasterization_stream != UINT32_MAX ? &rasterization_stream_info : nullptr;
         rasterization.polygonMode = VK_POLYGON_MODE_FILL;
         rasterization.cullMode = VK_CULL_MODE_NONE;
         rasterization.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -1652,6 +1652,7 @@ namespace sogen
             if (base->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT)
             {
                 auto* features = reinterpret_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(buffer.data());
+                // TODO: Expose geometry-stream support after geometry shaders are bridged.
                 features->geometryStreams = VK_FALSE;
             }
         }
@@ -1753,6 +1754,7 @@ namespace sogen
             if (base->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT)
             {
                 auto* properties = reinterpret_cast<VkPhysicalDeviceTransformFeedbackPropertiesEXT*>(buffer.data());
+                // TODO: Expose multiple transform-feedback streams after geometry shaders are bridged.
                 properties->maxTransformFeedbackStreams = std::min(properties->maxTransformFeedbackStreams, 1u);
                 properties->transformFeedbackStreamsLinesTriangles = VK_FALSE;
                 properties->transformFeedbackRasterizationStreamSelect = VK_FALSE;
@@ -1912,6 +1914,7 @@ namespace sogen
                         if (type == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT)
                         {
                             auto* transform_feedback = reinterpret_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(buffer.data());
+                            // TODO: Enable geometryStreams after geometry shaders are bridged.
                             transform_feedback->geometryStreams = VK_FALSE;
                         }
                         feature_tail->pNext = base;
@@ -4749,7 +4752,7 @@ namespace sogen
         const auto buffer = this->impl_->buffers.find(counter_buffer);
         if (cb == this->impl_->command_buffers.end() || buffer == this->impl_->buffers.end() ||
             buffer->second.device_id != cb->second.device_id || counter_buffer_offset > buffer->second.size ||
-            buffer->second.size - counter_buffer_offset < 4 || vertex_stride == 0)
+            buffer->second.size - counter_buffer_offset < sizeof(uint32_t) || vertex_stride == 0)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -424,6 +424,19 @@ namespace sogen
         int32_t cmd_reset_query_pool(uint64_t command_buffer, uint64_t query_pool, uint32_t first_query, uint32_t query_count);
         int32_t cmd_begin_query(uint64_t command_buffer, uint64_t query_pool, uint32_t query, uint32_t flags);
         int32_t cmd_end_query(uint64_t command_buffer, uint64_t query_pool, uint32_t query);
+        int32_t cmd_begin_query_indexed(uint64_t command_buffer, uint64_t query_pool, uint32_t query, uint32_t flags, uint32_t index);
+        int32_t cmd_end_query_indexed(uint64_t command_buffer, uint64_t query_pool, uint32_t query, uint32_t index);
+        int32_t cmd_bind_transform_feedback_buffers(uint64_t command_buffer, uint32_t first_binding, std::span<const uint64_t> buffers,
+                                                    std::span<const uint64_t> offsets, std::span<const uint64_t> sizes);
+        int32_t cmd_begin_transform_feedback(uint64_t command_buffer, uint32_t first_counter_buffer,
+                                             std::span<const uint64_t> counter_buffers, std::span<const uint64_t> counter_buffer_offsets,
+                                             bool has_counter_buffers, bool has_counter_buffer_offsets);
+        int32_t cmd_end_transform_feedback(uint64_t command_buffer, uint32_t first_counter_buffer,
+                                           std::span<const uint64_t> counter_buffers, std::span<const uint64_t> counter_buffer_offsets,
+                                           bool has_counter_buffers, bool has_counter_buffer_offsets);
+        int32_t cmd_draw_indirect_byte_count(uint64_t command_buffer, uint32_t instance_count, uint32_t first_instance,
+                                             uint64_t counter_buffer, uint64_t counter_buffer_offset, uint32_t counter_offset,
+                                             uint32_t vertex_stride);
         int32_t cmd_write_timestamp(uint64_t command_buffer, uint64_t query_pool, uint32_t query, uint32_t pipeline_stage);
         int32_t cmd_write_timestamp2(uint64_t command_buffer, uint64_t query_pool, uint32_t query, uint64_t pipeline_stage);
         int32_t cmd_copy_query_pool_results(uint64_t command_buffer, uint64_t query_pool, uint32_t first_query, uint32_t query_count,
@@ -564,6 +577,7 @@ namespace sogen
                                          std::span<const vertex_divisor> divisors, const depth_state& depth,
                                          std::span<const uint32_t> color_formats, uint32_t depth_format, uint32_t stencil_format,
                                          uint32_t rasterization_samples, uint32_t primitive_topology, uint32_t primitive_restart_enable,
+                                         uint32_t rasterization_stream, uint32_t rasterization_stream_flags,
                                          std::span<const uint32_t> dynamic_states, const specialization& vs_spec,
                                          const specialization& fs_spec, std::span<const color_blend_attachment> blend_attachments,
                                          uint64_t& out_pipeline);
@@ -617,6 +631,10 @@ namespace sogen
         int32_t cmd_set_dynamic_u32(uint64_t command_buffer, uint32_t state, uint32_t value);
 
       private:
+        int32_t cmd_transform_feedback(uint64_t command_buffer, uint32_t first_counter_buffer, std::span<const uint64_t> counter_buffers,
+                                       std::span<const uint64_t> counter_buffer_offsets, bool has_counter_buffers,
+                                       bool has_counter_buffer_offsets, bool begin);
+
         struct impl;
         std::unique_ptr<impl> impl_;
     };

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -426,7 +426,7 @@ namespace sogen
         int32_t cmd_end_query(uint64_t command_buffer, uint64_t query_pool, uint32_t query);
         int32_t cmd_begin_query_indexed(uint64_t command_buffer, uint64_t query_pool, uint32_t query, uint32_t flags, uint32_t index);
         int32_t cmd_end_query_indexed(uint64_t command_buffer, uint64_t query_pool, uint32_t query, uint32_t index);
-        int32_t cmd_bind_transform_feedback_buffers(uint64_t command_buffer, uint32_t first_binding, std::span<const uint64_t> buffers,
+        int32_t cmd_bind_transform_feedback_buffers(uint64_t command_buffer, uint32_t first_binding, std::span<const uint64_t> buffer_ids,
                                                     std::span<const uint64_t> offsets, std::span<const uint64_t> sizes);
         int32_t cmd_begin_transform_feedback(uint64_t command_buffer, uint32_t first_counter_buffer,
                                              std::span<const uint64_t> counter_buffers, std::span<const uint64_t> counter_buffer_offsets,
@@ -631,7 +631,7 @@ namespace sogen
         int32_t cmd_set_dynamic_u32(uint64_t command_buffer, uint32_t state, uint32_t value);
 
       private:
-        int32_t cmd_transform_feedback(uint64_t command_buffer, uint32_t first_counter_buffer, std::span<const uint64_t> counter_buffers,
+        int32_t cmd_transform_feedback(uint64_t command_buffer, uint32_t first_counter_buffer, std::span<const uint64_t> counter_buffer_ids,
                                        std::span<const uint64_t> counter_buffer_offsets, bool has_counter_buffers,
                                        bool has_counter_buffer_offsets, bool begin);
 


### PR DESCRIPTION
This PR is a follow-up to https://github.com/momo5502/sogen/pull/1269 and implements a more complete support for the transform-feedback extension in the GPU bridge. It's still incomplete due to the lack of geometry shader support, but the geometry shaders are a pre-existing gap in the GPU bridge and are outside the scope of this PR.