### PR TITLE
fix: relocate module-view maps that collide with the module's own base

### DIFF
--- a/src/windows-emulator/module/module_mapping.cpp
+++ b/src/windows-emulator/module/module_mapping.cpp
@@ -575,31 +575,27 @@ namespace sogen
             // exhausted address space terminates rather than spins.
             constexpr int max_host_relocation_retries = 8;
             bool mapped = false;
-            // Only valid when the caller left the target address to us. A caller-specified
-            // relocation_base means a view must land on an already-loaded image's own base for its
-            // internal absolute pointers to stay correct, so re-picking would silently misplace it.
-            if (relocation_base == 0)
+            // Also applies when the caller passed a relocation_base: that only expresses a preferred
+            // target (e.g. mapping another view of an already-loaded image at its current base), not a
+            // hard requirement - real Windows itself falls back to relocating such a view elsewhere and
+            // reports STATUS_IMAGE_NOT_AT_BASE rather than failing the map outright.
+            for (int attempt = 0; attempt <= max_host_relocation_retries; ++attempt)
             {
-                for (int attempt = 0; attempt <= max_host_relocation_retries; ++attempt)
+                binary.image_base = memory.find_free_host_allocation_base(image_size, fallback_start, highest_address);
+                if (!binary.image_base)
                 {
-                    binary.image_base = memory.find_free_host_allocation_base(image_size, fallback_start, highest_address);
-                    if (!binary.image_base)
-                    {
-                        break;
-                    }
+                    break;
+                }
 
-                    if (try_map_module_at_current_base(memory, binary, buffer, nt_headers, nt_headers_offset, optional_header,
-                                                       binary.image_base))
-                    {
-                        mapped = true;
-                        break;
-                    }
+                if (try_map_module_at_current_base(memory, binary, buffer, nt_headers, nt_headers_offset, optional_header,
+                                                   binary.image_base))
+                {
+                    mapped = true;
+                    break;
                 }
             }
 
-            if (!mapped && (!binary.image_base ||
-                            !try_map_module_at_current_base(memory, binary, buffer, nt_headers, nt_headers_offset, optional_header,
-                                                            relocation_base ? relocation_base : binary.image_base)))
+            if (!mapped)
             {
                 throw std::runtime_error("Memory range not allocatable");
             }


### PR DESCRIPTION
## Summary

Fixes #1294 — a regression from #1239 that broke `NtMapViewOfSection` for
duplicate views of an already-loaded image (the KnownDlls-view case from
#383).

`handle_NtMapViewOfSection` maps a second view of an already-loaded image
with `relocation_base = loaded_module.image_base`. That address is always
occupied by the module's own first mapping, so the preferred-base attempt
in `map_module_from_data` always fails. #1239's FEX-backend change gated
the free-address retry loop behind `relocation_base == 0`, so this case
fell straight through to a redundant retry at the same already-failed
address and threw `"Memory range not allocatable"` (surfaced to the guest
as `STATUS_FILE_INVALID`).

`relocation_base` only expresses a preference here — the sole caller that
sets it wants "map at this base if possible" — not a hard requirement.
Real Windows relocates such a view elsewhere and reports
`STATUS_IMAGE_NOT_AT_BASE`. This un-gates the retry loop so it always
runs on preferred-base failure, and drops the now-dead final fallback
that only ever retried the address that had just failed.

## Test plan

- [x] `cmake --build --preset=release`
- [x] Compiled and ran the repro from https://github.com/momo5502/sogen/issues/383#issuecomment-2984209869 under `analyzer.exe`:
  - before: `Failed to map module: Memory range not allocatable` -> `STATUS_UNMAPPABLE_VIEW`, both checks FAIL
  - after: `STATUS_IMAGE_NOT_AT_BASE` returned, mapped base differs from the original, both checks PASS
- [x] `analyzer.exe -s test-sample.exe` smoke test still passes
- [x] `windows-emulator-test.exe` — same pre-existing failures with and without this change (unrelated/environmental), no new failures