### PR TITLE
Fixes to window geometry

### DIFF
--- a/page/src/web-ui-host.ts
+++ b/page/src/web-ui-host.ts
@@ -94,10 +94,9 @@ const WS_SYSMENU = 0x00080000;
 const WS_MINIMIZEBOX = 0x00020000;
 const WS_MAXIMIZEBOX = 0x00010000;
 
-// The guest models windows without a non-client area (client rect == window
-// rect), so the presented surface fills win.rect exactly. We draw the caption
-// bar and frame *around* win.rect, mirroring how a native window manager (and
-// the SDL backend's OS windows) decorate the client area.
+// `rect` is the guest outer-window rectangle, while the presented surface is
+// client-sized and begins after the left/top client insets. The browser-drawn
+// caption and frame remain host chrome around that client box.
 const CAPTION_HEIGHT = 30;
 const FRAME_BORDER = 1;
 const CAPTION_BUTTON_WIDTH = 46;
@@ -122,6 +121,15 @@ function cloneRect(rect?: {
   bottom: number;
 }) {
   return rect ?? { left: 0, top: 0, right: 0, bottom: 0 };
+}
+
+function cloneClientInsets(insets?: {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}) {
+  return insets ? { ...insets } : { left: 0, top: 0, right: 0, bottom: 0 };
 }
 
 function convertSurfacePixels(
@@ -287,23 +295,56 @@ export function attachSogenUiHost(
     return hasCaption(window) ? CAPTION_HEIGHT : 0;
   }
 
-  function frameRect(window: HostWindowState): Rect {
-    const caption = captionHeight(window);
+  function clientRect(window: HostWindowState): Rect {
+    const outerWidth = Math.max(0, window.rect.right - window.rect.left);
+    const outerHeight = Math.max(0, window.rect.bottom - window.rect.top);
+    const clientLeft = Math.min(outerWidth, window.clientInsets.left);
+    const clientTop = Math.min(outerHeight, window.clientInsets.top);
+    const clientRight = Math.max(
+      clientLeft,
+      outerWidth - window.clientInsets.right,
+    );
+    const clientBottom = Math.max(
+      clientTop,
+      outerHeight - window.clientInsets.bottom,
+    );
+
     return {
-      left: window.rect.left - FRAME_BORDER,
-      top: window.rect.top - caption - FRAME_BORDER,
-      right: window.rect.right + FRAME_BORDER,
-      bottom: window.rect.bottom + FRAME_BORDER,
+      left: window.rect.left + clientLeft,
+      top: window.rect.top + clientTop,
+      right: window.rect.left + clientRight,
+      bottom: window.rect.top + clientBottom,
     };
   }
 
+  function frameRect(window: HostWindowState): Rect {
+    const client = clientRect(window);
+    const caption = captionHeight(window);
+    return {
+      left: Math.min(window.rect.left, client.left - FRAME_BORDER),
+      top: Math.min(window.rect.top, client.top - caption - FRAME_BORDER),
+      right: Math.max(window.rect.right, client.right + FRAME_BORDER),
+      bottom: Math.max(window.rect.bottom, client.bottom + FRAME_BORDER),
+    };
+  }
+
+  function hasNonClientInsets(window: HostWindowState) {
+    return (
+      window.clientInsets.left > 0 ||
+      window.clientInsets.top > 0 ||
+      window.clientInsets.right > 0 ||
+      window.clientInsets.bottom > 0
+    );
+  }
+
   function captionRect(window: HostWindowState): Rect {
+    const client = clientRect(window);
     const frame = frameRect(window);
     return {
       left: frame.left,
       top: frame.top,
       right: frame.right,
-      bottom: window.rect.top,
+      bottom: client.top,
     };
   }
 
@@ -464,12 +505,12 @@ export function attachSogenUiHost(
   }
 
   function drawChrome(window: HostWindowState) {
-    if (!hasCaption(window)) {
+    const captioned = hasCaption(window);
+    if (!captioned && !hasNonClientInsets(window)) {
       return;
     }
 
     const frame = frameRect(window);
-    const caption = captionRect(window);
     const focused = window.hwnd === focusedWindow;
 
     context2d.fillStyle = CHROME_COLORS.frame;
@@ -480,6 +521,11 @@ export function attachSogenUiHost(
       frame.bottom - frame.top,
     );
 
+    if (!captioned) {
+      return;
+    }
+
+    const caption = captionRect(window);
     context2d.fillStyle = focused
       ? CHROME_COLORS.captionFocused
       : CHROME_COLORS.captionUnfocused;
@@ -554,12 +600,23 @@ export function attachSogenUiHost(
 
     drawChrome(window);
 
-    if (window.surfaceCanvas) {
-      context2d.drawImage(
-        window.surfaceCanvas,
-        window.rect.left,
-        window.rect.top,
+    const client = clientRect(window);
+    if (
+      window.surfaceCanvas &&
+      client.right > client.left &&
+      client.bottom > client.top
+    ) {
+      context2d.save();
+      context2d.beginPath();
+      context2d.rect(
+        client.left,
+        client.top,
+        client.right - client.left,
+        client.bottom - client.top,
       );
+      context2d.clip();
+      context2d.drawImage(window.surfaceCanvas, client.left, client.top);
+      context2d.restore();
     }
   }
 
@@ -606,7 +663,7 @@ export function attachSogenUiHost(
         continue;
       }
 
-      if (pointInRect(window.rect, x, y)) {
+      if (pointInRect(clientRect(window), x, y)) {
         return { window, region: "client" };
       }
 
@@ -616,7 +673,7 @@ export function attachSogenUiHost(
         }
       }
 
-      if (pointInRect(captionRect(window), x, y)) {
+      if (hasCaption(window) && pointInRect(captionRect(window), x, y)) {
         return { window, region: "caption" };
       }
 
@@ -685,12 +742,7 @@ export function attachSogenUiHost(
         window.className = message.class_name ?? "";
         window.title = message.title ?? "";
         window.controlId = message.control_id ?? 0;
-        window.clientInsets = message.client_insets ?? {
-          left: 0,
-          top: 0,
-          right: 0,
-          bottom: 0,
-        };
+        window.clientInsets = cloneClientInsets(message.client_insets);
         window.style = message.style ?? 0;
         window.exStyle = message.ex_style ?? 0;
         window.visible = !!message.visible;
@@ -773,8 +825,9 @@ export function attachSogenUiHost(
       return;
     }
 
-    const localX = point.x - window.rect.left;
-    const localY = point.y - window.rect.top;
+    const client = clientRect(window);
+    const localX = point.x - client.left;
+    const localY = point.y - client.top;
     sendUiEvent(
       window.hwnd,
       event.button === 2 ? WM_RBUTTONDOWN : WM_LBUTTONDOWN,
@@ -808,8 +861,9 @@ export function attachSogenUiHost(
       return;
     }
 
-    const localX = point.x - target.rect.left;
-    const localY = point.y - target.rect.top;
+    const client = clientRect(target);
+    const localX = point.x - client.left;
+    const localY = point.y - client.top;
     sendUiEvent(
       target.hwnd,
       event.button === 2 ? WM_RBUTTONUP : WM_LBUTTONUP,
@@ -852,8 +906,9 @@ export function attachSogenUiHost(
     }
 
     if (hit && hit.region === "client") {
-      const localX = point.x - hit.window.rect.left;
-      const localY = point.y - hit.window.rect.top;
+      const client = clientRect(hit.window);
+      const localX = point.x - client.left;
+      const localY = point.y - client.top;
       sendUiEvent(hit.window.hwnd, WM_MOUSEMOVE, 0, packPoint(localX, localY));
     }
   }

--- a/page/src/web-ui-host.ts
+++ b/page/src/web-ui-host.ts
@@ -94,9 +94,9 @@ const WS_SYSMENU = 0x00080000;
 const WS_MINIMIZEBOX = 0x00020000;
 const WS_MAXIMIZEBOX = 0x00010000;
 
-// `rect` is the guest outer-window rectangle, while the presented surface is
-// client-sized and begins after the left/top client insets. The browser-drawn
-// caption and frame remain host chrome around that client box.
+// The guest models `rect` as the outer window bounds, with the presented
+// surface occupying the inset client area. We draw the caption bar and frame
+// around that client area, mirroring how a native window manager decorates it.
 const CAPTION_HEIGHT = 30;
 const FRAME_BORDER = 1;
 const CAPTION_BUTTON_WIDTH = 46;

--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -36,7 +36,7 @@ namespace sogen
     constexpr size_t USER_NUM_SYSCOLORS = 31;
     constexpr size_t USER_SERVERINFO_BRUSH_SLOT_COUNT = 32;
     constexpr size_t USER_SERVERINFO_BRUSH_TRAILING_BYTES = 0x78;
-    constexpr uint32_t USER_DEFAULT_DPI_CONTEXT = 18;
+    constexpr uint32_t USER_DEFAULT_DPI_CONTEXT = (96u << 8) | 0x12u;
 
     struct USER_SERVERINFO
     {

--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -36,7 +36,8 @@ namespace sogen
     constexpr size_t USER_NUM_SYSCOLORS = 31;
     constexpr size_t USER_SERVERINFO_BRUSH_SLOT_COUNT = 32;
     constexpr size_t USER_SERVERINFO_BRUSH_TRAILING_BYTES = 0x78;
-    constexpr uint32_t USER_DEFAULT_DPI_CONTEXT = (96u << 8) | 0x12u;
+    constexpr uint32_t USER_DEFAULT_DPI_CONTEXT = 18;
+    constexpr uint32_t USER_DEFAULT_WINDOW_DPI_CONTEXT = (96u << 8) | USER_DEFAULT_DPI_CONTEXT;
 
     struct USER_SERVERINFO
     {

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -222,8 +222,10 @@ namespace sogen
 #define SWP_NOZORDER                0x0004
 #define SWP_NOREDRAW                0x0008
 #define SWP_NOACTIVATE              0x0010
+#define SWP_FRAMECHANGED            0x0020
 #define SWP_SHOWWINDOW              0x0040
 #define SWP_HIDEWINDOW              0x0080
+#define SWP_NOSENDCHANGING          0x0400
 
 #define SW_SHOWNORMAL               1
 #define SW_SHOWMINIMIZED            2
@@ -474,6 +476,8 @@ namespace sogen
 #define GWLP_WNDPROC                (-4)
 #define GWLP_HINSTANCE              (-6)
 #define GWLP_HWNDPARENT             (-8)
+#define GWL_STYLE                   (-16)
+#define GWL_EXSTYLE                 (-20)
 #define GWLP_USERDATA               (-21)
 #define GWLP_ID                     (-12)
 

--- a/src/emulator-platform/platform/window.hpp
+++ b/src/emulator-platform/platform/window.hpp
@@ -215,6 +215,7 @@ namespace sogen
 #define WS_MAXIMIZEBOX              0x00010000L
 
 #define WS_EX_NOPARENTNOTIFY        0x00000004L
+#define WS_EX_CLIENTEDGE            0x00000200L
 
 #define SWP_NOSIZE                  0x0001
 #define SWP_NOMOVE                  0x0002

--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -1181,6 +1181,90 @@ namespace
         return executions == 2;
     }
 
+    bool test_window_geometry()
+    {
+        WNDCLASSEXA wc{};
+        wc.cbSize = sizeof(wc);
+        wc.lpszClassName = "TestWindowNonclientClass";
+        wc.hInstance = GetModuleHandleA(nullptr);
+        wc.lpfnWndProc = DefWindowProcA;
+
+        if (!RegisterClassExA(&wc))
+        {
+            puts("Failed to register window class");
+            return false;
+        }
+
+        const auto unregister_class = sogen::utils::finally([&] { UnregisterClassA(wc.lpszClassName, wc.hInstance); });
+
+        struct window_case
+        {
+            DWORD style;
+            DWORD ex_style;
+        };
+
+        constexpr std::array cases = {
+            window_case{.style = WS_POPUP | WS_THICKFRAME, .ex_style = 0},
+            window_case{.style = WS_POPUP | WS_CAPTION, .ex_style = 0},
+            window_case{.style = WS_POPUP | WS_DLGFRAME, .ex_style = 0},
+            window_case{.style = WS_POPUP, .ex_style = WS_EX_CLIENTEDGE},
+        };
+
+        for (const auto& test : cases)
+        {
+            constexpr LONG expected_client_height = 123;
+            constexpr LONG expected_client_width = 321;
+
+            RECT adjusted_rect{0, 0, expected_client_width, expected_client_height};
+            const BOOL adjusted = test.ex_style ? AdjustWindowRectEx(&adjusted_rect, test.style, FALSE, test.ex_style)
+                                                : AdjustWindowRect(&adjusted_rect, test.style, FALSE);
+            if (!adjusted)
+            {
+                puts("Failed to calculate nonclient insets");
+                return false;
+            }
+
+            const auto adjusted_width = adjusted_rect.right - adjusted_rect.left;
+            const auto adjusted_height = adjusted_rect.bottom - adjusted_rect.top;
+
+            const HWND hwnd = CreateWindowExA(test.ex_style, wc.lpszClassName, nullptr, test.style, 0, 0, adjusted_width, adjusted_height,
+                                              nullptr, nullptr, wc.hInstance, nullptr);
+            if (!hwnd)
+            {
+                puts("Failed to create test window");
+                return false;
+            }
+
+            const auto destroy_window = sogen::utils::finally([&] { DestroyWindow(hwnd); });
+
+            RECT window_rect{};
+            RECT client_rect{};
+            if (!GetWindowRect(hwnd, &window_rect) || !GetClientRect(hwnd, &client_rect))
+            {
+                return false;
+            }
+
+            const auto window_width = window_rect.right - window_rect.left;
+            const auto window_height = window_rect.bottom - window_rect.top;
+            const auto client_width = client_rect.right - client_rect.left;
+            const auto client_height = client_rect.bottom - client_rect.top;
+
+            if (window_width != adjusted_width || window_height != adjusted_height)
+            {
+                puts("Window size does not match AdjustWindowRect result");
+                return false;
+            }
+
+            if (client_width != expected_client_width || client_height != expected_client_height)
+            {
+                puts("AdjustWindowRect round-trip failed");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     bool test_message_queue()
     {
         thread_local UINT wnd_proc_num = 0;
@@ -1850,6 +1934,7 @@ int main(const int argc, const char* argv[])
     RUN_TEST(test_tls, "TLS")
     RUN_TEST(test_socket, "Socket")
     RUN_TEST(test_apc, "APC")
+    RUN_TEST(test_window_geometry, "Window Geometry")
     RUN_TEST(test_user_callback, "User Callback")
     RUN_TEST(test_mutable_callbacks, "Mutable User Callback")
     RUN_TEST(test_message_queue, "Message Queue (General)")

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -3374,7 +3374,7 @@ namespace sogen
                         win && win->client_width() > 0 && win->client_height() > 0)
                     {
                         // Client size, not outer: DXVK pins its swapchain to this extent and must match its
-                        // client-sized backbuffer, else the present upscales (see window::nonclient_border).
+                        // client-sized backbuffer, else the present upscales (see window::nonclient_insets).
                         window_width = static_cast<uint32_t>(win->client_width());
                         window_height = static_cast<uint32_t>(win->client_height());
                     }

--- a/src/windows-emulator/emulator_thread.hpp
+++ b/src/windows-emulator/emulator_thread.hpp
@@ -189,6 +189,7 @@ namespace sogen
         NtUserMessageCall,
         NtUserUpdateWindow,
         NtUserEnumDisplayMonitors,
+        NtUserSetWindowPos,
     };
 
     struct callback_frame

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -561,7 +561,7 @@ namespace sogen
             window.rcClient = window.rcWindow;
             window.fnid = 0x29D;   // FNID_DESKTOP
             window.windowBand = 1; // ZBID_DESKTOP
-            window.dpiContext = USER_DEFAULT_DPI_CONTEXT;
+            window.dpiContext = USER_DEFAULT_WINDOW_DPI_CONTEXT;
             window.processId = process_context::process_id;
         });
 
@@ -594,7 +594,7 @@ namespace sogen
                 window.rcWindow = {.left = x, .top = y, .right = x + width, .bottom = y + height};
                 window.rcClient = window.rcWindow;
                 window.windowBand = 1; // ZBID_DESKTOP
-                window.dpiContext = USER_DEFAULT_DPI_CONTEXT;
+                window.dpiContext = USER_DEFAULT_WINDOW_DPI_CONTEXT;
                 window.processId = process_context::process_id;
             });
             return handle;

--- a/src/windows-emulator/syscall_dispatcher.hpp
+++ b/src/windows-emulator/syscall_dispatcher.hpp
@@ -237,6 +237,31 @@ namespace sogen
         }
     };
 
+    struct window_position_state : completion_state
+    {
+        emulator_stack_allocation window_pos_alloc{};
+        emulator_stack_allocation changed_window_pos_alloc{};
+        std::vector<qmsg> message_queue{};
+        bool position_applied{};
+
+      private:
+        void serialize_object(utils::buffer_serializer& buffer) const override
+        {
+            buffer.write(this->window_pos_alloc);
+            buffer.write(this->changed_window_pos_alloc);
+            buffer.write_vector(this->message_queue);
+            buffer.write(this->position_applied);
+        }
+
+        void deserialize_object(utils::buffer_deserializer& buffer) override
+        {
+            buffer.read(this->window_pos_alloc);
+            buffer.read(this->changed_window_pos_alloc);
+            buffer.read_vector(this->message_queue);
+            buffer.read(this->position_applied);
+        }
+    };
+
     struct message_call_state : completion_state
     {
         hwnd window{};

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -613,6 +613,8 @@ namespace sogen
         hwnd handle_NtUserSetParent(const syscall_context& c, hwnd hwnd_child, hwnd hwnd_new_parent);
         BOOL handle_NtUserSetWindowPos(const syscall_context& c, hwnd hWnd, hwnd hwnd_insert_after, int x, int y, int cx, int cy,
                                        UINT flags);
+        BOOL completion_NtUserSetWindowPos(const syscall_context& c, hwnd hWnd, hwnd hwnd_insert_after, int x, int y, int cx, int cy,
+                                           UINT flags);
         NTSTATUS handle_NtUserSetForegroundWindow();
         hwnd handle_NtUserGetForegroundWindow(const syscall_context& c);
         hwnd handle_NtUserSetFocus(const syscall_context& c, hwnd hwnd);
@@ -1790,6 +1792,7 @@ namespace sogen
         add_callback(NtUserCreateWindowEx, window_create_state);
         add_callback(NtUserDestroyWindow, window_destroy_state);
         add_callback(NtUserShowWindow, window_show_state);
+        add_callback(NtUserSetWindowPos, window_position_state);
         add_callback(NtUserMessageCall, message_call_state);
         add_callback(NtUserUpdateWindow, window_update_state);
         add_stateless_callback(NtUserEnumDisplayMonitors);

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -575,14 +575,14 @@ namespace sogen
                     win = win->parent_handle != 0 ? c.proc.windows.get(win->parent_handle) : nullptr;
                 }
 
-                if (!win || !win->host_surface_window || win->width <= 0 || win->height <= 0)
+                if (!win || !win->host_surface_window || win->client_width() <= 0 || win->client_height() <= 0)
                 {
                     return nullptr;
                 }
 
                 const auto top_handle = static_cast<uint32_t>(win->handle);
-                const auto width = static_cast<uint32_t>(win->width);
-                const auto height = static_cast<uint32_t>(win->height);
+                const auto width = static_cast<uint32_t>(win->client_width());
+                const auto height = static_cast<uint32_t>(win->client_height());
 
                 auto& surface = c.proc.gdi_window_surfaces[top_handle];
                 if (surface.width != width || surface.height != height || surface.pixels.size() != static_cast<size_t>(width) * height)

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -466,10 +466,7 @@ namespace sogen
             const auto width = (position.flags & SWP_NOSIZE) != 0 ? win.width : position.cx;
             const auto height = (position.flags & SWP_NOSIZE) != 0 ? win.height : position.cy;
 
-            if ((position.flags & SWP_FRAMECHANGED) != 0)
-            {
-                // SWP_FRAMECHANGED is intentionally ignored until runtime style changes and non-client recalculation are implemented.
-            }
+            // TODO: Handle SWP_FRAMECHANGED once runtime style changes and non-client recalculation are implemented.
             update_window_geometry(c, win, x, y, width, height, false);
 
             EMU_WINDOWPOS changed_position{
@@ -526,9 +523,7 @@ namespace sogen
             }
         }
 
-        void complete_window_position_change(const syscall_context& c, window& win, const uint64_t window_pos_address,
-                                             emulator_stack_allocation& changed_window_pos_alloc, std::vector<qmsg>& message_queue,
-                                             const bool update_changed_window_position)
+        EMU_WINDOWPOS resolve_window_position_callback(const syscall_context& c, const uint64_t window_pos_address)
         {
             EMU_WINDOWPOS position{};
             c.emu.read_memory(window_pos_address, &position, sizeof(position));
@@ -538,7 +533,7 @@ namespace sogen
                 c.emu.write_memory(window_pos_address, &position, sizeof(position));
             }
 
-            apply_window_position_change(c, win, position, changed_window_pos_alloc, message_queue, update_changed_window_position);
+            return position;
         }
 
         void release_window_position_allocations(const syscall_context& c, window_position_state& state)
@@ -555,11 +550,15 @@ namespace sogen
 
         void invalidate_window_tree(const syscall_context& c, window& win);
 
-        void finish_set_window_position(const syscall_context& c, window& win, window_position_state& state, const int old_x,
-                                        const int old_y, const int old_width, const int old_height)
+        void apply_set_window_position(const syscall_context& c, window& win, window_position_state& state, const EMU_WINDOWPOS& position)
         {
-            EMU_WINDOWPOS position{};
-            c.emu.read_memory(state.window_pos_alloc.address(), &position, sizeof(position));
+            const auto old_x = win.x;
+            const auto old_y = win.y;
+            const auto old_width = win.width;
+            const auto old_height = win.height;
+
+            apply_window_position_change(c, win, position, state.changed_window_pos_alloc, state.message_queue);
+
             const bool showing_hidden_window = (position.flags & SWP_SHOWWINDOW) != 0 && (win.style & WS_VISIBLE) == 0;
             const bool hiding_visible_window = (position.flags & SWP_HIDEWINDOW) != 0 && (win.style & WS_VISIBLE) != 0;
 
@@ -1143,8 +1142,8 @@ namespace sogen
 
             if (auto* win = c.proc.windows.get(frame.handle))
             {
-                complete_window_position_change(c, *win, frame.pending_window_pos_address, frame.changed_window_pos_alloc,
-                                                frame.message_queue, true);
+                const auto position = resolve_window_position_callback(c, frame.pending_window_pos_address);
+                apply_window_position_change(c, *win, position, frame.changed_window_pos_alloc, frame.message_queue, true);
             }
             frame.pending_window_pos_address = 0;
         }
@@ -3393,8 +3392,11 @@ namespace sogen
                 const bool activation_position =
                     s.show_data.activation_window_pos_alloc &&
                     s.show_data.pending_window_pos_address == s.show_data.activation_window_pos_alloc.address();
-                complete_window_position_change(c, *win, s.show_data.pending_window_pos_address, s.show_data.changed_window_pos_alloc,
-                                                s.show_data.message_queue, !activation_position);
+
+                const auto position = resolve_window_position_callback(c, s.show_data.pending_window_pos_address);
+                apply_window_position_change(c, *win, position, s.show_data.changed_window_pos_alloc, s.show_data.message_queue,
+                                             !activation_position);
+
                 s.show_data.pending_window_pos_address = 0;
                 show_orchestrator.window_position_completed(activation_position);
             }
@@ -3667,9 +3669,11 @@ namespace sogen
                     data.activation_window_pos_alloc && data.pending_window_pos_address == data.activation_window_pos_alloc.address();
                 if (auto* win = c.proc.windows.get(data.handle))
                 {
-                    complete_window_position_change(c, *win, data.pending_window_pos_address, data.changed_window_pos_alloc,
-                                                    data.message_queue, !activation_position);
+                    const auto position = resolve_window_position_callback(c, data.pending_window_pos_address);
+                    apply_window_position_change(c, *win, position, data.changed_window_pos_alloc, data.message_queue,
+                                                 !activation_position);
                 }
+
                 data.pending_window_pos_address = 0;
                 orchestrator.window_position_completed(activation_position);
             }
@@ -4543,13 +4547,7 @@ namespace sogen
             }
             else
             {
-                const auto old_x = win->x;
-                const auto old_y = win->y;
-                const auto old_width = win->width;
-                const auto old_height = win->height;
-
-                apply_window_position_change(c, *win, position, state.changed_window_pos_alloc, state.message_queue);
-                finish_set_window_position(c, *win, state, old_x, old_y, old_width, old_height);
+                apply_set_window_position(c, *win, state, position);
 
                 if (state.message_queue.empty())
                 {
@@ -4576,14 +4574,8 @@ namespace sogen
 
             if (!state.position_applied)
             {
-                const auto old_x = win->x;
-                const auto old_y = win->y;
-                const auto old_width = win->width;
-                const auto old_height = win->height;
-
-                complete_window_position_change(c, *win, state.window_pos_alloc.address(), state.changed_window_pos_alloc,
-                                                state.message_queue, true);
-                finish_set_window_position(c, *win, state, old_x, old_y, old_width, old_height);
+                const auto position = resolve_window_position_callback(c, state.window_pos_alloc.address());
+                apply_set_window_position(c, *win, state, position);
             }
 
             if (!state.message_queue.empty())

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -368,12 +368,12 @@ namespace sogen
         void sync_guest_window_rects(window& win)
         {
             const auto window_rect = get_window_rect(win);
-            const auto client_x = win.x + win.client_x_offset();
-            const auto client_y = win.y + win.client_y_offset();
-            const RECT client_rect{.left = client_x,
-                                   .top = client_y,
-                                   .right = client_x + win.client_width(),
-                                   .bottom = client_y + win.client_height()};
+            const RECT client_rect{
+                .left = win.client_x(),
+                .top = win.client_y(),
+                .right = win.client_x() + win.client_width(),
+                .bottom = win.client_y() + win.client_height(),
+            };
 
             win.guest.access([&](USER_WINDOW& guest_win) {
                 guest_win.rcWindow = window_rect;
@@ -448,14 +448,28 @@ namespace sogen
             return position;
         }
 
+        uint64_t pack_message_lparam(const int low, const int high)
+        {
+            return static_cast<uint64_t>(static_cast<uint16_t>(low)) | (static_cast<uint64_t>(static_cast<uint16_t>(high)) << 16);
+        }
+
         void apply_window_position_change(const syscall_context& c, window& win, const EMU_WINDOWPOS& position,
                                           emulator_stack_allocation& changed_window_pos_alloc, std::vector<qmsg>& message_queue,
-                                          const bool update_changed_window_position)
+                                          const bool update_changed_window_position = true)
         {
+            const auto old_client_x = win.client_x();
+            const auto old_client_y = win.client_y();
+            const auto old_client_width = win.client_width();
+            const auto old_client_height = win.client_height();
             const auto x = (position.flags & SWP_NOMOVE) != 0 ? win.x : position.x;
             const auto y = (position.flags & SWP_NOMOVE) != 0 ? win.y : position.y;
             const auto width = (position.flags & SWP_NOSIZE) != 0 ? win.width : position.cx;
             const auto height = (position.flags & SWP_NOSIZE) != 0 ? win.height : position.cy;
+
+            if ((position.flags & SWP_FRAMECHANGED) != 0)
+            {
+                // SWP_FRAMECHANGED is intentionally ignored until runtime style changes and non-client recalculation are implemented.
+            }
             update_window_geometry(c, win, x, y, width, height, false);
 
             EMU_WINDOWPOS changed_position{
@@ -465,13 +479,13 @@ namespace sogen
                 .y = win.y,
                 .cx = win.width,
                 .cy = win.height,
-                .flags = position.flags,
+                .flags = position.flags & ~(SWP_NOCLIENTMOVE | SWP_NOCLIENTSIZE),
             };
-            if ((position.flags & SWP_NOMOVE) != 0)
+            if (old_client_x == win.client_x() && old_client_y == win.client_y())
             {
                 changed_position.flags |= SWP_NOCLIENTMOVE;
             }
-            if ((position.flags & SWP_NOSIZE) != 0)
+            if (old_client_width == win.client_width() && old_client_height == win.client_height())
             {
                 changed_position.flags |= SWP_NOCLIENTSIZE;
             }
@@ -501,10 +515,10 @@ namespace sogen
                     message.lParam = changed_window_pos_alloc.address();
                     break;
                 case WM_MOVE:
-                    message.lParam = static_cast<uint64_t>(((win.y & 0xFFFF) << 16) | (win.x & 0xFFFF));
+                    message.lParam = pack_message_lparam(win.client_x(), win.client_y());
                     break;
                 case WM_SIZE:
-                    message.lParam = static_cast<uint64_t>(((win.client_height() & 0xFFFF) << 16) | (win.client_width() & 0xFFFF));
+                    message.lParam = pack_message_lparam(win.client_width(), win.client_height());
                     break;
                 default:
                     break;
@@ -525,6 +539,64 @@ namespace sogen
             }
 
             apply_window_position_change(c, win, position, changed_window_pos_alloc, message_queue, update_changed_window_position);
+        }
+
+        void release_window_position_allocations(const syscall_context& c, window_position_state& state)
+        {
+            if (state.changed_window_pos_alloc)
+            {
+                c.emu.pop_stack(state.changed_window_pos_alloc);
+            }
+            if (state.window_pos_alloc)
+            {
+                c.emu.pop_stack(state.window_pos_alloc);
+            }
+        }
+
+        void invalidate_window_tree(const syscall_context& c, window& win);
+
+        void finish_set_window_position(const syscall_context& c, window& win, window_position_state& state, const int old_x,
+                                        const int old_y, const int old_width, const int old_height)
+        {
+            EMU_WINDOWPOS position{};
+            c.emu.read_memory(state.window_pos_alloc.address(), &position, sizeof(position));
+            const bool showing_hidden_window = (position.flags & SWP_SHOWWINDOW) != 0 && (win.style & WS_VISIBLE) == 0;
+            const bool hiding_visible_window = (position.flags & SWP_HIDEWINDOW) != 0 && (win.style & WS_VISIBLE) != 0;
+
+            if ((position.flags & SWP_HIDEWINDOW) != 0)
+            {
+                win.style &= ~WS_VISIBLE;
+                win.guest.access([&](USER_WINDOW& guest_win) { guest_win.dwStyle = win.style; });
+                if (win.host_surface_window)
+                {
+                    c.win_emu.ui().set_window_visible(win.handle, false);
+                }
+            }
+            else if (showing_hidden_window)
+            {
+                win.style |= WS_VISIBLE;
+                win.guest.access([&](USER_WINDOW& guest_win) { guest_win.dwStyle = win.style; });
+                if (win.host_surface_window)
+                {
+                    c.win_emu.ui().set_window_visible(win.handle, true);
+                }
+                invalidate_window_tree(c, win);
+            }
+
+            const bool geometry_changed = old_x != win.x || old_y != win.y || old_width != win.width || old_height != win.height;
+            if ((position.flags & SWP_NOREDRAW) == 0 && !showing_hidden_window && geometry_changed)
+            {
+                invalidate_window(c, win, std::nullopt, false);
+            }
+
+            // TODO: Apply hwndInsertAfter once guest and host z-order mutation are implemented.
+
+            if (geometry_changed || showing_hidden_window || hiding_visible_window)
+            {
+                state.message_queue.push_back(
+                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.changed_window_pos_alloc.address()});
+            }
+            state.position_applied = true;
         }
 
         RECT union_update_rect(const RECT& a, const RECT& b)
@@ -1498,11 +1570,6 @@ namespace sogen
             {
                 item.text = read_menu_item_text(c, mi, item_text);
             }
-        }
-
-        uint64_t pack_message_lparam(const int low, const int high)
-        {
-            return static_cast<uint64_t>(static_cast<uint16_t>(low)) | (static_cast<uint64_t>(static_cast<uint16_t>(high)) << 16);
         }
 
     }
