### PR TITLE
Forward missing Vulkan state through GPU bridge

### DIFF
--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -169,7 +169,7 @@ namespace sogen::gpu_bridge
         cmd_copy_image = 0x884,
         get_physical_device_memory_budget = 0x885,
         // Coalesced vkUpdateDescriptorSets: payload is a concatenation of update_descriptor_sets_request blobs
-        // (each a header + its descriptor_write[]), applied in issue order.
+        // (each a header + its descriptor_write[] + inline-uniform data), applied in issue order.
         update_descriptor_sets_batch = 0x886,
         cmd_blit_image = 0x887,
         reset_descriptor_pool = 0x888,
@@ -2028,6 +2028,7 @@ namespace sogen::gpu_bridge
     {
         int32_t vk_result;
         uint32_t supported; // VkBool32
+        uint32_t max_variable_descriptor_count;
     };
 
     // One pool size (trailing-array element of create_descriptor_pool).
@@ -2059,14 +2060,16 @@ namespace sogen::gpu_bridge
     };
 
     // ioctl_allocate_descriptor_sets: in header immediately followed by `set_count` object_id set-layout
-    // ids; out = allocate_descriptor_sets_response header followed by `count` object_id set ids
+    // ids and `variable_descriptor_count_count` uint32_t descriptor counts; out =
+    // allocate_descriptor_sets_response header followed by `count` object_id set ids
     struct allocate_descriptor_sets_request
     {
         object_id device;
         object_id descriptor_pool;
         uint32_t set_count;
-        uint32_t reserved;
+        uint32_t variable_descriptor_count_count;
         // object_id set_layouts[set_count];
+        // uint32_t variable_descriptor_counts[variable_descriptor_count_count];
     };
 
     struct allocate_descriptor_sets_response
@@ -2085,32 +2088,32 @@ namespace sogen::gpu_bridge
     };
 
     // One descriptor write (trailing-array element of update_descriptor_sets). Models a single buffer or
-    // image descriptor per write (descriptor_count == 1). For buffer types the buffer/offset/range fields
-    // apply; for image types (combined image sampler) the sampler/image_view/image_layout fields apply.
+    // image descriptor per write. Inline-uniform-block writes instead reference bytes trailing the write array.
     struct descriptor_write
     {
         object_id dst_set;
         uint32_t dst_binding;
         uint32_t dst_array_element;
         uint32_t descriptor_type; // VkDescriptorType
-        uint32_t reserved;
+        uint32_t inline_uniform_data_offset;
         object_id buffer_or_view;
         uint64_t offset;       // buffer offset
         uint64_t range;        // buffer range (VK_WHOLE_SIZE allowed)
         object_id sampler;     // image types: the sampler (else null_object)
         object_id image_view;  // image types: the sampled image view (else null_object)
         uint32_t image_layout; // image types: VkImageLayout
-        uint32_t reserved2;
+        uint32_t inline_uniform_data_size;
     };
 
     // ioctl_update_descriptor_sets: in header immediately followed by `write_count` descriptor_write
-    // entries; out = result_response
+    // entries and `inline_uniform_data_size` bytes; out = result_response
     struct update_descriptor_sets_request
     {
         object_id device;
         uint32_t write_count;
-        uint32_t reserved;
+        uint32_t inline_uniform_data_size;
         // descriptor_write writes[write_count];
+        // uint8_t inline_uniform_data[inline_uniform_data_size];
     };
 
     // immediately followed by `set_count` object_id descriptor-set ids. Bind point is graphics.
@@ -2213,7 +2216,7 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(cmd_set_dynamic_u32_request) == 16, "wire layout drift");
     static_assert(sizeof(descriptor_set_layout_binding) == 20, "wire layout drift");
     static_assert(sizeof(get_descriptor_set_layout_support_request) == 16, "wire layout drift");
-    static_assert(sizeof(descriptor_set_layout_support_response) == 8, "wire layout drift");
+    static_assert(sizeof(descriptor_set_layout_support_response) == 12, "wire layout drift");
     static_assert(sizeof(cmd_bind_descriptor_sets_request) == 32, "wire layout drift");
     static_assert(sizeof(create_sampler_request) == 64, "wire layout drift");
     static_assert(sizeof(enumerate_device_extension_properties_request) == 16, "wire layout drift");

--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -16,7 +16,7 @@ namespace sogen::gpu_bridge
     // Identifies a valid bridge and lets the guest detect a host that speaks a different
     // protocol revision before issuing any further commands.
     inline constexpr uint32_t protocol_magic = 0x55504753; // 'SGPU'
-    inline constexpr uint32_t protocol_version = 28;
+    inline constexpr uint32_t protocol_version = 30;
 
     // Windows IOCTL encoding: CTL_CODE(DeviceType, Function, Method, Access).
     //   value = (DeviceType << 16) | (Access << 14) | (Function << 2) | Method
@@ -872,6 +872,8 @@ namespace sogen::gpu_bridge
         object_id device;
         uint64_t size; // VkDeviceSize allocationSize
         uint32_t memory_type_index;
+        uint32_t flags;       // VkMemoryAllocateFlags
+        uint32_t device_mask; // VkMemoryAllocateFlagsInfo::deviceMask
         uint32_t reserved;
     };
 
@@ -1333,7 +1335,7 @@ namespace sogen::gpu_bridge
         object_id queue;
         object_id swapchain;
         uint32_t image_index;
-        uint32_t reserved;
+        uint32_t wait_semaphore_count;
     };
 
     // Shared output for the "create a device child" commands below (one new object id).
@@ -2001,6 +2003,7 @@ namespace sogen::gpu_bridge
         uint32_t descriptor_type;  // VkDescriptorType
         uint32_t descriptor_count; // array size (1 for a scalar binding)
         uint32_t stage_flags;      // VkShaderStageFlags
+        uint32_t binding_flags;    // VkDescriptorBindingFlags
     };
 
     // ioctl_create_descriptor_set_layout: in header immediately followed by `binding_count`
@@ -2009,18 +2012,15 @@ namespace sogen::gpu_bridge
     {
         object_id device;
         uint32_t binding_count;
-        uint32_t reserved;
+        uint32_t flags; // VkDescriptorSetLayoutCreateFlags
         // descriptor_set_layout_binding bindings[binding_count];
     };
 
-    // A separate query payload deliberately preserves the existing create-layout wire format. The bridge
-    // only evaluates the subset it can also create faithfully: flags == 0, no input pNext structures, and
-    // no immutable samplers. More advanced layouts are rejected conservatively by the guest shim.
     struct get_descriptor_set_layout_support_request
     {
         object_id device;
         uint32_t binding_count;
-        uint32_t reserved;
+        uint32_t flags; // VkDescriptorSetLayoutCreateFlags
         // descriptor_set_layout_binding bindings[binding_count];
     };
 
@@ -2044,7 +2044,8 @@ namespace sogen::gpu_bridge
         object_id device;
         uint32_t max_sets;
         uint32_t pool_size_count;
-        uint32_t reserved;
+        uint32_t flags; // VkDescriptorPoolCreateFlags
+        uint32_t max_inline_uniform_block_bindings;
         // descriptor_pool_size pool_sizes[pool_size_count];
     };
 
@@ -2157,7 +2158,7 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(object_id) == 8 && alignof(object_id) == 8, "object_id must be a portable 64-bit value");
     static_assert(sizeof(command_record_header) == 8, "wire layout drift");
     static_assert(sizeof(version_response) == 8, "wire layout drift");
