### PR TITLE
VKD3D bring-up (Part 4)

### DIFF
--- a/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
+++ b/src/gpu-bridge-protocol/gpu_bridge_protocol.hpp
@@ -194,6 +194,10 @@ namespace sogen::gpu_bridge
         get_physical_device_cooperative_matrix_properties = 0x89B,
         get_physical_device_fragment_shading_rates = 0x89C,
         get_physical_device_calibrateable_time_domains = 0x89D,
+        create_pipeline_cache = 0x89E,
+        destroy_pipeline_cache = 0x89F,
+        get_pipeline_cache_data = 0x8A0,
+        merge_pipeline_caches = 0x8A1,
         get_device_memory_commitment = 0x8A2,
         get_calibrated_timestamps = 0x8A3,
     };
@@ -349,6 +353,10 @@ namespace sogen::gpu_bridge
         make_ioctl(static_cast<uint32_t>(command::get_physical_device_calibrateable_time_domains));
     inline constexpr uint32_t ioctl_get_device_memory_commitment = make_ioctl(static_cast<uint32_t>(command::get_device_memory_commitment));
     inline constexpr uint32_t ioctl_get_calibrated_timestamps = make_ioctl(static_cast<uint32_t>(command::get_calibrated_timestamps));
+    inline constexpr uint32_t ioctl_create_pipeline_cache = make_ioctl(static_cast<uint32_t>(command::create_pipeline_cache));
+    inline constexpr uint32_t ioctl_destroy_pipeline_cache = make_ioctl(static_cast<uint32_t>(command::destroy_pipeline_cache));
+    inline constexpr uint32_t ioctl_get_pipeline_cache_data = make_ioctl(static_cast<uint32_t>(command::get_pipeline_cache_data));
+    inline constexpr uint32_t ioctl_merge_pipeline_caches = make_ioctl(static_cast<uint32_t>(command::merge_pipeline_caches));
 
     // Opaque identifier handed to the guest in place of a host Vulkan handle. The host keeps the
     // real VkInstance / VkPhysicalDevice / ... in a table and the guest only ever sees this id, so
@@ -1384,6 +1392,40 @@ namespace sogen::gpu_bridge
         std::array<uint8_t, max_shader_module_identifier_size> identifier;
     };
 