@@ -3065,12 +3132,12 @@ namespace sogen
                 // The client rect is the window minus its non-client frame (see window::nonclient_insets). The
                 // guest reads rcClient client-side to size its render target/backbuffer, so seeding it with the
                 // outer rect here makes a framed window render too large and rescale (softening the frame).
-                const auto client_x = x + win.client_x_offset();
-                const auto client_y = y + win.client_y_offset();
-                guest_win.rcClient = {.left = client_x,
-                                      .top = client_y,
-                                      .right = client_x + win.client_width(),
-                                      .bottom = client_y + win.client_height()};
+                guest_win.rcClient = {
+                    .left = win.client_x(),
+                    .top = win.client_y(),
+                    .right = win.client_x() + win.client_width(),
+                    .bottom = win.client_y() + win.client_height(),
+                };
                 if (parent_win && has_child_parent)
                 {
                     guest_win.spwndParent = parent_win->guest.value();
@@ -3096,7 +3163,7 @@ namespace sogen
                     guest_win.spmenu = menu;
                 }
                 guest_win.windowBand = 1; // ZBID_DESKTOP
-                guest_win.dpiContext = USER_DEFAULT_DPI_CONTEXT;
+                guest_win.dpiContext = USER_DEFAULT_WINDOW_DPI_CONTEXT;
                 guest_win.fnid = get_builtin_window_fnid(normalized_class);
                 guest_win.threadId = win.thread_id;
                 guest_win.processId = process_context::process_id;