-    static_assert(sizeof(allocate_memory_request) == 24, "wire layout drift");
+    static_assert(sizeof(allocate_memory_request) == 32, "wire layout drift");
     static_assert(sizeof(bind_buffer_memory_request) == 32, "wire layout drift");
     static_assert(sizeof(cmd_draw_request) == 24, "wire layout drift");
     static_assert(sizeof(cmd_bind_pipeline_request) == 24, "wire layout drift");
@@ -2210,7 +2211,7 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(cmd_set_stencil_request) == 24, "wire layout drift");
     static_assert(sizeof(cmd_set_stencil_op_request) == 32, "wire layout drift");
     static_assert(sizeof(cmd_set_dynamic_u32_request) == 16, "wire layout drift");
-    static_assert(sizeof(descriptor_set_layout_binding) == 16, "wire layout drift");
+    static_assert(sizeof(descriptor_set_layout_binding) == 20, "wire layout drift");
     static_assert(sizeof(get_descriptor_set_layout_support_request) == 16, "wire layout drift");
     static_assert(sizeof(descriptor_set_layout_support_response) == 8, "wire layout drift");
     static_assert(sizeof(cmd_bind_descriptor_sets_request) == 32, "wire layout drift");

--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -16,7 +16,7 @@ namespace sogen::gpu_bridge
     // Identifies a valid bridge and lets the guest detect a host that speaks a different
     // protocol revision before issuing any further commands.
     inline constexpr uint32_t protocol_magic = 0x55504753; // 'SGPU'
-    inline constexpr uint32_t protocol_version = 30;
+    inline constexpr uint32_t protocol_version = 29;
 
     // Windows IOCTL encoding: CTL_CODE(DeviceType, Function, Method, Access).
     //   value = (DeviceType << 16) | (Access << 14) | (Function << 2) | Method
@@ -2170,6 +2170,7 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(cmd_clear_depth_stencil_image_request) == 56, "wire layout drift");
     static_assert(sizeof(get_image_subresource_layout_request) == 32, "wire layout drift");
     static_assert(sizeof(get_image_subresource_layout_response) == 48, "wire layout drift");
+    static_assert(sizeof(queue_present_request) == 24, "wire layout drift");
     static_assert(sizeof(create_buffer_view_request) == 40, "wire layout drift");
     static_assert(sizeof(create_shader_module_request) == 16, "wire layout drift");
     static_assert(sizeof(vertex_input_divisor) == 8, "wire layout drift");
@@ -2186,6 +2187,8 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(cmd_write_timestamp2_request) == 32, "wire layout drift");
     static_assert(sizeof(cmd_write_timestamp_request) == 24, "wire layout drift");
     static_assert(sizeof(cmd_copy_query_pool_results_request) == 56, "wire layout drift");
+    static_assert(sizeof(create_descriptor_pool_request) == 24, "wire layout drift");
+    static_assert(sizeof(allocate_descriptor_sets_request) == 24, "wire layout drift");
     static_assert(sizeof(cmd_draw_indexed_indirect_request) == 32, "wire layout drift");
     static_assert(sizeof(cmd_draw_indexed_indirect_count_request) == 48, "wire layout drift");
     static_assert(sizeof(cmd_draw_indirect_request) == 32, "wire layout drift");

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -1373,6 +1373,16 @@ extern "C"
         request.device = to_object_id(device);
         request.size = pAllocateInfo->allocationSize;
         request.memory_type_index = pAllocateInfo->memoryTypeIndex;
+        for (auto* next = static_cast<const VkBaseInStructure*>(pAllocateInfo->pNext); next; next = next->pNext)
+        {
+            if (next->sType == VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO)
+            {
+                const auto* flags = reinterpret_cast<const VkMemoryAllocateFlagsInfo*>(next);
+                request.flags = flags->flags;
+                request.device_mask = flags->deviceMask;
+                break;
+            }
+        }
 
         gb::allocate_memory_response response{};
         if (!bridge_call(gb::ioctl_allocate_memory, &request, sizeof(request), &response, sizeof(response)))
@@ -3818,13 +3828,23 @@ extern "C"
         VkResult overall = VK_SUCCESS;
         for (uint32_t i = 0; i < pPresentInfo->swapchainCount; ++i)
         {
-            gb::queue_present_request request{};
-            request.queue = to_object_id(queue);
-            request.swapchain = to_object_id(pPresentInfo->pSwapchains[i]);
-            request.image_index = pPresentInfo->pImageIndices[i];
+            const uint32_t wait_count = i == 0 ? pPresentInfo->waitSemaphoreCount : 0;
+            std::vector<uint8_t> message(sizeof(gb::queue_present_request) + static_cast<size_t>(wait_count) * sizeof(gb::object_id));
+            auto* request = reinterpret_cast<gb::queue_present_request*>(message.data());
+            request->queue = to_object_id(queue);
+            request->swapchain = to_object_id(pPresentInfo->pSwapchains[i]);
+            request->image_index = pPresentInfo->pImageIndices[i];
+            request->wait_semaphore_count = wait_count;
+
+            auto* waits = reinterpret_cast<gb::object_id*>(message.data() + sizeof(*request));
+            for (uint32_t wait_index = 0; wait_index < wait_count; ++wait_index)
+            {
+                waits[wait_index] = to_object_id(pPresentInfo->pWaitSemaphores[wait_index]);
+            }
 
             gb::result_response response{};
-            const bool ok = bridge_call(gb::ioctl_queue_present, &request, sizeof(request), &response, sizeof(response));
+            const bool ok =
+                bridge_call(gb::ioctl_queue_present, message.data(), static_cast<DWORD>(message.size()), &response, sizeof(response));
             const VkResult result = ok ? static_cast<VkResult>(response.vk_result) : VK_ERROR_INITIALIZATION_FAILED;
             if (pPresentInfo->pResults)
             {
@@ -4028,6 +4048,17 @@ extern "C"
         gb::create_descriptor_set_layout_request header{};
         header.device = to_object_id(device);
         header.binding_count = pCreateInfo->bindingCount;
+        header.flags = pCreateInfo->flags;
+
+        const VkDescriptorSetLayoutBindingFlagsCreateInfo* binding_flags = nullptr;
+        for (auto* next = static_cast<const VkBaseInStructure*>(pCreateInfo->pNext); next; next = next->pNext)
+        {
+            if (next->sType == VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO)
+            {
+                binding_flags = reinterpret_cast<const VkDescriptorSetLayoutBindingFlagsCreateInfo*>(next);
+                break;
+            }
+        }
 
         std::vector<uint8_t> message(sizeof(header) +
                                      static_cast<size_t>(header.binding_count) * sizeof(gb::descriptor_set_layout_binding));
@@ -4040,6 +4071,10 @@ extern "C"
             wire.descriptor_type = static_cast<uint32_t>(b.descriptorType);
             wire.descriptor_count = b.descriptorCount;
             wire.stage_flags = b.stageFlags;
+            if (binding_flags && i < binding_flags->bindingCount)
+            {
+                wire.binding_flags = binding_flags->pBindingFlags[i];
+            }
             std::memcpy(message.data() + sizeof(header) + i * sizeof(wire), &wire, sizeof(wire));
         }
 
@@ -4073,6 +4108,16 @@ extern "C"
         header.device = to_object_id(device);
         header.max_sets = pCreateInfo->maxSets;
         header.pool_size_count = pCreateInfo->poolSizeCount;
+        header.flags = pCreateInfo->flags;
+        for (auto* next = static_cast<const VkBaseInStructure*>(pCreateInfo->pNext); next; next = next->pNext)
+        {
+            if (next->sType == VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO)
+            {
+                const auto* inline_uniform_blocks = reinterpret_cast<const VkDescriptorPoolInlineUniformBlockCreateInfo*>(next);
+                header.max_inline_uniform_block_bindings = inline_uniform_blocks->maxInlineUniformBlockBindings;
+                break;
+            }
+        }
 
         std::vector<uint8_t> message(sizeof(header) + static_cast<size_t>(header.pool_size_count) * sizeof(gb::descriptor_pool_size));
         std::memcpy(message.data(), &header, sizeof(header));
@@ -4426,10 +4471,17 @@ extern "C"
             return;
         }
 