+    struct create_pipeline_cache_request
+    {
+        object_id device;
+        uint32_t flags;             // VkPipelineCacheCreateFlags
+        uint32_t initial_data_size; // bytes immediately following this header
+        // uint8_t initial_data[initial_data_size];
+    };
+
+    struct get_pipeline_cache_data_request
+    {
+        object_id device;
+        object_id pipeline_cache;
+        uint64_t max_data_size; // guest-provided capacity
+        uint32_t has_data;      // non-zero when pData was supplied, even if max_data_size is zero
+        uint32_t reserved;
+    };
+
+    struct get_pipeline_cache_data_response
+    {
+        int32_t vk_result;
+        uint32_t reserved;
+        uint64_t data_size; // bytes written, or total required for a count-only query
+        // uint8_t data[data_size];
+    };
+
+    struct merge_pipeline_caches_request
+    {
+        object_id device;
+        object_id destination_cache;
+        uint32_t source_count;
+        uint32_t reserved;
+        // object_id source_caches[source_count];
+    };
+
     struct create_image_view_request
     {
         object_id device;
@@ -1748,7 +1790,8 @@ namespace sogen::gpu_bridge
     struct create_graphics_pipeline_request
     {
         object_id device;
-        object_id render_pass; // 0 => dynamic rendering: use the attachment formats below, and viewport/scissor are dynamic
+        object_id pipeline_cache; // null_object => VK_NULL_HANDLE
+        object_id render_pass;    // 0 => dynamic rendering: use the attachment formats below, and viewport/scissor are dynamic
         object_id pipeline_layout;
         shader_stage_source vertex_shader;
         shader_stage_source fragment_shader;
@@ -1796,6 +1839,7 @@ namespace sogen::gpu_bridge
     struct create_compute_pipeline_request
     {
         object_id device;
+        object_id pipeline_cache; // null_object => VK_NULL_HANDLE
         object_id pipeline_layout;
         shader_stage_source shader;
         uint32_t flags; // VkPipelineCreateFlags
@@ -2265,8 +2309,12 @@ namespace sogen::gpu_bridge
     static_assert(sizeof(vertex_input_divisor) == 8, "wire layout drift");
     static_assert(sizeof(shader_module_identifier_response) == 40, "wire layout drift");
     static_assert(sizeof(shader_stage_source) == 48, "wire layout drift");
-    static_assert(sizeof(create_compute_pipeline_request) == 72, "wire layout drift");
-    static_assert(sizeof(create_graphics_pipeline_request) == 504, "wire layout drift");
+    static_assert(sizeof(create_pipeline_cache_request) == 16, "wire layout drift");
+    static_assert(sizeof(get_pipeline_cache_data_request) == 32, "wire layout drift");
+    static_assert(sizeof(get_pipeline_cache_data_response) == 16, "wire layout drift");
+    static_assert(sizeof(merge_pipeline_caches_request) == 24, "wire layout drift");
+    static_assert(sizeof(create_compute_pipeline_request) == 80, "wire layout drift");
+    static_assert(sizeof(create_graphics_pipeline_request) == 512, "wire layout drift");
     static_assert(sizeof(buffer_copy_region) == 24, "wire layout drift");
     static_assert(sizeof(cmd_copy_buffer_request) == 32, "wire layout drift");
     static_assert(sizeof(create_query_pool_request) == 24, "wire layout drift");

--- a/src/samples/vulkan-shim-test/vulkan-shim-test.cpp
+++ b/src/samples/vulkan-shim-test/vulkan-shim-test.cpp
@@ -337,6 +337,74 @@ namespace
         return ok;
     }
 
+    bool test_pipeline_cache(PFN_vkGetInstanceProcAddr get_instance_proc, VkInstance instance, VkDevice device)
+    {
+        const auto get_device_proc = reinterpret_cast<PFN_vkGetDeviceProcAddr>(get_instance_proc(instance, "vkGetDeviceProcAddr"));
+        if (!get_device_proc)
+        {
+            std::printf("[shim-test] no vkGetDeviceProcAddr for pipeline cache test\n");
+            return false;
+        }
+
+        const auto create_pipeline_cache = reinterpret_cast<PFN_vkCreatePipelineCache>(get_device_proc(device, "vkCreatePipelineCache"));
+        const auto destroy_pipeline_cache = reinterpret_cast<PFN_vkDestroyPipelineCache>(get_device_proc(device, "vkDestroyPipelineCache"));
+        const auto get_pipeline_cache_data =
+            reinterpret_cast<PFN_vkGetPipelineCacheData>(get_device_proc(device, "vkGetPipelineCacheData"));
+        const auto merge_pipeline_caches = reinterpret_cast<PFN_vkMergePipelineCaches>(get_device_proc(device, "vkMergePipelineCaches"));
+        if (!create_pipeline_cache || !destroy_pipeline_cache || !get_pipeline_cache_data || !merge_pipeline_caches)
+        {
+            std::printf("[shim-test] pipeline cache entry point missing\n");
+            return false;
+        }
+
+        VkPipelineCacheCreateInfo create_info{};
+        create_info.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
+        VkPipelineCache cache = VK_NULL_HANDLE;
+        const VkResult create_result = create_pipeline_cache(device, &create_info, nullptr, &cache);
+
+        size_t data_size = 0;
+        VkResult size_result = VK_ERROR_INITIALIZATION_FAILED;
+        VkResult data_result = VK_ERROR_INITIALIZATION_FAILED;
+        VkResult seeded_result = VK_ERROR_INITIALIZATION_FAILED;
+        VkResult merge_result = VK_ERROR_INITIALIZATION_FAILED;
+        VkPipelineCache seeded_cache = VK_NULL_HANDLE;
+        if (create_result == VK_SUCCESS)
+        {
+            size_result = get_pipeline_cache_data(device, cache, &data_size, nullptr);
+            if (size_result == VK_SUCCESS)
+            {
+                std::vector<uint8_t> data(data_size);
+                data_result = get_pipeline_cache_data(device, cache, &data_size, data.data());
+                data.resize(data_size);
+                if (data_result == VK_SUCCESS)
+                {
+                    VkPipelineCacheCreateInfo seeded_info{};
+                    seeded_info.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
+                    seeded_info.initialDataSize = data.size();
+                    seeded_info.pInitialData = data.empty() ? nullptr : data.data();
+                    seeded_result = create_pipeline_cache(device, &seeded_info, nullptr, &seeded_cache);
+                    if (seeded_result == VK_SUCCESS)
+                    {
+                        merge_result = merge_pipeline_caches(device, cache, 1, &seeded_cache);
+                    }
+                }
+            }
+        }
+
+        const bool ok = create_result == VK_SUCCESS && size_result == VK_SUCCESS && data_result == VK_SUCCESS &&
+                        seeded_result == VK_SUCCESS && merge_result == VK_SUCCESS;
+        std::printf("[shim-test] pipeline cache round trip -> %s\n", ok ? "PASS" : "FAIL");
+        if (seeded_cache != VK_NULL_HANDLE)
+        {
+            destroy_pipeline_cache(device, seeded_cache, nullptr);
+        }
+        if (cache != VK_NULL_HANDLE)
+        {
+            destroy_pipeline_cache(device, cache, nullptr);
+        }
+        return ok;
+    }
+
     // Allocates a host-visible buffer, has the GPU fill it with a known pattern via vkCmdFillBuffer,
     // then maps it back and verifies the bytes -- the first end-to-end "GPU produces data the guest
     // reads back" path across the bridge.
@@ -890,6 +958,7 @@ int main(int argc, char** argv)
     bool transform_feedback_test_ok = true;
     bool transform_feedback_capabilities_ok = true;
     bool shader_identifier_test_ok = true;
+    bool pipeline_cache_test_ok = true;
     uint32_t count = 0;
     result = enumerate(instance, &count, nullptr);
     std::printf("[shim-test] vkEnumeratePhysicalDevices -> %d, count=%u\n", result, count);
@@ -1172,6 +1241,7 @@ int main(int argc, char** argv)
                 {
                     shader_identifier_test_ok = test_shader_module_identifier(get_instance_proc, instance, device);
                 }
+                pipeline_cache_test_ok = test_pipeline_cache(get_instance_proc, instance, device);
 
                 destroy_device(device, nullptr);
             }
@@ -1184,7 +1254,7 @@ int main(int argc, char** argv)
     }
 
     const bool all_ok = timestamp2_test_ok && calibrated_timestamps_test_ok && transform_feedback_test_ok &&