@@ -3259,7 +3326,7 @@ namespace sogen
             const bool initially_visible = (style & WS_VISIBLE) != 0;
             if (has_child_parent)
             {
-                const auto move_lparam = pack_message_lparam(x, y);
+                const auto move_lparam = pack_message_lparam(win.client_x(), win.client_y());
                 const auto size_lparam = pack_message_lparam(win.client_width(), win.client_height());
                 std::vector<qmsg> child_messages{};
 
@@ -4446,50 +4513,6 @@ namespace sogen
             return old_parent;
         }
 
-        void finish_set_window_position(const syscall_context& c, window& win, window_position_state& state, const int old_x,
-                                        const int old_y, const int old_width, const int old_height)
-        {
-            EMU_WINDOWPOS position{};
-            c.emu.read_memory(state.window_pos_alloc.address(), &position, sizeof(position));
-            const bool showing_hidden_window = (position.flags & SWP_SHOWWINDOW) != 0 && (win.style & WS_VISIBLE) == 0;
-            const bool hiding_visible_window = (position.flags & SWP_HIDEWINDOW) != 0 && (win.style & WS_VISIBLE) != 0;
-
-            if ((position.flags & SWP_HIDEWINDOW) != 0)
-            {
-                win.style &= ~WS_VISIBLE;
-                win.guest.access([&](USER_WINDOW& guest_win) { guest_win.dwStyle = win.style; });
-                if (win.host_surface_window)
-                {
-                    c.win_emu.ui().set_window_visible(win.handle, false);
-                }
-            }
-            else if (showing_hidden_window)
-            {
-                win.style |= WS_VISIBLE;
-                win.guest.access([&](USER_WINDOW& guest_win) { guest_win.dwStyle = win.style; });
-                if (win.host_surface_window)
-                {
-                    c.win_emu.ui().set_window_visible(win.handle, true);
-                }
-                invalidate_window_tree(c, win);
-            }
-
-            const bool geometry_changed = old_x != win.x || old_y != win.y || old_width != win.width || old_height != win.height;
-            if ((position.flags & SWP_NOREDRAW) == 0 && !showing_hidden_window && geometry_changed)
-            {
-                invalidate_window(c, win, std::nullopt, false);
-            }
-
-            const bool frame_changed = (position.flags & SWP_FRAMECHANGED) != 0;
-            const bool z_order_changed = (position.flags & SWP_NOZORDER) == 0;
-            if (geometry_changed || showing_hidden_window || hiding_visible_window || frame_changed || z_order_changed)
-            {
-                state.message_queue.push_back(
-                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.changed_window_pos_alloc.address()});
-            }
-            state.position_applied = true;
-        }
-
         BOOL handle_NtUserSetWindowPos(const syscall_context& c, const hwnd hWnd, const hwnd hwnd_insert_after, const int x, const int y,
                                        const int cx, const int cy, const UINT flags)
         {
@@ -4525,13 +4548,12 @@ namespace sogen
                 const auto old_width = win->width;
                 const auto old_height = win->height;
 
-                apply_window_position_change(c, *win, position, state.changed_window_pos_alloc, state.message_queue, true);
+                apply_window_position_change(c, *win, position, state.changed_window_pos_alloc, state.message_queue);
                 finish_set_window_position(c, *win, state, old_x, old_y, old_width, old_height);
 
                 if (state.message_queue.empty())
                 {
-                    c.emu.pop_stack(state.changed_window_pos_alloc);
-                    c.emu.pop_stack(state.window_pos_alloc);
+                    release_window_position_allocations(c, state);
                     return TRUE;
                 }
 
@@ -4548,11 +4570,7 @@ namespace sogen
             auto* win = c.proc.windows.get(hWnd);
             if (!win)
             {
-                if (state.changed_window_pos_alloc)
-                {
-                    c.emu.pop_stack(state.changed_window_pos_alloc);
-                }
-                c.emu.pop_stack(state.window_pos_alloc);
+                release_window_position_allocations(c, state);
                 return FALSE;
             }
 
@@ -4574,8 +4592,7 @@ namespace sogen
                 return {};
             }
 