-        // Keep this query aligned with what vkCreateDescriptorSetLayout currently marshals. Layout flags,
-        // input pNext structures (including binding flags), and immutable samplers are not represented by
-        // the create command, so claiming support for them would recreate the original false positive.
-        if (pCreateInfo->flags != 0 || pCreateInfo->pNext != nullptr)
+        const VkDescriptorSetLayoutBindingFlagsCreateInfo* binding_flags = nullptr;
+        for (auto* next = static_cast<const VkBaseInStructure*>(pCreateInfo->pNext); next; next = next->pNext)
+        {
+            if (next->sType != VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO)
+            {
+                return;
+            }
+            binding_flags = reinterpret_cast<const VkDescriptorSetLayoutBindingFlagsCreateInfo*>(next);
+        }
+        if (binding_flags && (binding_flags->bindingCount != pCreateInfo->bindingCount ||
+                              (binding_flags->bindingCount != 0 && !binding_flags->pBindingFlags)))
         {
             return;
         }
@@ -4444,6 +4496,7 @@ extern "C"
         gb::get_descriptor_set_layout_support_request header{};
         header.device = to_object_id(device);
         header.binding_count = pCreateInfo->bindingCount;
+        header.flags = pCreateInfo->flags;
         if (header.binding_count > (static_cast<size_t>(UINT32_MAX) - sizeof(header)) / sizeof(gb::descriptor_set_layout_binding))
         {
             return;
@@ -4455,12 +4508,16 @@ extern "C"
         for (uint32_t i = 0; i < header.binding_count; ++i)
         {
             const VkDescriptorSetLayoutBinding& b = pCreateInfo->pBindings[i];
-            const gb::descriptor_set_layout_binding wire{
+            gb::descriptor_set_layout_binding wire{
                 .binding = b.binding,
                 .descriptor_type = static_cast<uint32_t>(b.descriptorType),
                 .descriptor_count = b.descriptorCount,
                 .stage_flags = b.stageFlags,
             };
+            if (binding_flags)
+            {
+                wire.binding_flags = binding_flags->pBindingFlags[i];
+            }
             std::memcpy(message.data() + sizeof(header) + static_cast<size_t>(i) * sizeof(wire), &wire, sizeof(wire));
         }
 

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -1373,7 +1373,7 @@ extern "C"
         request.device = to_object_id(device);
         request.size = pAllocateInfo->allocationSize;
         request.memory_type_index = pAllocateInfo->memoryTypeIndex;
-        for (auto* next = static_cast<const VkBaseInStructure*>(pAllocateInfo->pNext); next; next = next->pNext)
+        for (const auto* next = static_cast<const VkBaseInStructure*>(pAllocateInfo->pNext); next; next = next->pNext)
         {
             if (next->sType == VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO)
             {
@@ -4051,7 +4051,7 @@ extern "C"
         header.flags = pCreateInfo->flags;
 
         const VkDescriptorSetLayoutBindingFlagsCreateInfo* binding_flags = nullptr;
-        for (auto* next = static_cast<const VkBaseInStructure*>(pCreateInfo->pNext); next; next = next->pNext)
+        for (const auto* next = static_cast<const VkBaseInStructure*>(pCreateInfo->pNext); next; next = next->pNext)
         {
             if (next->sType == VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO)
             {
@@ -4109,7 +4109,7 @@ extern "C"
         header.max_sets = pCreateInfo->maxSets;
         header.pool_size_count = pCreateInfo->poolSizeCount;
         header.flags = pCreateInfo->flags;
-        for (auto* next = static_cast<const VkBaseInStructure*>(pCreateInfo->pNext); next; next = next->pNext)
+        for (const auto* next = static_cast<const VkBaseInStructure*>(pCreateInfo->pNext); next; next = next->pNext)
         {
             if (next->sType == VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO)
             {
@@ -4170,17 +4170,41 @@ extern "C"
                                                                                   VkDescriptorSet* pDescriptorSets)
     {
         const uint32_t count = pAllocateInfo->descriptorSetCount;
+        const VkDescriptorSetVariableDescriptorCountAllocateInfo* variable_descriptor_counts = nullptr;
+        for (const auto* next = static_cast<const VkBaseInStructure*>(pAllocateInfo->pNext); next; next = next->pNext)
+        {
+            if (next->sType == VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO)
+            {
+                variable_descriptor_counts = reinterpret_cast<const VkDescriptorSetVariableDescriptorCountAllocateInfo*>(next);
+                break;
+            }
+        }
+        const uint32_t variable_descriptor_count_count = variable_descriptor_counts ? variable_descriptor_counts->descriptorSetCount : 0;
+        if (variable_descriptor_count_count != 0 &&
+            (variable_descriptor_count_count != count || !variable_descriptor_counts->pDescriptorCounts))
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
         gb::allocate_descriptor_sets_request header{};
         header.device = to_object_id(device);
         header.descriptor_pool = to_object_id(pAllocateInfo->descriptorPool);
         header.set_count = count;
+        header.variable_descriptor_count_count = variable_descriptor_count_count;
 
-        std::vector<uint8_t> message(sizeof(header) + static_cast<size_t>(count) * sizeof(gb::object_id));
+        const size_t layouts_size = static_cast<size_t>(count) * sizeof(gb::object_id);
+        const size_t variable_counts_size = static_cast<size_t>(header.variable_descriptor_count_count) * sizeof(uint32_t);
+        std::vector<uint8_t> message(sizeof(header) + layouts_size + variable_counts_size);
         std::memcpy(message.data(), &header, sizeof(header));
         for (uint32_t i = 0; i < count; ++i)
         {
             const gb::object_id id = to_object_id(pAllocateInfo->pSetLayouts[i]);
             std::memcpy(message.data() + sizeof(header) + i * sizeof(id), &id, sizeof(id));
+        }
+        if (variable_counts_size != 0)
+        {
+            std::memcpy(message.data() + sizeof(header) + layouts_size, variable_descriptor_counts->pDescriptorCounts,
+                        variable_counts_size);
         }
 
         std::vector<uint8_t> out(sizeof(gb::allocate_descriptor_sets_response) + static_cast<size_t>(count) * sizeof(gb::object_id));
@@ -4225,12 +4249,47 @@ extern "C"
                                                                             const VkWriteDescriptorSet* pDescriptorWrites, uint32_t,
                                                                             const VkCopyDescriptorSet*)
     {
-        // Descriptor copies are not modeled; only writes are forwarded. Each VkWriteDescriptorSet is
-        // flattened to `descriptorCount` single-descriptor wire writes.
+        // Descriptor copies are not modeled; only writes are forwarded. Non-inline writes are flattened
+        // to `descriptorCount` single-descriptor wire writes.
         std::vector<gb::descriptor_write> writes;
+        std::vector<uint8_t> inline_uniform_data;
         for (uint32_t w = 0; w < descriptorWriteCount; ++w)
         {
             const VkWriteDescriptorSet& src = pDescriptorWrites[w];
+            if (src.descriptorType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK)
+            {
+                const VkWriteDescriptorSetInlineUniformBlock* inline_uniform_block = nullptr;
+                for (const auto* next = static_cast<const VkBaseInStructure*>(src.pNext); next; next = next->pNext)
+                {
+                    if (next->sType == VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK)
+                    {
+                        inline_uniform_block = reinterpret_cast<const VkWriteDescriptorSetInlineUniformBlock*>(next);
+                        break;
+                    }
+                }
+                if (!inline_uniform_block || inline_uniform_block->dataSize != src.descriptorCount ||
+                    (inline_uniform_block->dataSize != 0 && !inline_uniform_block->pData) ||
+                    inline_uniform_data.size() > UINT32_MAX - inline_uniform_block->dataSize)
+                {
+                    continue;
+                }
+
+                gb::descriptor_write wire{};
+                wire.dst_set = to_object_id(src.dstSet);
+                wire.dst_binding = src.dstBinding;
+                wire.dst_array_element = src.dstArrayElement;
+                wire.descriptor_type = static_cast<uint32_t>(src.descriptorType);
+                wire.inline_uniform_data_offset = static_cast<uint32_t>(inline_uniform_data.size());
+                wire.inline_uniform_data_size = inline_uniform_block->dataSize;
+                if (inline_uniform_block->dataSize != 0)
+                {
+                    const auto* data = static_cast<const uint8_t*>(inline_uniform_block->pData);
+                    inline_uniform_data.insert(inline_uniform_data.end(), data, data + inline_uniform_block->dataSize);
+                }
+                writes.push_back(wire);
+                continue;
+            }
+
             for (uint32_t e = 0; e < src.descriptorCount; ++e)
             {
                 gb::descriptor_write wire{};
@@ -4261,6 +4320,7 @@ extern "C"
         gb::update_descriptor_sets_request header{};
         header.device = to_object_id(device);
         header.write_count = static_cast<uint32_t>(writes.size());
+        header.inline_uniform_data_size = static_cast<uint32_t>(inline_uniform_data.size());
 
         // Append to the pending batch instead of issuing an IOCTL now (drained before the next bridge call).
         const auto* header_bytes = reinterpret_cast<const uint8_t*>(&header);
@@ -4272,6 +4332,7 @@ extern "C"
             g_pending_descriptor_updates.insert(g_pending_descriptor_updates.end(), write_bytes,
                                                 write_bytes + writes.size() * sizeof(gb::descriptor_write));
         }
+        g_pending_descriptor_updates.insert(g_pending_descriptor_updates.end(), inline_uniform_data.begin(), inline_uniform_data.end());
     }
 
     // Descriptor update templates are lowered entirely inside the shim: the template definition is kept
@@ -4327,10 +4388,12 @@ extern "C"
         std::vector<std::vector<VkDescriptorImageInfo>> image_infos;
         std::vector<std::vector<VkDescriptorBufferInfo>> buffer_infos;
         std::vector<std::vector<VkBufferView>> texel_views;
+        std::vector<VkWriteDescriptorSetInlineUniformBlock> inline_uniform_blocks;
         writes.reserve(tmpl->entries.size());
         image_infos.reserve(tmpl->entries.size());
         buffer_infos.reserve(tmpl->entries.size());
         texel_views.reserve(tmpl->entries.size());
+        inline_uniform_blocks.reserve(tmpl->entries.size());
 
         const auto* base = static_cast<const uint8_t*>(pData);
         for (const auto& entry : tmpl->entries)
@@ -4343,7 +4406,15 @@ extern "C"
             write.descriptorCount = entry.descriptorCount;
             write.descriptorType = entry.descriptorType;
 
-            if (is_image_descriptor(entry.descriptorType))
+            if (entry.descriptorType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK)
+            {
+                auto& inline_uniform_block = inline_uniform_blocks.emplace_back();
+                inline_uniform_block.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK;
+                inline_uniform_block.dataSize = entry.descriptorCount;
+                inline_uniform_block.pData = base + entry.offset;
+                write.pNext = &inline_uniform_block;
+            }
+            else if (is_image_descriptor(entry.descriptorType))
             {
                 auto& arr = image_infos.emplace_back();
                 arr.reserve(entry.descriptorCount);
@@ -4453,12 +4524,13 @@ extern "C"
         // Initialize the one output-chain structure relevant to descriptor-layout support. Unknown output
         // structures make the query unsupported rather than leaving partially initialized data behind.
         bool unsupported_output_chain = false;
+        VkDescriptorSetVariableDescriptorCountLayoutSupport* variable_support = nullptr;
         for (auto* base = static_cast<VkBaseOutStructure*>(pSupport->pNext); base != nullptr; base = base->pNext)
         {
             if (base->sType == VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT)
             {
-                auto* const variable = reinterpret_cast<VkDescriptorSetVariableDescriptorCountLayoutSupport*>(base);
-                variable->maxVariableDescriptorCount = 0;
+                variable_support = reinterpret_cast<VkDescriptorSetVariableDescriptorCountLayoutSupport*>(base);
+                variable_support->maxVariableDescriptorCount = 0;
             }
             else
             {
@@ -4472,7 +4544,7 @@ extern "C"
         }
 
         const VkDescriptorSetLayoutBindingFlagsCreateInfo* binding_flags = nullptr;
-        for (auto* next = static_cast<const VkBaseInStructure*>(pCreateInfo->pNext); next; next = next->pNext)
+        for (const auto* next = static_cast<const VkBaseInStructure*>(pCreateInfo->pNext); next; next = next->pNext)
         {
             if (next->sType != VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO)
             {
@@ -4480,8 +4552,8 @@ extern "C"
             }
             binding_flags = reinterpret_cast<const VkDescriptorSetLayoutBindingFlagsCreateInfo*>(next);
         }
-        if (binding_flags && (binding_flags->bindingCount != pCreateInfo->bindingCount ||
-                              (binding_flags->bindingCount != 0 && !binding_flags->pBindingFlags)))
+        if (binding_flags && binding_flags->bindingCount != 0 &&
+            (binding_flags->bindingCount != pCreateInfo->bindingCount || !binding_flags->pBindingFlags))
         {
             return;
         }
@@ -4513,8 +4585,9 @@ extern "C"
                 .descriptor_type = static_cast<uint32_t>(b.descriptorType),
                 .descriptor_count = b.descriptorCount,
                 .stage_flags = b.stageFlags,
+                .binding_flags = 0,
             };
-            if (binding_flags)
+            if (binding_flags && binding_flags->bindingCount != 0)
             {
                 wire.binding_flags = binding_flags->pBindingFlags[i];
             }
@@ -4530,6 +4603,10 @@ extern "C"
         }
 
         pSupport->supported = response.supported ? VK_TRUE : VK_FALSE;
+        if (variable_support)
+        {
+            variable_support->maxVariableDescriptorCount = response.max_variable_descriptor_count;
+        }
     }
 
     __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkGetDescriptorSetLayoutSupportKHR(VkDevice device,

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -2383,8 +2383,8 @@ namespace sogen
                 }
 
                 gpu_bridge::descriptor_set_layout_support_response response{};
-                response.vk_result =
-                    this->vulkan_.get_descriptor_set_layout_support(request.device, request.flags, bindings, response.supported);
+                response.vk_result = this->vulkan_.get_descriptor_set_layout_support(
+                    request.device, request.flags, bindings, response.supported, response.max_variable_descriptor_count);
                 return write_output(win_emu, context, response);
             }
 
@@ -2473,13 +2473,25 @@ namespace sogen
                     return STATUS_INVALID_PARAMETER;
                 }
 
+                if (request.variable_descriptor_count_count != 0 && request.variable_descriptor_count_count != request.set_count)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+                std::vector<uint32_t> variable_descriptor_counts;
+                const size_t variable_counts_offset = sizeof(request_t) + set_layouts.size() * sizeof(gpu_bridge::object_id);
+                if (!read_trailing_array(win_emu, context, variable_counts_offset, request.variable_descriptor_count_count,
+                                         variable_descriptor_counts))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
                 const auto array_capacity = static_cast<uint32_t>(
                     std::min<uint64_t>((context.output_buffer_length - sizeof(response_t)) / sizeof(gpu_bridge::object_id),
                                        max_array_readback_bytes / sizeof(gpu_bridge::object_id)));
                 std::vector<uint64_t> ids(std::min(request.set_count, array_capacity));
                 uint32_t count = 0;
-                const int32_t result =
-                    this->vulkan_.allocate_descriptor_sets(request.device, request.descriptor_pool, set_layouts, std::span{ids}, count);
+                const int32_t result = this->vulkan_.allocate_descriptor_sets(request.device, request.descriptor_pool, set_layouts,
+                                                                              variable_descriptor_counts, std::span{ids}, count);
 
                 emulator_object<response_t>{win_emu.emu(), context.output_buffer}.write(response_t{.vk_result = result, .count = count});
 
@@ -2539,8 +2551,8 @@ namespace sogen
             static constexpr size_t max_memory_transfer_bytes = size_t{256} * 1024 * 1024;
 #endif
 
-            // Applies one update_descriptor_sets_request blob (header + write_count descriptor_write records) and
-            // advances `offset` past it. Shared by the single and coalesced-batch IOCTLs.
+            // Applies one update_descriptor_sets_request blob and advances `offset` past it. Shared by the
+            // single and coalesced-batch IOCTLs.
             int32_t apply_update_descriptor_sets(const std::byte* data, size_t size, size_t& offset)
             {
                 constexpr int32_t vk_error_initialization_failed = -3; // VK_ERROR_INITIALIZATION_FAILED (no vulkan.h here)
@@ -2555,8 +2567,13 @@ namespace sogen
                 std::memcpy(&request, data + offset, sizeof(request));
                 offset += sizeof(request);
 
+                if (request.write_count > (size - offset) / sizeof(gpu_bridge::descriptor_write))
+                {
+                    return vk_error_initialization_failed;
+                }
                 const size_t writes_bytes = static_cast<size_t>(request.write_count) * sizeof(gpu_bridge::descriptor_write);
-                if (size - offset < writes_bytes)
+                const size_t inline_uniform_data_offset = offset + writes_bytes;
+                if (request.inline_uniform_data_size > size - inline_uniform_data_offset)
                 {
                     return vk_error_initialization_failed;
                 }
@@ -2568,6 +2585,11 @@ namespace sogen
                     gpu_bridge::descriptor_write w{};
                     std::memcpy(&w, data + write_offset, sizeof(w));
                     write_offset += sizeof(w);
+                    if (w.inline_uniform_data_offset > request.inline_uniform_data_size ||
+                        w.inline_uniform_data_size > request.inline_uniform_data_size - w.inline_uniform_data_offset)
+                    {
+                        return vk_error_initialization_failed;
+                    }
                     write = {.dst_set = w.dst_set,
                              .dst_binding = w.dst_binding,
                              .dst_array_element = w.dst_array_element,
@@ -2577,9 +2599,11 @@ namespace sogen
                              .range = w.range,
                              .sampler = w.sampler,
                              .image_view = w.image_view,
-                             .image_layout = w.image_layout};
+                             .image_layout = w.image_layout,
+                             .inline_uniform_data = std::span<const std::byte>{
+                                 data + inline_uniform_data_offset + w.inline_uniform_data_offset, w.inline_uniform_data_size}};
                 }
-                offset += writes_bytes;
+                offset = inline_uniform_data_offset + request.inline_uniform_data_size;
                 return this->vulkan_.update_descriptor_sets(request.device, writes);
             }
 

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -1399,7 +1399,8 @@ namespace sogen
                 }
 
                 uint64_t memory = gpu_bridge::null_object;
-                const int32_t result = this->vulkan_.allocate_memory(request.device, request.size, request.memory_type_index, memory);
+                const int32_t result = this->vulkan_.allocate_memory(request.device, request.size, request.memory_type_index, request.flags,
+                                                                     request.device_mask, memory);
                 return write_output(win_emu, context,
                                     gpu_bridge::allocate_memory_response{.vk_result = result, .reserved = 0, .memory = memory});
             }
@@ -1883,13 +1884,18 @@ namespace sogen
                 {
                     return STATUS_INVALID_PARAMETER;
                 }
+                std::vector<gpu_bridge::object_id> wait_semaphores;
+                if (!read_trailing_array(win_emu, context, sizeof(request), request.wait_semaphore_count, wait_semaphores))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
 
                 std::vector<std::byte> pixels;
                 uint32_t width = 0;
                 uint32_t height = 0;
                 uint64_t hwnd_value = 0;
-                const int32_t result =
-                    this->vulkan_.queue_present(request.queue, request.swapchain, request.image_index, pixels, width, height, hwnd_value);
+                const int32_t result = this->vulkan_.queue_present(request.queue, request.swapchain, request.image_index, wait_semaphores,
+                                                                   pixels, width, height, hwnd_value);
 
                 // Hand the freshly read-back pixels to the guest window through the UI backend (the same
                 // seam GDI EndPaint uses). The swapchain is B8G8R8A8, matching bgra8, so no swizzle.
@@ -2338,12 +2344,13 @@ namespace sogen
                     *binding_out = {.binding = entry.binding,
                                     .descriptor_type = entry.descriptor_type,
                                     .descriptor_count = entry.descriptor_count,
-                                    .stage_flags = entry.stage_flags};
+                                    .stage_flags = entry.stage_flags,
+                                    .binding_flags = entry.binding_flags};
                     ++binding_out;
                 }
 
                 uint64_t layout = gpu_bridge::null_object;