-                        transform_feedback_capabilities_ok && shader_identifier_test_ok;
+                        transform_feedback_capabilities_ok && shader_identifier_test_ok && pipeline_cache_test_ok;
     std::printf("[shim-test] %s\n", all_ok ? "ok" : "FAILED");
     return all_ok ? 0 : 6;
 }

--- a/src/samples/vulkan-shim/vulkan_shim.cpp
+++ b/src/samples/vulkan-shim/vulkan_shim.cpp
@@ -4850,6 +4850,122 @@ extern "C"
     }
 }
 
+extern "C"
+{
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkCreatePipelineCache(VkDevice device,
+                                                                               const VkPipelineCacheCreateInfo* pCreateInfo,
+                                                                               const VkAllocationCallbacks*,
+                                                                               VkPipelineCache* pPipelineCache)
+    {
+        if (!pCreateInfo || !pPipelineCache || (pCreateInfo->initialDataSize > 0 && !pCreateInfo->pInitialData) ||
+            pCreateInfo->initialDataSize > UINT32_MAX)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        gb::create_pipeline_cache_request request{};
+        request.device = to_object_id(device);
+        request.flags = static_cast<uint32_t>(pCreateInfo->flags);
+        request.initial_data_size = static_cast<uint32_t>(pCreateInfo->initialDataSize);
+        if (request.initial_data_size > MAXDWORD - sizeof(request))
+        {
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+
+        std::vector<uint8_t> message(sizeof(request) + request.initial_data_size);
+        std::memcpy(message.data(), &request, sizeof(request));
+        if (request.initial_data_size > 0)
+        {
+            std::memcpy(message.data() + sizeof(request), pCreateInfo->pInitialData, request.initial_data_size);
+        }
+
+        gb::object_response response{};
+        if (!bridge_call(gb::ioctl_create_pipeline_cache, message.data(), static_cast<DWORD>(message.size()), &response, sizeof(response)))
+        {
+            *pPipelineCache = VK_NULL_HANDLE;
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        *pPipelineCache = response.vk_result == VK_SUCCESS ? to_handle<VkPipelineCache>(response.object) : VK_NULL_HANDLE;
+        return static_cast<VkResult>(response.vk_result);
+    }
+
+    __declspec(dllexport) VKAPI_ATTR void VKAPI_CALL vkDestroyPipelineCache(VkDevice device, VkPipelineCache pipelineCache,
+                                                                            const VkAllocationCallbacks*)
+    {
+        destroy_device_child(gb::ioctl_destroy_pipeline_cache, device, pipelineCache);
+    }
+
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkGetPipelineCacheData(VkDevice device, VkPipelineCache pipelineCache,
+                                                                                size_t* pDataSize, void* pData)
+    {
+        if (!pDataSize)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        const size_t capacity = pData ? *pDataSize : 0;
+        if (capacity > MAXDWORD - sizeof(gb::get_pipeline_cache_data_response))
+        {
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+
+        gb::get_pipeline_cache_data_request request{};
+        request.device = to_object_id(device);
+        request.pipeline_cache = to_object_id(pipelineCache);
+        request.max_data_size = capacity;
+        request.has_data = pData != nullptr;
+
+        std::vector<std::byte> buffer(sizeof(gb::get_pipeline_cache_data_response) + capacity);
+        if (!bridge_call(gb::ioctl_get_pipeline_cache_data, &request, sizeof(request), buffer.data(), static_cast<DWORD>(buffer.size())))
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        const auto* response = reinterpret_cast<const gb::get_pipeline_cache_data_response*>(buffer.data());
+        const size_t written = std::min<size_t>(static_cast<size_t>(response->data_size), capacity);
+        if (pData && written > 0)
+        {
+            std::memcpy(pData, buffer.data() + sizeof(gb::get_pipeline_cache_data_response), written);
+        }
+        *pDataSize = static_cast<size_t>(response->data_size);
+        return static_cast<VkResult>(response->vk_result);
+    }
+
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkMergePipelineCaches(VkDevice device, VkPipelineCache dstCache,
+                                                                               uint32_t srcCacheCount, const VkPipelineCache* pSrcCaches)
+    {
+        if (srcCacheCount > 0 && !pSrcCaches)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        if (srcCacheCount > (MAXDWORD - sizeof(gb::merge_pipeline_caches_request)) / sizeof(gb::object_id))
+        {
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+
+        gb::merge_pipeline_caches_request request{};
+        request.device = to_object_id(device);
+        request.destination_cache = to_object_id(dstCache);
+        request.source_count = srcCacheCount;
+
+        const size_t message_size = sizeof(request) + static_cast<size_t>(srcCacheCount) * sizeof(gb::object_id);
+        std::vector<uint8_t> message(message_size);
+        std::memcpy(message.data(), &request, sizeof(request));
+        for (uint32_t i = 0; i < srcCacheCount; ++i)
+        {
+            const gb::object_id source = to_object_id(pSrcCaches[i]);
+            std::memcpy(message.data() + sizeof(request) + static_cast<size_t>(i) * sizeof(source), &source, sizeof(source));
+        }
+
+        gb::result_response response{};
+        if (!bridge_call(gb::ioctl_merge_pipeline_caches, message.data(), static_cast<DWORD>(message.size()), &response, sizeof(response)))
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        return static_cast<VkResult>(response.vk_result);
+    }
+}
+
 namespace
 {
     struct resolved_stage_source
@@ -4913,7 +5029,7 @@ namespace
 
 extern "C"
 {
-    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkCreateGraphicsPipelines(VkDevice device, VkPipelineCache,
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache,
                                                                                    uint32_t createInfoCount,
                                                                                    const VkGraphicsPipelineCreateInfo* pCreateInfos,
                                                                                    const VkAllocationCallbacks*, VkPipeline* pPipelines)
@@ -5010,6 +5126,7 @@ extern "C"
 
             gb::create_graphics_pipeline_request request{};
             request.device = to_object_id(device);
+            request.pipeline_cache = to_object_id(pipelineCache);
             request.render_pass = to_object_id(ci.renderPass);
             request.pipeline_layout = to_object_id(ci.layout);
             request.vertex_shader = vertex_shader.wire;
@@ -5199,7 +5316,7 @@ extern "C"
         return overall;
     }
 
-    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkCreateComputePipelines(VkDevice device, VkPipelineCache,
+    __declspec(dllexport) VKAPI_ATTR VkResult VKAPI_CALL vkCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache,
                                                                                   uint32_t createInfoCount,
                                                                                   const VkComputePipelineCreateInfo* pCreateInfos,
                                                                                   const VkAllocationCallbacks*, VkPipeline* pPipelines)
@@ -5219,6 +5336,7 @@ extern "C"
 
             gb::create_compute_pipeline_request request{};
             request.device = to_object_id(device);
+            request.pipeline_cache = to_object_id(pipelineCache);
             request.pipeline_layout = to_object_id(ci.layout);
             request.shader = shader.wire;
             request.flags = static_cast<uint32_t>(ci.flags & ~VK_PIPELINE_CREATE_DERIVATIVE_BIT);
@@ -5938,6 +6056,10 @@ extern "C"
             {.name = "vkUpdateDescriptorSetWithTemplateKHR",
              .func = reinterpret_cast<PFN_vkVoidFunction>(vkUpdateDescriptorSetWithTemplate)},
             {.name = "vkCmdBindDescriptorSets", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCmdBindDescriptorSets)},
+            {.name = "vkCreatePipelineCache", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreatePipelineCache)},
+            {.name = "vkDestroyPipelineCache", .func = reinterpret_cast<PFN_vkVoidFunction>(vkDestroyPipelineCache)},
+            {.name = "vkGetPipelineCacheData", .func = reinterpret_cast<PFN_vkVoidFunction>(vkGetPipelineCacheData)},
+            {.name = "vkMergePipelineCaches", .func = reinterpret_cast<PFN_vkVoidFunction>(vkMergePipelineCaches)},
             {.name = "vkCreateGraphicsPipelines", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateGraphicsPipelines)},
             {.name = "vkCreateComputePipelines", .func = reinterpret_cast<PFN_vkVoidFunction>(vkCreateComputePipelines)},
             {.name = "vkDestroyPipeline", .func = reinterpret_cast<PFN_vkVoidFunction>(vkDestroyPipeline)},

--- a/src/samples/vulkan-shim/vulkan_shim.def
+++ b/src/samples/vulkan-shim/vulkan_shim.def
@@ -111,6 +111,7 @@ EXPORTS
     vkCreateImageView
     vkCreateInstance
     vkCreatePipelineLayout
+    vkCreatePipelineCache
     vkCreateRenderPass
     vkCreateSampler
     vkCreateShaderModule
@@ -130,6 +131,7 @@ EXPORTS
     vkDestroyImageView
     vkDestroyInstance
     vkDestroyPipeline
+    vkDestroyPipelineCache
     vkDestroyPipelineLayout
     vkDestroyRenderPass
     vkDestroySampler
@@ -163,6 +165,7 @@ EXPORTS
     vkGetImageSparseMemoryRequirements2KHR
     vkGetImageSubresourceLayout
     vkGetInstanceProcAddr
+    vkGetPipelineCacheData
     vkGetQueryPoolResults
     vkGetShaderModuleCreateInfoIdentifierEXT
     vkGetShaderModuleIdentifierEXT
@@ -197,6 +200,7 @@ EXPORTS
     vkGetPhysicalDeviceWin32PresentationSupportKHR
     vkGetSwapchainImagesKHR
     vkMapMemory
+    vkMergePipelineCaches
     vkQueuePresentKHR
     vkQueueBindSparse
     vkQueueSubmit

--- a/src/windows-emulator/devices/gpu_bridge.cpp
+++ b/src/windows-emulator/devices/gpu_bridge.cpp
@@ -74,6 +74,14 @@ namespace sogen
                     return handle_get_physical_device_format_properties(win_emu, context);
                 case gpu_bridge::ioctl_create_compute_pipeline:
                     return handle_create_compute_pipeline(win_emu, context);
+                case gpu_bridge::ioctl_create_pipeline_cache:
+                    return handle_create_pipeline_cache(win_emu, context);
+                case gpu_bridge::ioctl_destroy_pipeline_cache:
+                    return handle_destroy_pipeline_cache(win_emu, context);
+                case gpu_bridge::ioctl_get_pipeline_cache_data:
+                    return handle_get_pipeline_cache_data(win_emu, context);
+                case gpu_bridge::ioctl_merge_pipeline_caches:
+                    return handle_merge_pipeline_caches(win_emu, context);
                 case gpu_bridge::ioctl_create_device:
                     return handle_create_device(win_emu, context);
                 case gpu_bridge::ioctl_get_device_queue:
@@ -1235,6 +1243,95 @@ namespace sogen
                 return write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});
             }
 