-            c.emu.pop_stack(state.changed_window_pos_alloc);
-            c.emu.pop_stack(state.window_pos_alloc);
+            release_window_position_allocations(c, state);
             return TRUE;
         }
 
@@ -4745,6 +4762,12 @@ namespace sogen
                         oldValue = guest_win.lpfnWndProc;
                         guest_win.lpfnWndProc = dwNewLong;
                         win->wnd_proc = dwNewLong;
+                        break;
+
+                    case GWL_STYLE:
+                    case GWL_EXSTYLE:
+                        // TODO: Support runtime GWL_STYLE/GWL_EXSTYLE changes together with
+                        // WM_STYLECHANGING/WM_STYLECHANGED and non-client frame recalculation.
                         break;
 
                     default:

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -444,18 +444,10 @@ namespace sogen
             return position;
         }
 
-        void complete_window_position_change(const syscall_context& c, window& win, const uint64_t window_pos_address,
-                                             emulator_stack_allocation& changed_window_pos_alloc, std::vector<qmsg>& message_queue,
-                                             const bool update_changed_window_position)
+        void apply_window_position_change(const syscall_context& c, window& win, const EMU_WINDOWPOS& position,
+                                          emulator_stack_allocation& changed_window_pos_alloc, std::vector<qmsg>& message_queue,
+                                          const bool update_changed_window_position)
         {
-            EMU_WINDOWPOS position{};
-            c.emu.read_memory(window_pos_address, &position, sizeof(position));
-            if (const auto callback_position = read_window_pos_callback_output(c))
-            {
-                position = *callback_position;
-                c.emu.write_memory(window_pos_address, &position, sizeof(position));
-            }
-
             const auto x = (position.flags & SWP_NOMOVE) != 0 ? win.x : position.x;
             const auto y = (position.flags & SWP_NOMOVE) != 0 ? win.y : position.y;
             const auto width = (position.flags & SWP_NOSIZE) != 0 ? win.width : position.cx;
@@ -514,6 +506,21 @@ namespace sogen
                     break;
                 }
             }