-                const int32_t result = this->vulkan_.create_descriptor_set_layout(request.device, bindings, layout);
+                const int32_t result = this->vulkan_.create_descriptor_set_layout(request.device, request.flags, bindings, layout);
                 return write_output(win_emu, context, gpu_bridge::object_response{.vk_result = result, .reserved = 0, .object = layout});
             }
 
@@ -2370,12 +2377,14 @@ namespace sogen
                     *binding_out = {.binding = entry.binding,
                                     .descriptor_type = entry.descriptor_type,
                                     .descriptor_count = entry.descriptor_count,
-                                    .stage_flags = entry.stage_flags};
+                                    .stage_flags = entry.stage_flags,
+                                    .binding_flags = entry.binding_flags};
                     ++binding_out;
                 }
 
                 gpu_bridge::descriptor_set_layout_support_response response{};
-                response.vk_result = this->vulkan_.get_descriptor_set_layout_support(request.device, bindings, response.supported);
+                response.vk_result =
+                    this->vulkan_.get_descriptor_set_layout_support(request.device, request.flags, bindings, response.supported);
                 return write_output(win_emu, context, response);
             }
 
@@ -2415,7 +2424,8 @@ namespace sogen
                 }
 
                 uint64_t pool = gpu_bridge::null_object;
-                const int32_t result = this->vulkan_.create_descriptor_pool(request.device, request.max_sets, sizes, pool);
+                const int32_t result = this->vulkan_.create_descriptor_pool(request.device, request.max_sets, request.flags,
+                                                                            request.max_inline_uniform_block_bindings, sizes, pool);
                 return write_output(win_emu, context, gpu_bridge::object_response{.vk_result = result, .reserved = 0, .object = pool});
             }
 

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -2856,7 +2856,8 @@ namespace sogen
         return VK_SUCCESS;
     }
 
