### PR TITLE
Fixing WHP FPU register initialization

### DIFF
--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -2077,7 +2077,7 @@ namespace sogen::whp
                 values[12].Reg64 = 0;
                 values[13].FpControlStatus.FpControl = 0x037Full;
                 values[13].FpControlStatus.FpStatus = 0;
-                values[13].FpControlStatus.FpTag = 0xFF;
+                values[13].FpControlStatus.FpTag = 0x0;
                 values[14].XmmControlStatus.XmmStatusControl = 0x1F80u;
                 values[14].XmmControlStatus.XmmStatusControlMask = 0xFFFFFFFFu;
                 values[15].Reg64 = this->syscall_hook_page_;


### PR DESCRIPTION
The WHP backend mistakenly marks all x87 registers as used from the start. This PR fixes that.

This also partially fixes #1278, but only for the WHP backend. The issue still persists with the other backends.

(My first PR ever, sorry if I did something wrong.)