+        }
+
+        void complete_window_position_change(const syscall_context& c, window& win, const uint64_t window_pos_address,
+                                             emulator_stack_allocation& changed_window_pos_alloc, std::vector<qmsg>& message_queue,
+                                             const bool update_changed_window_position)
+        {
+            EMU_WINDOWPOS position{};
+            c.emu.read_memory(window_pos_address, &position, sizeof(position));
+            if (const auto callback_position = read_window_pos_callback_output(c))
+            {
+                position = *callback_position;
+                c.emu.write_memory(window_pos_address, &position, sizeof(position));
+            }
+
+            apply_window_position_change(c, win, position, changed_window_pos_alloc, message_queue, update_changed_window_position);
         }
 
         RECT union_update_rect(const RECT& a, const RECT& b)
@@ -4425,8 +4432,52 @@ namespace sogen
             return old_parent;
         }
 
-        BOOL handle_NtUserSetWindowPos(const syscall_context& c, const hwnd hWnd, const hwnd /*hwnd_insert_after*/, const int x,
-                                       const int y, const int cx, const int cy, const UINT flags)
+        void finish_set_window_position(const syscall_context& c, window& win, window_position_state& state, const int old_x,
+                                        const int old_y, const int old_width, const int old_height)
+        {
+            EMU_WINDOWPOS position{};
+            c.emu.read_memory(state.window_pos_alloc.address(), &position, sizeof(position));
+            const bool showing_hidden_window = (position.flags & SWP_SHOWWINDOW) != 0 && (win.style & WS_VISIBLE) == 0;
+            const bool hiding_visible_window = (position.flags & SWP_HIDEWINDOW) != 0 && (win.style & WS_VISIBLE) != 0;
+
+            if ((position.flags & SWP_HIDEWINDOW) != 0)
+            {
+                win.style &= ~WS_VISIBLE;
+                win.guest.access([&](USER_WINDOW& guest_win) { guest_win.dwStyle = win.style; });
+                if (win.host_surface_window)
+                {
+                    c.win_emu.ui().set_window_visible(win.handle, false);
+                }
+            }
+            else if (showing_hidden_window)
+            {
+                win.style |= WS_VISIBLE;
+                win.guest.access([&](USER_WINDOW& guest_win) { guest_win.dwStyle = win.style; });
+                if (win.host_surface_window)
+                {
+                    c.win_emu.ui().set_window_visible(win.handle, true);
+                }
+                invalidate_window_tree(c, win);
+            }
+
+            const bool geometry_changed = old_x != win.x || old_y != win.y || old_width != win.width || old_height != win.height;
+            if ((position.flags & SWP_NOREDRAW) == 0 && !showing_hidden_window && geometry_changed)
+            {
+                invalidate_window(c, win, std::nullopt, false);
+            }
+
+            const bool frame_changed = (position.flags & SWP_FRAMECHANGED) != 0;
+            const bool z_order_changed = (position.flags & SWP_NOZORDER) == 0;
+            if (geometry_changed || showing_hidden_window || hiding_visible_window || frame_changed || z_order_changed)
+            {
+                state.message_queue.push_back(
+                    {.message = WM_WINDOWPOSCHANGED, .wParam = 0, .lParam = state.changed_window_pos_alloc.address()});
+            }
+            state.position_applied = true;
+        }
+
+        BOOL handle_NtUserSetWindowPos(const syscall_context& c, const hwnd hWnd, const hwnd hwnd_insert_after, const int x, const int y,
+                                       const int cx, const int cy, const UINT flags)
         {
             auto* win = c.proc.windows.get(hWnd);
             if (!win)
@@ -4434,36 +4485,76 @@ namespace sogen
                 return FALSE;
             }
 