-    int32_t vulkan_host::allocate_memory(uint64_t device, uint64_t size, uint32_t memory_type_index, uint64_t& out_memory)
+    int32_t vulkan_host::allocate_memory(uint64_t device, uint64_t size, uint32_t memory_type_index, uint32_t flags, uint32_t device_mask,
+                                         uint64_t& out_memory)
     {
         out_memory = 0;
 
@@ -2886,6 +2887,15 @@ namespace sogen
         info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
         info.allocationSize = aligned_size;
         info.memoryTypeIndex = this->impl_->substitute_cached_memory_type(dev->second, memory_type_index);
+
+        VkMemoryAllocateFlagsInfo flags_info{};
+        if (flags != 0 || device_mask != 0)
+        {
+            flags_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO;
+            flags_info.flags = flags;
+            flags_info.deviceMask = device_mask;
+            info.pNext = &flags_info;
+        }
 
         VkDeviceMemory memory{};
         const VkResult result = dev->second.allocate_memory(dev->second.handle, &info, nullptr, &memory);
@@ -4078,7 +4088,8 @@ namespace sogen
         return VK_SUCCESS;
     }
 
-    int32_t vulkan_host::queue_present(uint64_t queue, uint64_t swapchain, uint32_t image_index, std::vector<std::byte>& out_pixels,
+    int32_t vulkan_host::queue_present(uint64_t queue, uint64_t swapchain, uint32_t image_index,
+                                       const std::vector<uint64_t>& wait_semaphores, std::vector<std::byte>& out_pixels,
                                        uint32_t& out_width, uint32_t& out_height, uint64_t& out_hwnd)
     {
         out_pixels.clear();
@@ -4112,6 +4123,18 @@ namespace sogen
             !dev.reset_fences)
         {
             return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        std::vector<VkSemaphore> wait_handles;
+        wait_handles.reserve(wait_semaphores.size());
+        for (const uint64_t semaphore : wait_semaphores)
+        {
+            const auto semaphore_it = this->impl_->semaphores.find(semaphore);
+            if (semaphore_it == this->impl_->semaphores.end() || semaphore_it->second.device_id != sc.device_id)
+            {
+                return VK_ERROR_INITIALIZATION_FAILED;
+            }
+            wait_handles.push_back(semaphore_it->second.handle);
         }
 
         // The work loop normally collects completed readbacks. If another present arrives first, reclaim
@@ -4176,6 +4199,10 @@ namespace sogen
 
         VkSubmitInfo submit{};
         submit.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        std::vector<VkPipelineStageFlags> wait_stages(wait_handles.size(), VK_PIPELINE_STAGE_TRANSFER_BIT);
+        submit.waitSemaphoreCount = static_cast<uint32_t>(wait_handles.size());
+        submit.pWaitSemaphores = wait_handles.data();
+        submit.pWaitDstStageMask = wait_stages.data();
         submit.commandBufferCount = 1;
         submit.pCommandBuffers = &sc.present_cmd;
         if (dev.queue_submit(queue_it->second.handle, 1, &submit, sc.present_fence) != VK_SUCCESS)
@@ -4842,7 +4869,8 @@ namespace sogen
         this->impl_->pipeline_layouts.erase(it);
     }
 
-    int32_t vulkan_host::create_descriptor_set_layout(uint64_t device, std::span<const descriptor_binding> bindings, uint64_t& out_layout)
+    int32_t vulkan_host::create_descriptor_set_layout(uint64_t device, uint32_t flags, std::span<const descriptor_binding> bindings,
+                                                      uint64_t& out_layout)
     {
         out_layout = 0;
         const auto dev = this->impl_->devices.find(device);
@@ -4852,7 +4880,9 @@ namespace sogen
         }
 
         std::vector<VkDescriptorSetLayoutBinding> vk_bindings;
+        std::vector<VkDescriptorBindingFlags> vk_binding_flags;
         vk_bindings.reserve(bindings.size());
+        vk_binding_flags.reserve(bindings.size());
         for (const descriptor_binding& b : bindings)
         {
             VkDescriptorSetLayoutBinding vb{};
@@ -4861,10 +4891,18 @@ namespace sogen
             vb.descriptorCount = b.descriptor_count;
             vb.stageFlags = b.stage_flags;
             vk_bindings.push_back(vb);
+            vk_binding_flags.push_back(b.binding_flags);
         }
+
+        VkDescriptorSetLayoutBindingFlagsCreateInfo binding_flags{};
+        binding_flags.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO;
+        binding_flags.bindingCount = static_cast<uint32_t>(vk_binding_flags.size());
+        binding_flags.pBindingFlags = vk_binding_flags.data();
 
         VkDescriptorSetLayoutCreateInfo info{};
         info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        info.pNext = vk_binding_flags.empty() ? nullptr : &binding_flags;
+        info.flags = flags;
         info.bindingCount = static_cast<uint32_t>(vk_bindings.size());
         info.pBindings = vk_bindings.empty() ? nullptr : vk_bindings.data();
 
@@ -4881,7 +4919,7 @@ namespace sogen
         return VK_SUCCESS;
     }
 
