### PR TITLE
Fix KVM FPU tag word initialization

### DIFF
--- a/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
+++ b/src/backends/kvm-emulator/kvm_x86_64_emulator.cpp
@@ -1461,7 +1461,7 @@ namespace sogen::kvm
                 kvm_fpu fpu{};
                 fpu.fcw = 0x037Fu;
                 fpu.fsw = 0;
-                fpu.ftwx = 0xFF;
+                fpu.ftwx = 0x0;
                 fpu.mxcsr = 0x1F80u;
                 this->set_fpu(fpu);
 


### PR DESCRIPTION
Applies the #1283 fix to the KVM backend.

`kvm_fpu::ftwx` is documented in `asm/kvm.h` as `/* in fxsave format */`, i.e. the abridged tag word where a set bit marks the corresponding x87 register as **valid**. The architectural reset state is FTW = `0xFFFF` (all slots empty), which in abridged form is `0x0`.

Initializing it to `0xFF` brought the vCPU up with all eight x87 slots marked occupied. The guest's first `fld`/`fild` then hit an x87 stack overflow (IE|SF, C1=0); since `fcw` is initialized to `0x037F` the invalid-operation exception is masked, so the load silently produced QNaN indefinite instead of the operand while TOP kept wrapping. Guest code doing real x87 work computes garbage from there on — see #1278.

Both backends picked up the wrong constant in 7e22ecf. #1283 fixes the WHP side (`FpControlStatus.FpTag`); this does the same for KVM.

The value stays consistent with how the rest of the tree treats `x86_register::fptag`: `kvm_x86_64_emulator.cpp` only widens/narrows `ftwx` between `uint8_t` and `uint16_t`, and `cpu_context.cpp` stores it straight into `XSAVE_FORMAT::TagWord`, which is a `BYTE` — the same abridged encoding.

## Testing

Not built or run locally: the CMake configure fails in this environment on missing SDL3 (and KVM is unavailable in the container), so this is a spec-level change verified against `asm/kvm.h` and the surrounding uses rather than empirically. CI covers the build.

A guest-side check on a KVM host would be: without an explicit `finit`, run `fld1` / `fstsw ax` and confirm SF/C1 are clear and `st0 == 1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tUuZihD1efKJoZv9cPAd1

---
_Generated by [Claude Code](https://claude.ai/code/session_015tUuZihD1efKJoZv9cPAd1)_