-            const auto new_x = (flags & SWP_NOMOVE) ? win->x : x;
-            const auto new_y = (flags & SWP_NOMOVE) ? win->y : y;
-            const auto new_width = (flags & SWP_NOSIZE) ? win->width : cx;
-            const auto new_height = (flags & SWP_NOSIZE) ? win->height : cy;
-            const bool showing_hidden_window = (flags & SWP_SHOWWINDOW) != 0 && (win->style & WS_VISIBLE) == 0;
-            const bool repaint = (flags & SWP_NOREDRAW) == 0 && !showing_hidden_window;
+            window_position_state state{};
+            state.window_pos_alloc = c.emu.push_stack(EMU_WINDOWPOS{
+                .hwnd = hWnd,
+                .hwndInsertAfter = hwnd_insert_after,
+                .x = x,
+                .y = y,
+                .cx = cx,
+                .cy = cy,
+                .flags = flags,
+            });
 
-            update_window_geometry(c, *win, new_x, new_y, new_width, new_height, repaint);
-
-            if ((flags & SWP_HIDEWINDOW) != 0)
+            if ((flags & SWP_NOSENDCHANGING) == 0)
             {
-                win->style &= ~WS_VISIBLE;
-                win->guest.access([&](USER_WINDOW& guest_win) { guest_win.dwStyle = win->style; });
-                if (win->host_surface_window)
-                {
-                    c.win_emu.ui().set_window_visible(hWnd, false);
-                }
+                const auto window_pos_address = state.window_pos_alloc.address();
+                dispatch_window_message(c, callback_id::NtUserSetWindowPos, std::move(state), *win, WM_WINDOWPOSCHANGING, 0,
+                                        window_pos_address);
             }
-            else if (showing_hidden_window)
+            else
             {
-                win->style |= WS_VISIBLE;
-                win->guest.access([&](USER_WINDOW& guest_win) { guest_win.dwStyle = win->style; });
-                if (win->host_surface_window)
-                {
-                    c.win_emu.ui().set_window_visible(hWnd, true);
-                }
-                // Repaint the now-visible window and its child controls (see invalidate_window_tree).
-                invalidate_window_tree(c, *win);
+                const auto old_x = win->x;
+                const auto old_y = win->y;
+                const auto old_width = win->width;
+                const auto old_height = win->height;
+
+                EMU_WINDOWPOS position{};
+                c.emu.read_memory(state.window_pos_alloc.address(), &position, sizeof(position));
+                apply_window_position_change(c, *win, position, state.changed_window_pos_alloc, state.message_queue, true);
+                finish_set_window_position(c, *win, state, old_x, old_y, old_width, old_height);
+
+                dispatch_next_message(c, callback_id::NtUserSetWindowPos, std::move(state), *win, state.message_queue);
             }
 