-    int32_t vulkan_host::get_descriptor_set_layout_support(uint64_t device, std::span<const descriptor_binding> bindings,
+    int32_t vulkan_host::get_descriptor_set_layout_support(uint64_t device, uint32_t flags, std::span<const descriptor_binding> bindings,
                                                            uint32_t& supported)
     {
         supported = VK_FALSE;
@@ -4893,7 +4931,9 @@ namespace sogen
         }
 
         std::vector<VkDescriptorSetLayoutBinding> vk_bindings;
+        std::vector<VkDescriptorBindingFlags> vk_binding_flags;
         vk_bindings.reserve(bindings.size());
+        vk_binding_flags.reserve(bindings.size());
         for (const descriptor_binding& b : bindings)
         {
             VkDescriptorSetLayoutBinding vb{};
@@ -4902,10 +4942,18 @@ namespace sogen
             vb.descriptorCount = b.descriptor_count;
             vb.stageFlags = b.stage_flags;
             vk_bindings.push_back(vb);
+            vk_binding_flags.push_back(b.binding_flags);
         }
+
+        VkDescriptorSetLayoutBindingFlagsCreateInfo binding_flags{};
+        binding_flags.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO;
+        binding_flags.bindingCount = static_cast<uint32_t>(vk_binding_flags.size());
+        binding_flags.pBindingFlags = vk_binding_flags.data();
 
         VkDescriptorSetLayoutCreateInfo info{};
         info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        info.pNext = vk_binding_flags.empty() ? nullptr : &binding_flags;
+        info.flags = flags;
         info.bindingCount = static_cast<uint32_t>(vk_bindings.size());
         info.pBindings = vk_bindings.empty() ? nullptr : vk_bindings.data();
 
@@ -4931,7 +4979,8 @@ namespace sogen
         this->impl_->descriptor_set_layouts.erase(it);
     }
 
