### PR TITLE
ci: configure the fast APT mirror in every job that installs apt packages

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -57,6 +57,12 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Configure fast APT mirror
+        uses: vegardit/fast-apt-mirror.sh@1.4.5
+        if: "${{ matrix.platform == 'Linux' }}"
+        with:
+          exclude-current: true
+
       - name: Install LLVM
         uses: KyleMayes/install-llvm-action@v2
         with:
@@ -111,6 +117,11 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@v7
+
+      - name: Configure fast APT mirror
+        uses: vegardit/fast-apt-mirror.sh@1.4.5
+        with:
+          exclude-current: true
 
       - name: Install Clang-format
         uses: nick-fields/retry@v4.0.0
@@ -337,7 +348,7 @@ jobs:
 
       - name: Configure fast APT mirror
         uses: vegardit/fast-apt-mirror.sh@1.4.5
-        if: "${{ startsWith(matrix.platform, 'MinGW') }}"
+        if: "${{ startsWith(matrix.platform, 'MinGW') || startsWith(matrix.platform, 'Linux') }}"
         with:
           exclude-current: true
 
@@ -1111,6 +1122,12 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+
+      - name: Configure fast APT mirror
+        uses: vegardit/fast-apt-mirror.sh@1.4.5
+        if: "${{ startsWith(matrix.runner, 'ubuntu') }}"
+        with:
+          exclude-current: true
 
       - name: Set up Python
         uses: actions/setup-python@v7


### PR DESCRIPTION
## Summary

`ci-reusable.yml` only wired `vegardit/fast-apt-mirror.sh` up for the MinGW
leg of the `build` matrix. Every other job that runs `apt-get install`/`apt
install` still hits the default `azure.archive.ubuntu.com` mirror:

- `clang-tidy` (Linux leg) - Install Linux UI Dependencies
- `verify-formatting` - Install Clang-format
- `build` - Install Clang / Install Ninja / Install Linux UI Dependencies for
  the non-MinGW Linux platforms in the matrix (Linux x86_64 GCC Sanitizer,
  Linux x86_64 Clang, Linux arm64 Clang)
- `build-python-wheel` - Install Linux UI Dependencies

This is what caused CI on #1295 to fail: `Build / Run Clang Tidy (Linux)`
stalled for 14+ minutes on the default mirror before the `nick-fields/retry`
wrapper's timeout-kill handler crashed with an unrelated `EPERM`, failing the
job before it ever reached the actual build.

## Changes

Add the same `Configure fast APT mirror` step (unconditional on Linux, right
after checkout) ahead of each of those installs, and broaden the existing
`build`-job step's condition from MinGW-only to also cover the Linux
platforms already present in that matrix.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci-reusable.yml'))"` - valid YAML
- [x] Diff reviewed against the existing MinGW/`publish-python-package` usage of `vegardit/fast-apt-mirror.sh` - same step shape, same `exclude-current: true` option
- [ ] CI on this PR exercises the changed jobs directly