+            NTSTATUS handle_create_pipeline_cache(windows_emulator& win_emu, const io_device_context& context)
+            {
+                using request_t = gpu_bridge::create_pipeline_cache_request;
+                if (!context.input_buffer || context.input_buffer_length < sizeof(request_t))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                const auto request = emulator_object<request_t>{win_emu.emu(), context.input_buffer}.read();
+                const size_t available = context.input_buffer_length - sizeof(request_t);
+                if (request.initial_data_size > available || request.initial_data_size > max_array_readback_bytes)
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                std::vector<uint8_t> initial_data(request.initial_data_size);
+                if (!initial_data.empty())
+                {
+                    win_emu.emu().read_memory(context.input_buffer + sizeof(request_t), initial_data.data(), initial_data.size());
+                }
+
+                uint64_t cache = gpu_bridge::null_object;
+                const int32_t result = this->vulkan_.create_pipeline_cache(request.device, request.flags, initial_data, cache);
+                return write_output(win_emu, context, gpu_bridge::object_response{.vk_result = result, .reserved = 0, .object = cache});
+            }
+
+            NTSTATUS handle_destroy_pipeline_cache(windows_emulator& win_emu, const io_device_context& context)
+            {
+                gpu_bridge::device_child_request request{};
+                if (!read_input(win_emu, context, request))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+                this->vulkan_.destroy_pipeline_cache(request.device, request.object);
+                return STATUS_SUCCESS;
+            }
+
+            NTSTATUS handle_get_pipeline_cache_data(windows_emulator& win_emu, const io_device_context& context)
+            {
+                using request_t = gpu_bridge::get_pipeline_cache_data_request;
+                using response_t = gpu_bridge::get_pipeline_cache_data_response;
+                if (!context.input_buffer || context.input_buffer_length < sizeof(request_t))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+                if (!context.output_buffer || context.output_buffer_length < sizeof(response_t))
+                {
+                    return STATUS_BUFFER_TOO_SMALL;
+                }
+
+                const auto request = emulator_object<request_t>{win_emu.emu(), context.input_buffer}.read();
+                const size_t capacity = std::min<size_t>(context.output_buffer_length - sizeof(response_t), max_array_readback_bytes);
+                const auto requested = static_cast<size_t>(std::min<uint64_t>(request.max_data_size, capacity));
+                std::vector<std::byte> data(requested);
+
+                size_t data_size = 0;
+                const int32_t result =
+                    this->vulkan_.get_pipeline_cache_data(request.device, request.pipeline_cache, data.empty() ? nullptr : data.data(),
+                                                          data.size(), request.has_data != 0, data_size);
+
+                const response_t response{.vk_result = result, .reserved = 0, .data_size = data_size};
+                emulator_object<response_t>{win_emu.emu(), context.output_buffer}.write(response);
+                const size_t written = std::min(data_size, data.size());
+                if (written > 0)
+                {
+                    win_emu.emu().write_memory(context.output_buffer + sizeof(response_t), data.data(), written);
+                }
+                set_information(context, static_cast<ULONG>(sizeof(response_t) + written));
+                return STATUS_SUCCESS;
+            }
+
+            NTSTATUS handle_merge_pipeline_caches(windows_emulator& win_emu, const io_device_context& context)
+            {
+                using request_t = gpu_bridge::merge_pipeline_caches_request;
+                request_t request{};
+                if (!read_input(win_emu, context, request))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+
+                std::vector<uint64_t> sources;
+                if (!read_trailing_array(win_emu, context, sizeof(request_t), request.source_count, sources))
+                {
+                    return STATUS_INVALID_PARAMETER;
+                }
+                const int32_t result = this->vulkan_.merge_pipeline_caches(request.device, request.destination_cache, sources);
+                return write_output(win_emu, context, gpu_bridge::result_response{.vk_result = result, .reserved = 0});
+            }
+
             NTSTATUS handle_create_compute_pipeline(windows_emulator& win_emu, const io_device_context& context)
             {
                 gpu_bridge::create_compute_pipeline_request request{};
@@ -1254,8 +1351,8 @@ namespace sogen
                 };
 
                 uint64_t pipeline = gpu_bridge::null_object;