-    int32_t vulkan_host::create_descriptor_pool(uint64_t device, uint32_t max_sets, std::span<const descriptor_pool_size> sizes,
+    int32_t vulkan_host::create_descriptor_pool(uint64_t device, uint32_t max_sets, uint32_t flags,
+                                                uint32_t max_inline_uniform_block_bindings, std::span<const descriptor_pool_size> sizes,
                                                 uint64_t& out_pool)
     {
         out_pool = 0;
@@ -4950,10 +4999,18 @@ namespace sogen
 
         VkDescriptorPoolCreateInfo info{};
         info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-        info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+        info.flags = flags;
         info.maxSets = max_sets;
         info.poolSizeCount = static_cast<uint32_t>(vk_sizes.size());
         info.pPoolSizes = vk_sizes.empty() ? nullptr : vk_sizes.data();
+
+        VkDescriptorPoolInlineUniformBlockCreateInfo inline_uniform_blocks{};
+        if (max_inline_uniform_block_bindings != 0)
+        {
+            inline_uniform_blocks.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO;
+            inline_uniform_blocks.maxInlineUniformBlockBindings = max_inline_uniform_block_bindings;
+            info.pNext = &inline_uniform_blocks;
+        }
 
         VkDescriptorPool pool{};
         const VkResult result = dev->second.create_descriptor_pool(dev->second.handle, &info, nullptr, &pool);
@@ -5381,9 +5438,13 @@ namespace sogen
         // DXVK sets them per-draw); a render-pass pipeline keeps the baked viewport from width/height.
         VkPipelineViewportStateCreateInfo viewport_state{};
         viewport_state.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
-        viewport_state.viewportCount = 1;
+        const bool viewport_with_count =
+            std::ranges::find(dynamic_states, static_cast<uint32_t>(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT)) != dynamic_states.end();
+        const bool scissor_with_count =
+            std::ranges::find(dynamic_states, static_cast<uint32_t>(VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT)) != dynamic_states.end();
+        viewport_state.viewportCount = viewport_with_count ? 0 : 1;
         viewport_state.pViewports = dynamic_rendering ? nullptr : &viewport;
-        viewport_state.scissorCount = 1;
+        viewport_state.scissorCount = scissor_with_count ? 0 : 1;
         viewport_state.pScissors = dynamic_rendering ? nullptr : &scissor;
 
         // Use the dynamic-state list DXVK declared on the pipeline. It marks vertex-binding stride, cull,

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -4920,9 +4920,10 @@ namespace sogen
     }
 
     int32_t vulkan_host::get_descriptor_set_layout_support(uint64_t device, uint32_t flags, std::span<const descriptor_binding> bindings,
-                                                           uint32_t& supported)
+                                                           uint32_t& supported, uint32_t& max_variable_descriptor_count)
     {
         supported = VK_FALSE;
+        max_variable_descriptor_count = 0;
 
         const auto dev = this->impl_->devices.find(device);
         if (dev == this->impl_->devices.end() || !dev->second.get_descriptor_set_layout_support)
@@ -4959,8 +4960,12 @@ namespace sogen
 
         VkDescriptorSetLayoutSupport support{};
         support.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT;
+        VkDescriptorSetVariableDescriptorCountLayoutSupport variable_support{};
+        variable_support.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT;
+        support.pNext = &variable_support;
         dev->second.get_descriptor_set_layout_support(dev->second.handle, &info, &support);
         supported = support.supported;
+        max_variable_descriptor_count = variable_support.maxVariableDescriptorCount;
         return VK_SUCCESS;
     }
 
@@ -5063,13 +5068,15 @@ namespace sogen
     }
 
     int32_t vulkan_host::allocate_descriptor_sets(uint64_t device, uint64_t pool, std::span<const uint64_t> set_layouts,
-                                                  std::span<uint64_t> out_sets, uint32_t& out_count)
+                                                  std::span<const uint32_t> variable_descriptor_counts, std::span<uint64_t> out_sets,
+                                                  uint32_t& out_count)
     {
         out_count = 0;
         const auto dev = this->impl_->devices.find(device);
         const auto pool_it = this->impl_->descriptor_pools.find(pool);
         if (dev == this->impl_->devices.end() || pool_it == this->impl_->descriptor_pools.end() || pool_it->second.device_id != device ||
-            !dev->second.allocate_descriptor_sets)
+            !dev->second.allocate_descriptor_sets ||
+            (!variable_descriptor_counts.empty() && variable_descriptor_counts.size() != set_layouts.size()))
         {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
@@ -5091,6 +5098,15 @@ namespace sogen
         info.descriptorPool = pool_it->second.handle;
         info.descriptorSetCount = static_cast<uint32_t>(vk_layouts.size());
         info.pSetLayouts = vk_layouts.empty() ? nullptr : vk_layouts.data();
+
+        VkDescriptorSetVariableDescriptorCountAllocateInfo variable_counts{};
+        if (!variable_descriptor_counts.empty())
+        {
+            variable_counts.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO;
+            variable_counts.descriptorSetCount = static_cast<uint32_t>(variable_descriptor_counts.size());
+            variable_counts.pDescriptorCounts = variable_descriptor_counts.data();
+            info.pNext = &variable_counts;
+        }
 
         std::vector<VkDescriptorSet> sets(vk_layouts.size());
         const VkResult result = dev->second.allocate_descriptor_sets(dev->second.handle, &info, sets.data());
@@ -5155,18 +5171,20 @@ namespace sogen
             return VK_ERROR_INITIALIZATION_FAILED;
         }
 
-        // Each write carries exactly one descriptor. Buffer infos and image infos are kept in stable
-        // vectors so the VkWriteDescriptorSet pointers remain valid until the driver call below. This runs
-        // ~100k times/s in heavy scenes, so the buffers are reused (single emulator thread, no reentrancy)
-        // instead of allocated per call.
+        // Buffer infos, image infos and inline-uniform blocks are kept in stable vectors so the
+        // VkWriteDescriptorSet pointers remain valid until the driver call below. This runs ~100k times/s
+        // in heavy scenes, so the buffers are reused (single emulator thread, no reentrancy) instead of
+        // allocated per call.
         static thread_local std::vector<VkWriteDescriptorSet> vk_writes;
         static thread_local std::vector<VkDescriptorBufferInfo> buffer_infos;
         static thread_local std::vector<VkDescriptorImageInfo> image_infos;
         static thread_local std::vector<VkBufferView> texel_buffer_views;