+            return {};
+        }
+
+        BOOL completion_NtUserSetWindowPos(const syscall_context& c, const hwnd hWnd, const hwnd /*hwnd_insert_after*/, const int /*x*/,
+                                           const int /*y*/, const int /*cx*/, const int /*cy*/, const UINT /*flags*/)
+        {
+            auto& state = c.get_completion_state<window_position_state>();
+            auto* win = c.proc.windows.get(hWnd);
+            if (!win)
+            {
+                if (state.changed_window_pos_alloc)
+                {
+                    c.emu.pop_stack(state.changed_window_pos_alloc);
+                }
+                c.emu.pop_stack(state.window_pos_alloc);
+                return FALSE;
+            }
+
+            if (!state.position_applied)
+            {
+                const auto old_x = win->x;
+                const auto old_y = win->y;
+                const auto old_width = win->width;
+                const auto old_height = win->height;
+
+                complete_window_position_change(c, *win, state.window_pos_alloc.address(), state.changed_window_pos_alloc,
+                                                state.message_queue, true);
+                finish_set_window_position(c, *win, state, old_x, old_y, old_width, old_height);
+            }
+
+            if (!state.message_queue.empty())
+            {
+                dispatch_next_message(c, callback_id::NtUserSetWindowPos, std::move(state), *win, state.message_queue);
+                return {};
+            }
+
+            c.emu.pop_stack(state.changed_window_pos_alloc);
+            c.emu.pop_stack(state.window_pos_alloc);
             return TRUE;
         }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -361,15 +361,19 @@ namespace sogen
 
         ui_insets get_host_ui_client_insets(const window& win)
         {
-            const auto border = win.nonclient_border();
-            return {.left = border, .top = border, .right = border, .bottom = border};
+            const auto insets = win.nonclient_insets();
+            return {.left = insets.left, .top = insets.top, .right = insets.right, .bottom = insets.bottom};
         }
 
         void sync_guest_window_rects(window& win)
         {
             const auto window_rect = get_window_rect(win);
-            // Frameless: the client sits at the window origin, so it shares the top-left and shrinks by the frame.
-            const RECT client_rect{.left = win.x, .top = win.y, .right = win.x + win.client_width(), .bottom = win.y + win.client_height()};
+            const auto client_x = win.x + win.client_x_offset();
+            const auto client_y = win.y + win.client_y_offset();
+            const RECT client_rect{.left = client_x,
+                                   .top = client_y,
+                                   .right = client_x + win.client_width(),
+                                   .bottom = client_y + win.client_height()};
 
             win.guest.access([&](USER_WINDOW& guest_win) {
                 guest_win.rcWindow = window_rect;
@@ -1041,6 +1045,11 @@ namespace sogen
         template <typename T>
         void dispatch_next_message(const syscall_context& c, callback_id id, T&& state, const window& win, std::vector<qmsg>& message_queue)
         {
+            if (message_queue.empty())
+            {
+                throw std::runtime_error("Cannot dispatch the next message because the message queue is empty");
+            }
+
             const auto m = message_queue.back();
             message_queue.pop_back();
 
@@ -3053,10 +3062,15 @@ namespace sogen
                 guest_win.dwExStyle = ex_style;
                 guest_win.dwStyle = style;
                 guest_win.rcWindow = {.left = x, .top = y, .right = x + width, .bottom = y + height};
-                // The client rect is the window minus its non-client frame (see window::nonclient_border). The
+                // The client rect is the window minus its non-client frame (see window::nonclient_insets). The
                 // guest reads rcClient client-side to size its render target/backbuffer, so seeding it with the
-                // outer rect here makes a framed window render 2px too large and rescale (softening the frame).
-                guest_win.rcClient = {.left = x, .top = y, .right = x + win.client_width(), .bottom = y + win.client_height()};
+                // outer rect here makes a framed window render too large and rescale (softening the frame).
+                const auto client_x = x + win.client_x_offset();
+                const auto client_y = y + win.client_y_offset();
+                guest_win.rcClient = {.left = client_x,
+                                      .top = client_y,
+                                      .right = client_x + win.client_width(),
+                                      .bottom = client_y + win.client_height()};
                 if (parent_win && has_child_parent)
                 {
                     guest_win.spwndParent = parent_win->guest.value();
@@ -4485,8 +4499,7 @@ namespace sogen
                 return FALSE;
             }
 
-            window_position_state state{};
-            state.window_pos_alloc = c.emu.push_stack(EMU_WINDOWPOS{
+            EMU_WINDOWPOS position{
                 .hwnd = hWnd,
                 .hwndInsertAfter = hwnd_insert_after,
                 .x = x,
@@ -4494,7 +4507,10 @@ namespace sogen
                 .cx = cx,
                 .cy = cy,
                 .flags = flags,
-            });
+            };
+
+            window_position_state state{};
+            state.window_pos_alloc = c.emu.push_stack(position);
 
             if ((flags & SWP_NOSENDCHANGING) == 0)
             {
@@ -4509,10 +4525,15 @@ namespace sogen
                 const auto old_width = win->width;
                 const auto old_height = win->height;
 
-                EMU_WINDOWPOS position{};
-                c.emu.read_memory(state.window_pos_alloc.address(), &position, sizeof(position));
                 apply_window_position_change(c, *win, position, state.changed_window_pos_alloc, state.message_queue, true);
                 finish_set_window_position(c, *win, state, old_x, old_y, old_width, old_height);
+
+                if (state.message_queue.empty())
+                {
+                    c.emu.pop_stack(state.changed_window_pos_alloc);
+                    c.emu.pop_stack(state.window_pos_alloc);
+                    return TRUE;
+                }
 
                 dispatch_next_message(c, callback_id::NtUserSetWindowPos, std::move(state), *win, state.message_queue);
             }
@@ -6103,7 +6124,7 @@ namespace sogen
 
         uint64_t handle_NtUserGetProcessDpiAwarenessContext()
         {
-            return 0;
+            return USER_DEFAULT_DPI_CONTEXT;
         }
 
         NTSTATUS handle_NtUserSetProcessDpiAwarenessContext()

--- a/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/sdl_ui_backend.cpp
@@ -1054,13 +1054,16 @@ namespace sogen
             void set_cursor_position(const hwnd window, const int32_t screen_x, const int32_t screen_y) override
             {
                 this->queue_or_run([this, window, screen_x, screen_y] {
-                    // Top-levels are positioned at their emulated rect (SDL_SetWindowPosition), so emulated screen
-                    // coordinates map to guest client pixels by subtracting that origin.
+                    // SDL exposes only the drawable client area, while emulated screen coordinates include the guest frame.
                     const auto top = this->get_top_level_ancestor(window);
                     if (auto* state = this->resolve_window(top); state && state->window)
                     {
-                        auto window_x = static_cast<float>(screen_x - state->desc.rect.left);
-                        auto window_y = static_cast<float>(screen_y - state->desc.rect.top);
+                        const auto outer_width = std::max<int32_t>(0, state->desc.rect.right - state->desc.rect.left);
+                        const auto outer_height = std::max<int32_t>(0, state->desc.rect.bottom - state->desc.rect.top);
+                        const auto client_x_offset = std::min<int32_t>(outer_width, state->desc.client_insets.left);
+                        const auto client_y_offset = std::min<int32_t>(outer_height, state->desc.client_insets.top);
+                        auto window_x = static_cast<float>(screen_x - state->desc.rect.left - client_x_offset);
+                        auto window_y = static_cast<float>(screen_y - state->desc.rect.top - client_y_offset);
                         // The frame is letterboxed into the window, so guest pixels are not at the same position in
                         // the host window; map through the same transform map_window_point inverts.
                         if (state->renderer)

--- a/src/windows-emulator/ui_backends/web_ui_backend.cpp
+++ b/src/windows-emulator/ui_backends/web_ui_backend.cpp
@@ -13,11 +13,6 @@ namespace sogen
             ui_event event{};
         };
 
-        // The guest models windows without a non-client area (client rect == window rect),
-        // so the presented surface fills the whole window rect. The host draws the caption
-        // bar and frame *around* that rect (see web_ui_host.js), exactly like the SDL backend
-        // relies on the OS window manager to decorate the client area. We therefore forward
-        // the guest's own (zero) insets unchanged rather than reserving title-bar space inside.
         ui_insets get_web_ui_client_insets(const ui_window_desc& desc)
         {
             return desc.client_insets;

--- a/src/windows-emulator/window_show_orchestrator.cpp
+++ b/src/windows-emulator/window_show_orchestrator.cpp
@@ -49,7 +49,8 @@ namespace sogen
 
         if (emit_size_move)
         {
-            this->data_.message_queue.push_back({.message = WM_MOVE, .wParam = 0, .lParam = pack_message_lparam(win.x, win.y)});
+            this->data_.message_queue.push_back(
+                {.message = WM_MOVE, .wParam = 0, .lParam = pack_message_lparam(win.client_x(), win.client_y())});
             this->data_.message_queue.push_back(
                 {.message = WM_SIZE, .wParam = 0, .lParam = pack_message_lparam(win.client_width(), win.client_height())});
         }

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -173,15 +173,14 @@ namespace sogen
             return this->class_name == builtin_dialog_class_name;
         }
 
-        // The guest sizes its window via AdjustWindowRect, which inflates the client rect it wants to render
-        // into by the non-client frame. user32 always adds a 1px border for framed windows (SM_CXBORDER/
-        // SM_CYBORDER are hardcoded to 1) and our system metrics for the sizing frame and caption are zero, so
-        // the only inset is that 1px border. Mirror it so the client size we report (GetClientRect, the Vulkan
-        // surface extent, the presented surface) matches what the guest actually renders -- otherwise the
-        // layer (DXVK) renders its whole frame onto a 1px-larger surface and the upscaled image softens.
         int32_t nonclient_border() const
         {
-            return (this->style & (WS_BORDER | WS_DLGFRAME | WS_THICKFRAME)) != 0 ? 1 : 0;
+            if ((this->style & WS_THICKFRAME) != 0)
+            {
+                return 3;
+            }
+
+            return (this->style & (WS_BORDER | WS_DLGFRAME)) != 0 ? 1 : 0;
         }
 
         int32_t client_width() const

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -173,24 +173,64 @@ namespace sogen
             return this->class_name == builtin_dialog_class_name;
         }
 
-        int32_t nonclient_border() const
+        RECT nonclient_insets() const
         {
+            int32_t border = 0;
+
+            const bool caption = (this->style & WS_CAPTION) == WS_CAPTION;
             if ((this->style & WS_THICKFRAME) != 0)
             {
-                return 3;
+                border = caption ? 3 : 2;
+            }
+            else if (caption)
+            {
+                border = 1;
+            }
+            else if ((this->style & WS_DLGFRAME) != 0)
+            {
+                border = 3;
+            }
+            else if ((this->style & WS_BORDER) != 0)
+            {
+                border = 1;
             }
 
-            return (this->style & (WS_BORDER | WS_DLGFRAME)) != 0 ? 1 : 0;
+            if ((this->ex_style & WS_EX_CLIENTEDGE) != 0)
+            {
+                border += 2;
+            }
+
+            return {.left = border, .top = border, .right = border, .bottom = border};
+        }
+
+        int32_t client_x_offset() const
+        {
+            const auto outer_width = std::max(0, this->width);
+            return std::min<int>(outer_width, this->nonclient_insets().left);
+        }
+
+        int32_t client_y_offset() const
+        {
+            const auto outer_height = std::max(0, this->height);
+            return std::min<int>(outer_height, this->nonclient_insets().top);
         }
 
         int32_t client_width() const
         {
-            return std::max(0, this->width - 2 * this->nonclient_border());
+            const auto outer_width = std::max(0, this->width);
+            const auto insets = this->nonclient_insets();
+            const auto client_left = std::min<int>(outer_width, insets.left);
+            const auto client_right = std::max<int>(client_left, outer_width - insets.right);
+            return client_right - client_left;
         }
 
         int32_t client_height() const
         {
-            return std::max(0, this->height - 2 * this->nonclient_border());
+            const auto outer_height = std::max(0, this->height);
+            const auto insets = this->nonclient_insets();
+            const auto client_top = std::min<int>(outer_height, insets.top);
+            const auto client_bottom = std::max<int>(client_top, outer_height - insets.bottom);
+            return client_bottom - client_top;
         }
 
         void serialize_object(utils::buffer_serializer& buffer) const override

--- a/src/windows-emulator/windows_objects.hpp
+++ b/src/windows-emulator/windows_objects.hpp
@@ -215,6 +215,16 @@ namespace sogen
             return std::min<int>(outer_height, this->nonclient_insets().top);
         }
 
+        int32_t client_x() const
+        {
+            return this->x + this->client_x_offset();
+        }
+
+        int32_t client_y() const
+        {
+            return this->y + this->client_y_offset();
+        }
+
         int32_t client_width() const
         {
             const auto outer_width = std::max(0, this->width);


### PR DESCRIPTION
This PR fixes some issues with window geometry:

* Replaces the fixed `nonclient_border()` model with style-aware `nonclient_insets()`, accounting for `WS_BORDER`, `WS_DLGFRAME`, `WS_THICKFRAME`, `WS_CAPTION`, and `WS_EX_CLIENTEDGE`; derives `client_x/y/width/height` from those insets.
* Corrects `rcWindow` / `rcClient` separation so `rcClient` starts at the actual client origin rather than the outer-window origin, fixing framed-window client geometry and render-target sizing.
* Makes GDI window surfaces use `client_width()` / `client_height()` instead of outer window dimensions, preventing non-client pixels from inflating the backing surface.
* Makes the web UI render the surface at `clientRect`, clip it to the client area, derive frame/caption geometry from client insets, and perform client-area hit testing / mouse coordinate translation against the client origin.
* Corrects SDL cursor coordinate conversion by subtracting the guest non-client left/top insets before mapping into the drawable client area.
* Reworks `NtUserSetWindowPos` into a callback/completion path implementing `WM_WINDOWPOSCHANGING` -> geometry application -> `WM_WINDOWPOSCHANGED`, including callback-modified `WINDOWPOS`, `SWP_NOSENDCHANGING`, `SWP_NOCLIENTMOVE`, and `SWP_NOCLIENTSIZE` semantics.
* Corrects `SetWindowPos` visibility/redraw behavior for `SWP_SHOWWINDOW`, `SWP_HIDEWINDOW`, and `SWP_NOREDRAW`, including invalidation when geometry changes or a hidden window becomes visible.
* Changes `WM_MOVE` coordinates to the client origin and keeps `WM_SIZE` based on client dimensions, including initial/show-window message generation.
* Corrects the USER window DPI context encoding in the window object.

I used this test to make sure these changes match Windows behavior: https://pastebin.com/raw/cyPxWMAn (108 tests fail on main, this PR brings that down to 16).

# Before

<img width="776" height="493" alt="image" src="https://github.com/user-attachments/assets/d7cb82ad-caf2-44b6-8494-3effc6a082bd" />
(Note the white border at the bottom)

# After

<img width="774" height="488" alt="image" src="https://github.com/user-attachments/assets/eabd8b10-3296-4b67-9097-c23db5e9587a" />