-                const int32_t result =
-                    this->vulkan_.create_compute_pipeline(request.device, request.pipeline_layout, shader, request.flags, pipeline);
+                const int32_t result = this->vulkan_.create_compute_pipeline(request.device, request.pipeline_cache,
+                                                                             request.pipeline_layout, shader, request.flags, pipeline);
                 return write_output(win_emu, context,
                                     gpu_bridge::create_compute_pipeline_response{.vk_result = result, .reserved = 0, .pipeline = pipeline});
             }
@@ -2367,11 +2464,11 @@ namespace sogen
 
                 uint64_t pipeline = gpu_bridge::null_object;
                 const int32_t result = this->vulkan_.create_graphics_pipeline(
-                    request.device, request.render_pass, request.pipeline_layout, vertex_shader, fragment_shader, request.flags,
-                    request.width, request.height, bindings, attributes, divisors, depth, color_formats, request.depth_format,
-                    request.stencil_format, request.rasterization_samples, request.primitive_topology, request.primitive_restart_enable,
-                    request.rasterization_stream, request.rasterization_stream_flags, dynamic_states, vs_spec, fs_spec, blend_attachments,
-                    pipeline);
+                    request.device, request.pipeline_cache, request.render_pass, request.pipeline_layout, vertex_shader, fragment_shader,
+                    request.flags, request.width, request.height, bindings, attributes, divisors, depth, color_formats,
+                    request.depth_format, request.stencil_format, request.rasterization_samples, request.primitive_topology,
+                    request.primitive_restart_enable, request.rasterization_stream, request.rasterization_stream_flags, dynamic_states,
+                    vs_spec, fs_spec, blend_attachments, pipeline);
                 if (result != 0)
                 {
                     win_emu.log.error(

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -333,6 +333,10 @@ namespace sogen
             PFN_vkFreeDescriptorSets free_descriptor_sets{};
             PFN_vkUpdateDescriptorSets update_descriptor_sets{};
             PFN_vkCmdBindDescriptorSets cmd_bind_descriptor_sets{};
+            PFN_vkCreatePipelineCache create_pipeline_cache{};
+            PFN_vkDestroyPipelineCache destroy_pipeline_cache{};
+            PFN_vkGetPipelineCacheData get_pipeline_cache_data{};
+            PFN_vkMergePipelineCaches merge_pipeline_caches{};
             PFN_vkCreateGraphicsPipelines create_graphics_pipelines{};
             PFN_vkCreateComputePipelines create_compute_pipelines{};
             PFN_vkDestroyPipeline destroy_pipeline{};
@@ -549,6 +553,12 @@ namespace sogen
             uint64_t device_id{};
         };
 
+        struct pipeline_cache_data
+        {
+            VkPipelineCache handle{};
+            uint64_t device_id{};
+        };
+
         struct descriptor_set_layout_data
         {
             VkDescriptorSetLayout handle{};
@@ -585,6 +595,7 @@ namespace sogen
         std::unordered_map<uint64_t, framebuffer_data> framebuffers;
         std::unordered_map<uint64_t, pipeline_layout_data> pipeline_layouts;
         std::unordered_map<uint64_t, pipeline_data> pipelines;
+        std::unordered_map<uint64_t, pipeline_cache_data> pipeline_caches;
         std::unordered_map<uint64_t, descriptor_set_layout_data> descriptor_set_layouts;
         std::unordered_map<uint64_t, descriptor_pool_data> descriptor_pools;
         std::unordered_map<uint64_t, descriptor_set_data> descriptor_sets;
@@ -833,6 +844,13 @@ namespace sogen
                     it->second.destroy_pipeline(it->second.handle, pipe.handle, nullptr);
                 }
             }