+        static thread_local std::vector<VkWriteDescriptorSetInlineUniformBlock> inline_uniform_blocks;
         vk_writes.clear();
         buffer_infos.resize(writes.size());
         image_infos.resize(writes.size());
         texel_buffer_views.resize(writes.size());
+        inline_uniform_blocks.resize(writes.size());
         vk_writes.reserve(writes.size());
 
         // Consecutive writes usually target the same descriptor set; cache the last lookup to avoid a hash
@@ -5204,7 +5222,17 @@ namespace sogen
                  w.descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLER);
             const bool is_texel_buffer = (w.descriptor_type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER ||
                                           w.descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
-            if (is_texel_buffer)
+            if (w.descriptor_type == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK)
+            {
+                VkWriteDescriptorSetInlineUniformBlock& inline_uniform_block = inline_uniform_blocks[i];
+                inline_uniform_block = {};
+                inline_uniform_block.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK;
+                inline_uniform_block.dataSize = static_cast<uint32_t>(w.inline_uniform_data.size());
+                inline_uniform_block.pData = w.inline_uniform_data.empty() ? nullptr : w.inline_uniform_data.data();
+                vw.pNext = &inline_uniform_block;
+                vw.descriptorCount = inline_uniform_block.dataSize;
+            }
+            else if (is_texel_buffer)
             {
                 VkBufferView& buffer_view = texel_buffer_views[i];
                 buffer_view = VK_NULL_HANDLE;

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -460,8 +460,8 @@ namespace sogen
             uint32_t descriptor_count;
         };
 
-        // A single descriptor write (one descriptor). For buffer types buffer/offset/range apply; for
-        // image types (combined image sampler) sampler/image_view/image_layout apply.
+        // A single descriptor write. For buffer types buffer/offset/range apply; for image types
+        // sampler/image_view/image_layout apply; inline-uniform-block writes carry their raw bytes.
         struct descriptor_write
         {
             uint64_t dst_set;
@@ -474,12 +474,13 @@ namespace sogen
             uint64_t sampler;
             uint64_t image_view;
             uint32_t image_layout;
+            std::span<const std::byte> inline_uniform_data;
         };
 
         int32_t create_descriptor_set_layout(uint64_t device, uint32_t flags, std::span<const descriptor_binding> bindings,
                                              uint64_t& out_layout);
         int32_t get_descriptor_set_layout_support(uint64_t device, uint32_t flags, std::span<const descriptor_binding> bindings,
-                                                  uint32_t& supported);
+                                                  uint32_t& supported, uint32_t& max_variable_descriptor_count);
         void destroy_descriptor_set_layout(uint64_t device, uint64_t layout);
         int32_t create_descriptor_pool(uint64_t device, uint32_t max_sets, uint32_t flags, uint32_t max_inline_uniform_block_bindings,
                                        std::span<const descriptor_pool_size> sizes, uint64_t& out_pool);
@@ -488,7 +489,8 @@ namespace sogen
         // Allocates one set per layout id; writes the allocated set ids into out_sets, out_count gets the
         // true count.
         int32_t allocate_descriptor_sets(uint64_t device, uint64_t pool, std::span<const uint64_t> set_layouts,
-                                         std::span<uint64_t> out_sets, uint32_t& out_count);
+                                         std::span<const uint32_t> variable_descriptor_counts, std::span<uint64_t> out_sets,
+                                         uint32_t& out_count);
         int32_t free_descriptor_sets(uint64_t device, uint64_t pool, std::span<const uint64_t> sets);
         int32_t update_descriptor_sets(uint64_t device, std::span<const descriptor_write> writes);
 

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -162,7 +162,8 @@ namespace sogen
 
         // Allocates a single VkDeviceMemory of `size` from `memory_type_index`. out_memory receives a
         // fresh object id, or 0 on failure.
-        int32_t allocate_memory(uint64_t device, uint64_t size, uint32_t memory_type_index, uint64_t& out_memory);
+        int32_t allocate_memory(uint64_t device, uint64_t size, uint32_t memory_type_index, uint32_t flags, uint32_t device_mask,
+                                uint64_t& out_memory);
         void free_memory(uint64_t device, uint64_t memory);
         int32_t get_device_memory_commitment(uint64_t device, uint64_t memory, uint64_t& out_committed_bytes);
 
@@ -387,8 +388,8 @@ namespace sogen
         // Submits an asynchronous copy of the presented image into the readback buffer. If the previous
         // copy has already completed, out_pixels receives that frame immediately; otherwise it is later
         // returned by poll_presented_frames().
-        int32_t queue_present(uint64_t queue, uint64_t swapchain, uint32_t image_index, std::vector<std::byte>& out_pixels,
-                              uint32_t& out_width, uint32_t& out_height, uint64_t& out_hwnd);
+        int32_t queue_present(uint64_t queue, uint64_t swapchain, uint32_t image_index, const std::vector<uint64_t>& wait_semaphores,
+                              std::vector<std::byte>& out_pixels, uint32_t& out_width, uint32_t& out_height, uint64_t& out_hwnd);
 
         struct presented_frame
         {
@@ -449,6 +450,7 @@ namespace sogen
             uint32_t descriptor_type;
             uint32_t descriptor_count;
             uint32_t stage_flags;
+            uint32_t binding_flags;
         };
 
         // VkDescriptorPoolSize as plain integers.
@@ -474,10 +476,13 @@ namespace sogen
             uint32_t image_layout;
         };
 
-        int32_t create_descriptor_set_layout(uint64_t device, std::span<const descriptor_binding> bindings, uint64_t& out_layout);
-        int32_t get_descriptor_set_layout_support(uint64_t device, std::span<const descriptor_binding> bindings, uint32_t& supported);
+        int32_t create_descriptor_set_layout(uint64_t device, uint32_t flags, std::span<const descriptor_binding> bindings,
+                                             uint64_t& out_layout);
+        int32_t get_descriptor_set_layout_support(uint64_t device, uint32_t flags, std::span<const descriptor_binding> bindings,
+                                                  uint32_t& supported);
         void destroy_descriptor_set_layout(uint64_t device, uint64_t layout);
-        int32_t create_descriptor_pool(uint64_t device, uint32_t max_sets, std::span<const descriptor_pool_size> sizes, uint64_t& out_pool);
+        int32_t create_descriptor_pool(uint64_t device, uint32_t max_sets, uint32_t flags, uint32_t max_inline_uniform_block_bindings,
+                                       std::span<const descriptor_pool_size> sizes, uint64_t& out_pool);
         int32_t reset_descriptor_pool(uint64_t device, uint64_t pool, uint32_t flags);
         void destroy_descriptor_pool(uint64_t device, uint64_t pool);
         // Allocates one set per layout id; writes the allocated set ids into out_sets, out_count gets the


### PR DESCRIPTION
This PR fixes some Vulkan conformance issues that I encountered while running a game on Android using the Adreno driver:

* Forward `VkMemoryAllocateFlagsInfo` flags and device mask during memory allocation.
* Forward and wait on `vkQueuePresentKHR` wait semaphores.
* Forward descriptor set layout flags and per-binding `VkDescriptorBindingFlags`.
* Preserve descriptor pool creation flags and inline uniform block configuration.
* Handle `VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT` and `VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT` correctly.
