### PR TITLE
fix(whp): query required XSAVE state size instead of a fixed capacity

### DIFF
--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -42,7 +42,6 @@ namespace sogen::whp
         constexpr uint64_t internal_page_table_base = 0x0000007000000000ull;
         constexpr uint64_t syscall_hook_virtual_address = 0xFFFF800000001000ull;
         constexpr uint64_t unmapped_guest_page = (std::numeric_limits<uint64_t>::max)();
-        constexpr uint32_t xsave_state_capacity = 0xFFF;
 
         uint64_t align_down_to_page(const uint64_t value)
         {
@@ -1140,7 +1139,7 @@ namespace sogen::whp
                                                              static_cast<UINT32>(names.size()), values.data()));
 
                 const auto register_bytes = sizeof(WHV_REGISTER_VALUE) * values.size();
-                std::vector<std::byte> bytes(register_bytes + sizeof(UINT32) + (this->xsave_enabled_ ? xsave_state_capacity : 0));
+                std::vector<std::byte> bytes(register_bytes + sizeof(UINT32));
                 std::memcpy(bytes.data(), values.data(), register_bytes);
 
                 UINT32 xsave_size = 0;
@@ -1148,8 +1147,19 @@ namespace sogen::whp
                 {
                     // WHvGetVirtualProcessorRegisters exposes XMM0-XMM15 and legacy FP state, but not YMM_Hi128, AVX-512, AMX, or other
                     // XSAVE-managed components. Capture the VP XSAVE state to preserve all enabled extended processor state.
+                    // The required size depends on the XSAVE features the host CPU exposes to the partition, so it is queried
+                    // up front instead of assuming a fixed capacity.
+                    UINT32 required_size = 0;
+                    const auto size_hr = WHvGetVirtualProcessorState(this->partition_, this->vp_index_,
+                                                                     WHvVirtualProcessorStateTypeXsaveState, nullptr, 0, &required_size);
+                    if (size_hr != WHV_E_INSUFFICIENT_BUFFER)
+                    {
+                        WHP_CHECK_HR(size_hr);
+                    }
+
+                    bytes.resize(register_bytes + sizeof(xsave_size) + required_size);
                     WHP_CHECK_HR(WHvGetVirtualProcessorState(this->partition_, this->vp_index_, WHvVirtualProcessorStateTypeXsaveState,
-                                                             bytes.data() + register_bytes + sizeof(xsave_size), xsave_state_capacity,
+                                                             bytes.data() + register_bytes + sizeof(xsave_size), required_size,
                                                              &xsave_size));
                 }
 


### PR DESCRIPTION
## Summary
- The WHP backend's `save_registers()` used a hardcoded 4095-byte (`0xFFF`) buffer for `WHvGetVirtualProcessorState(..., WHvVirtualProcessorStateTypeXsaveState, ...)`.
- The actual size needed depends on which XSAVE-managed state components the host CPU exposes to the partition (AVX-512, AMX, etc.), which varies by hardware. On hosts whose exposed XSAVE area exceeds 4095 bytes, the call fails with `WHV_E_INSUFFICIENT_BUFFER` (`0x80370301`) — this is why the WHP smoke test intermittently failed in CI depending on which runner host it landed on.
- Per the API contract, calling with an undersized buffer returns the required size via `BytesWritten`. Now the code probes the required size first (0-byte buffer), resizes, then does the real call — no more fixed-size guess.

## Test plan
- [x] `cmake --build --preset=release` builds cleanly
- [x] `analyzer.exe -s test-sample.exe` smoke test passes
- [ ] CI (this specifically exercises the flaky path across whatever host the runner lands on)