+            for (auto& [id, cache] : this->pipeline_caches)
+            {
+                if (cache.device_id == device_id && cache.handle && it->second.destroy_pipeline_cache)
+                {
+                    it->second.destroy_pipeline_cache(it->second.handle, cache.handle, nullptr);
+                }
+            }
             for (auto& [id, layout] : this->pipeline_layouts)
             {
                 if (layout.device_id == device_id && layout.handle && it->second.destroy_pipeline_layout)
@@ -877,6 +895,7 @@ namespace sogen
             }
             this->erase_owned(this->framebuffers, [&](const framebuffer_data& d) { return d.device_id == device_id; });
             this->erase_owned(this->pipelines, [&](const pipeline_data& d) { return d.device_id == device_id; });
+            this->erase_owned(this->pipeline_caches, [&](const pipeline_cache_data& d) { return d.device_id == device_id; });
             this->erase_owned(this->pipeline_layouts, [&](const pipeline_layout_data& d) { return d.device_id == device_id; });
             this->erase_owned(this->render_passes, [&](const render_pass_data& d) { return d.device_id == device_id; });
             this->erase_owned(this->image_views, [&](const image_view_data& d) { return d.device_id == device_id; });
@@ -2081,6 +2100,10 @@ namespace sogen
             data.free_descriptor_sets = reinterpret_cast<PFN_vkFreeDescriptorSets>(resolve("vkFreeDescriptorSets"));
             data.update_descriptor_sets = reinterpret_cast<PFN_vkUpdateDescriptorSets>(resolve("vkUpdateDescriptorSets"));
             data.cmd_bind_descriptor_sets = reinterpret_cast<PFN_vkCmdBindDescriptorSets>(resolve("vkCmdBindDescriptorSets"));
+            data.create_pipeline_cache = reinterpret_cast<PFN_vkCreatePipelineCache>(resolve("vkCreatePipelineCache"));
+            data.destroy_pipeline_cache = reinterpret_cast<PFN_vkDestroyPipelineCache>(resolve("vkDestroyPipelineCache"));
+            data.get_pipeline_cache_data = reinterpret_cast<PFN_vkGetPipelineCacheData>(resolve("vkGetPipelineCacheData"));
+            data.merge_pipeline_caches = reinterpret_cast<PFN_vkMergePipelineCaches>(resolve("vkMergePipelineCaches"));
             data.create_graphics_pipelines = reinterpret_cast<PFN_vkCreateGraphicsPipelines>(resolve("vkCreateGraphicsPipelines"));
             data.create_compute_pipelines = reinterpret_cast<PFN_vkCreateComputePipelines>(resolve("vkCreateComputePipelines"));
             data.destroy_pipeline = reinterpret_cast<PFN_vkDestroyPipeline>(resolve("vkDestroyPipeline"));
@@ -5570,7 +5593,113 @@ namespace sogen
         return VK_SUCCESS;
     }
 
-    int32_t vulkan_host::create_graphics_pipeline(uint64_t device, uint64_t render_pass, uint64_t pipeline_layout,
+    int32_t vulkan_host::create_pipeline_cache(uint64_t device, uint32_t flags, std::span<const uint8_t> initial_data,
+                                               uint64_t& out_pipeline_cache)
+    {
+        out_pipeline_cache = 0;
+        const auto dev = this->impl_->devices.find(device);
+        if (dev == this->impl_->devices.end() || !dev->second.create_pipeline_cache)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        VkPipelineCacheCreateInfo info{};
+        info.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
+        info.flags = static_cast<VkPipelineCacheCreateFlags>(flags);
+        info.initialDataSize = initial_data.size();
+        info.pInitialData = initial_data.empty() ? nullptr : initial_data.data();
+
+        VkPipelineCache cache = VK_NULL_HANDLE;
+        const VkResult result = dev->second.create_pipeline_cache(dev->second.handle, &info, nullptr, &cache);
+        if (result != VK_SUCCESS)
+        {
+            return result;
+        }
+
+        const uint64_t id = this->impl_->next_id++;
+        this->impl_->pipeline_caches.emplace(id, impl::pipeline_cache_data{.handle = cache, .device_id = device});
+        out_pipeline_cache = id;
+        return VK_SUCCESS;
+    }
+
+    void vulkan_host::destroy_pipeline_cache(uint64_t device, uint64_t pipeline_cache)
+    {
+        const auto dev = this->impl_->devices.find(device);
+        const auto cache = this->impl_->pipeline_caches.find(pipeline_cache);
+        if (cache == this->impl_->pipeline_caches.end() || cache->second.device_id != device)
+        {
+            return;
+        }
+
+        if (dev != this->impl_->devices.end() && cache->second.handle && dev->second.destroy_pipeline_cache)
+        {
+            dev->second.destroy_pipeline_cache(dev->second.handle, cache->second.handle, nullptr);
+        }
+        this->impl_->pipeline_caches.erase(cache);
+    }
+
+    int32_t vulkan_host::get_pipeline_cache_data(uint64_t device, uint64_t pipeline_cache, void* out, size_t out_size, bool has_data,
+                                                 size_t& data_size)
+    {
+        data_size = 0;
+        const auto dev = this->impl_->devices.find(device);
+        const auto cache = this->impl_->pipeline_caches.find(pipeline_cache);
+        if (dev == this->impl_->devices.end() || cache == this->impl_->pipeline_caches.end() || cache->second.device_id != device)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        if (!dev->second.get_pipeline_cache_data)
+        {
+            return VK_ERROR_FEATURE_NOT_PRESENT;
+        }
+
+        std::byte dummy{};
+        void* data = nullptr;
+        if (has_data)
+        {
+            data = out;
+            if (!data)
+            {
+                data = &dummy;
+            }
+        }
+        size_t size = has_data ? out_size : 0;
+        const VkResult result = dev->second.get_pipeline_cache_data(dev->second.handle, cache->second.handle, &size, data);
+        data_size = size;
+        return result;
+    }
+
+    int32_t vulkan_host::merge_pipeline_caches(uint64_t device, uint64_t destination_cache, std::span<const uint64_t> source_caches)
+    {
+        const auto dev = this->impl_->devices.find(device);
+        const auto destination = this->impl_->pipeline_caches.find(destination_cache);
+        if (dev == this->impl_->devices.end() || destination == this->impl_->pipeline_caches.end() ||
+            destination->second.device_id != device)
+        {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        if (!dev->second.merge_pipeline_caches)
+        {
+            return VK_ERROR_FEATURE_NOT_PRESENT;
+        }
+
+        std::vector<VkPipelineCache> sources;
+        sources.reserve(source_caches.size());
+        for (const uint64_t source_id : source_caches)
+        {
+            const auto source = this->impl_->pipeline_caches.find(source_id);
+            if (source == this->impl_->pipeline_caches.end() || source->second.device_id != device)
+            {
+                return VK_ERROR_INITIALIZATION_FAILED;
+            }
+            sources.push_back(source->second.handle);
+        }
+
+        return dev->second.merge_pipeline_caches(dev->second.handle, destination->second.handle, static_cast<uint32_t>(sources.size()),
+                                                 sources.empty() ? nullptr : sources.data());
+    }
+
+    int32_t vulkan_host::create_graphics_pipeline(uint64_t device, uint64_t pipeline_cache, uint64_t render_pass, uint64_t pipeline_layout,
                                                   const shader_stage_source& vertex_shader, const shader_stage_source& fragment_shader,
                                                   uint32_t flags, uint32_t width, uint32_t height, std::span<const vertex_binding> bindings,
                                                   std::span<const vertex_attribute> attributes, std::span<const vertex_divisor> divisors,
@@ -5616,6 +5745,17 @@ namespace sogen
         if (!resolve_stage(vertex_shader, vertex_module) || !resolve_stage(fragment_shader, fragment_module))
         {
             return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        VkPipelineCache cache_handle = VK_NULL_HANDLE;
+        if (pipeline_cache != 0)
+        {
+            const auto cache = this->impl_->pipeline_caches.find(pipeline_cache);
+            if (cache == this->impl_->pipeline_caches.end() || cache->second.device_id != device)
+            {
+                return VK_ERROR_INITIALIZATION_FAILED;
+            }
+            cache_handle = cache->second.handle;
         }
 
         // render_pass == 0 means the pipeline targets dynamic rendering (DXVK 2.x): there is no render-pass
@@ -5881,7 +6021,7 @@ namespace sogen
         info.subpass = 0;
 
         VkPipeline pipeline{};
-        const VkResult result = dev->second.create_graphics_pipelines(dev->second.handle, VK_NULL_HANDLE, 1, &info, nullptr, &pipeline);
+        const VkResult result = dev->second.create_graphics_pipelines(dev->second.handle, cache_handle, 1, &info, nullptr, &pipeline);
         if (result != VK_SUCCESS)
         {
             return result;
@@ -5893,8 +6033,8 @@ namespace sogen
         return VK_SUCCESS;
     }
 
-    int32_t vulkan_host::create_compute_pipeline(uint64_t device, uint64_t pipeline_layout, const shader_stage_source& shader,
-                                                 uint32_t flags, uint64_t& out_pipeline)
+    int32_t vulkan_host::create_compute_pipeline(uint64_t device, uint64_t pipeline_cache, uint64_t pipeline_layout,
+                                                 const shader_stage_source& shader, uint32_t flags, uint64_t& out_pipeline)
     {
         out_pipeline = 0;
 
@@ -5932,6 +6072,17 @@ namespace sogen
             identifier.pIdentifier = shader.identifier.data();
         }
 
+        VkPipelineCache cache_handle = VK_NULL_HANDLE;
+        if (pipeline_cache != 0)
+        {
+            const auto cache = this->impl_->pipeline_caches.find(pipeline_cache);
+            if (cache == this->impl_->pipeline_caches.end() || cache->second.device_id != device)
+            {
+                return VK_ERROR_INITIALIZATION_FAILED;
+            }
+            cache_handle = cache->second.handle;
+        }
+
         VkComputePipelineCreateInfo info{};
         info.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
         info.flags = static_cast<VkPipelineCreateFlags>(flags);
@@ -5943,7 +6094,7 @@ namespace sogen
         info.stage.pName = "main";
 
         VkPipeline pipeline{};
-        const VkResult result = dev->second.create_compute_pipelines(dev->second.handle, VK_NULL_HANDLE, 1, &info, nullptr, &pipeline);
+        const VkResult result = dev->second.create_compute_pipelines(dev->second.handle, cache_handle, 1, &info, nullptr, &pipeline);
         if (result != VK_SUCCESS)
         {
             return result;

--- a/src/windows-emulator/devices/vulkan_host.hpp
+++ b/src/windows-emulator/devices/vulkan_host.hpp
@@ -584,11 +584,17 @@ namespace sogen
             std::span<const uint8_t> identifier;
         };
 
+        int32_t create_pipeline_cache(uint64_t device, uint32_t flags, std::span<const uint8_t> initial_data, uint64_t& out_pipeline_cache);
+        void destroy_pipeline_cache(uint64_t device, uint64_t pipeline_cache);
+        int32_t get_pipeline_cache_data(uint64_t device, uint64_t pipeline_cache, void* out, size_t out_size, bool has_data,
+                                        size_t& data_size);
+        int32_t merge_pipeline_caches(uint64_t device, uint64_t destination_cache, std::span<const uint64_t> source_caches);
+
         // Triangle list, static full-extent viewport/scissor, one non-blended color attachment, optional
         // depth test. Empty vertex input (no bindings/attributes) leaves vertices to be baked into the shader.
         // When render_pass == 0 the pipeline is built for dynamic rendering (VK_KHR_dynamic_rendering) using
         // color_formats/depth_format/stencil_format, with viewport and scissor as dynamic state.
-        int32_t create_graphics_pipeline(uint64_t device, uint64_t render_pass, uint64_t pipeline_layout,
+        int32_t create_graphics_pipeline(uint64_t device, uint64_t pipeline_cache, uint64_t render_pass, uint64_t pipeline_layout,
                                          const shader_stage_source& vertex_shader, const shader_stage_source& fragment_shader,
                                          uint32_t flags, uint32_t width, uint32_t height, std::span<const vertex_binding> bindings,
                                          std::span<const vertex_attribute> attributes, std::span<const vertex_divisor> divisors,
@@ -598,8 +604,8 @@ namespace sogen
                                          uint32_t rasterization_stream_flags, std::span<const uint32_t> dynamic_states,
                                          const specialization& vs_spec, const specialization& fs_spec,
                                          std::span<const color_blend_attachment> blend_attachments, uint64_t& out_pipeline);
-        int32_t create_compute_pipeline(uint64_t device, uint64_t pipeline_layout, const shader_stage_source& shader, uint32_t flags,
-                                        uint64_t& out_pipeline);
+        int32_t create_compute_pipeline(uint64_t device, uint64_t pipeline_cache, uint64_t pipeline_layout,
+                                        const shader_stage_source& shader, uint32_t flags, uint64_t& out_pipeline);
         void destroy_pipeline(uint64_t device, uint64_t pipeline);
 
         // clear_depth is used only when the render pass has a depth attachment.


### PR DESCRIPTION
This PR is a follow-up to https://github.com/momo5502/sogen/pull/1281. It extends Vulkan pipeline cache support in the GPU bridge.

This is the final PR for VKD3D. I double-checked, and the Mario 64 PC port using DirectX 12 still runs:

<img width="650" height="525" alt="image" src="https://github.com/user-attachments/assets/72f036c4-8141-4c7b-817d-52b7287813e2" />
