### PR TITLE
Implement key creation in NtCreateKey

### DIFF
--- a/src/emulator-platform/platform/registry.hpp
+++ b/src/emulator-platform/platform/registry.hpp
@@ -5,6 +5,9 @@
 namespace sogen
 {
 
+#define REG_CREATED_NEW_KEY     0x00000001L
+#define REG_OPENED_EXISTING_KEY 0x00000002L
+
     typedef enum _KEY_INFORMATION_CLASS
     {
         KeyBasicInformation,          // KEY_BASIC_INFORMATION

--- a/src/emulator-platform/platform/registry.hpp
+++ b/src/emulator-platform/platform/registry.hpp
@@ -5,8 +5,10 @@
 namespace sogen
 {
 
-#define REG_CREATED_NEW_KEY     0x00000001L
-#define REG_OPENED_EXISTING_KEY 0x00000002L
+#ifndef OS_WINDOWS
+#define REG_CREATED_NEW_KEY     0x00000001L // A new key was created
+#define REG_OPENED_EXISTING_KEY 0x00000002L // An existing key was opened
+#endif
 
     typedef enum _KEY_INFORMATION_CLASS
     {

--- a/src/windows-emulator-test/registry_file_test.cpp
+++ b/src/windows-emulator-test/registry_file_test.cpp
@@ -276,7 +276,6 @@ namespace sogen::test
 
     TEST_F(RegistryFileTest, CreatesMissingKeyInLoadedHive)
     {
-        constexpr uint32_t reg_binary = 3;
         const std::filesystem::path path{uR"(\Registry\Machine\Software\Vendor\Product)"};
         ASSERT_FALSE(registry().get_key(utils::path_key{path}).has_value());
         ASSERT_TRUE(registry().can_create_key(path));
@@ -286,22 +285,21 @@ namespace sogen::test
         EXPECT_TRUE(registry().get_key(utils::path_key{path}).has_value());
 
         const std::vector data{std::byte{1}, std::byte{2}};
-        registry().set_value(*created, "Value", reg_binary, data);
+        registry().set_value(*created, "Value", REG_BINARY, data);
 
         const auto value = registry().get_value(*created, "Value");
         ASSERT_TRUE(value.has_value());
-        EXPECT_EQ(value->type, reg_binary);
-        EXPECT_EQ(value->data, data);
+        EXPECT_EQ(value->type, REG_BINARY);
+        EXPECT_EQ(std::vector(value->data.begin(), value->data.end()), data);
     }
 
     TEST_F(RegistryFileTest, CreateKeyIsIdempotent)
     {
-        constexpr uint32_t reg_binary = 3;
         const std::filesystem::path path{uR"(\Registry\Machine\Software\Vendor\Once)"};
 
         const auto first = registry().create_key(path);
         ASSERT_TRUE(first.has_value());
-        registry().set_value(*first, "Keep", reg_binary, std::vector{std::byte{7}});
+        registry().set_value(*first, "Keep", REG_BINARY, std::vector{std::byte{7}});
 
         const auto second = registry().create_key(path);
         ASSERT_TRUE(second.has_value());

--- a/src/windows-emulator-test/registry_file_test.cpp
+++ b/src/windows-emulator-test/registry_file_test.cpp
@@ -273,4 +273,45 @@ namespace sogen::test
         EXPECT_THROW(import_registry_file_contents(registry(), unterminated_type, "type.reg"), std::runtime_error);
         EXPECT_THROW(import_registry_file_contents(registry(), odd_utf16, "utf16.reg"), std::runtime_error);
     }
+
+    TEST_F(RegistryFileTest, CreatesMissingKeyInLoadedHive)
+    {
+        constexpr uint32_t reg_binary = 3;
+        const std::filesystem::path path{uR"(\Registry\Machine\Software\Vendor\Product)"};
+        ASSERT_FALSE(registry().get_key(utils::path_key{path}).has_value());
+        ASSERT_TRUE(registry().can_create_key(path));
+
+        const auto created = registry().create_key(path);
+        ASSERT_TRUE(created.has_value());
+        EXPECT_TRUE(registry().get_key(utils::path_key{path}).has_value());
+
+        const std::vector data{std::byte{1}, std::byte{2}};
+        registry().set_value(*created, "Value", reg_binary, data);
+
+        const auto value = registry().get_value(*created, "Value");
+        ASSERT_TRUE(value.has_value());
+        EXPECT_EQ(value->type, reg_binary);
+        EXPECT_EQ(value->data, data);
+    }
+
+    TEST_F(RegistryFileTest, CreateKeyIsIdempotent)
+    {
+        constexpr uint32_t reg_binary = 3;
+        const std::filesystem::path path{uR"(\Registry\Machine\Software\Vendor\Once)"};
+
+        const auto first = registry().create_key(path);
+        ASSERT_TRUE(first.has_value());
+        registry().set_value(*first, "Keep", reg_binary, std::vector{std::byte{7}});
+
+        const auto second = registry().create_key(path);
+        ASSERT_TRUE(second.has_value());
+        EXPECT_TRUE(registry().get_value(*second, "Keep").has_value());
+    }
+
+    TEST_F(RegistryFileTest, RejectsKeyOutsideAnyLoadedHive)
+    {
+        const std::filesystem::path path{uR"(\Registry\NoSuchHive\Key)"};
+        EXPECT_FALSE(registry().can_create_key(path));
+        EXPECT_FALSE(registry().create_key(path).has_value());
+    }
 } // namespace sogen::test

--- a/src/windows-emulator/syscalls/registry.cpp
+++ b/src/windows-emulator/syscalls/registry.cpp
@@ -393,16 +393,55 @@ namespace sogen
         NTSTATUS handle_NtCreateKey(const syscall_context& c, const emulator_object<handle> key_handle, const ACCESS_MASK desired_access,
                                     const emulator_object<OBJECT_ATTRIBUTES<EmulatorTraits<Emu64>>> object_attributes,
                                     const ULONG /*title_index*/, const emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> /*class*/,
-                                    const ULONG /*create_options*/, const emulator_object<ULONG> /*disposition*/)
+                                    const ULONG /*create_options*/, const emulator_object<ULONG> disposition)
         {
             const auto result = handle_NtOpenKey(c, key_handle, desired_access, object_attributes);
 
-            if (result == STATUS_OBJECT_NAME_NOT_FOUND)
+            if (result == STATUS_SUCCESS)
             {
-                return STATUS_NOT_SUPPORTED;
+                if (disposition.value())
+                {
+                    disposition.write(REG_OPENED_EXISTING_KEY);
+                }
+
+                return result;
             }
 
-            return result;
+            if (result != STATUS_OBJECT_NAME_NOT_FOUND)
+            {
+                return result;
+            }
+
+            const auto attributes = object_attributes.read();
+            auto key = read_unicode_string(c.emu, attributes.ObjectName);
+
+            if (attributes.RootDirectory)
+            {
+                const auto* parent_handle = c.proc.registry_keys.get(attributes.RootDirectory);
+                if (!parent_handle)
+                {
+                    return STATUS_INVALID_HANDLE;
+                }
+
+                const std::filesystem::path full_path = parent_handle->hive.get() / parent_handle->path.get() / key;
+                key = full_path.u16string();
+            }
+
+            auto entry = c.win_emu.registry.create_key({key});
+            if (!entry.has_value())
+            {
+                return STATUS_OBJECT_PATH_NOT_FOUND;
+            }
+
+            const auto new_handle = c.proc.registry_keys.store(std::move(entry.value()));
+            key_handle.write(new_handle);
+
+            if (disposition.value())
+            {
+                disposition.write(REG_CREATED_NEW_KEY);
+            }
+
+            return STATUS_SUCCESS;
         }
 
         NTSTATUS handle_NtSetValueKey(const syscall_context& c, const handle key_handle,


### PR DESCRIPTION
`NtCreateKey` currently forwards to `NtOpenKey` and converts a lookup miss into
a failure:

```cpp
const auto result = handle_NtOpenKey(c, key_handle, desired_access, object_attributes);
if (result == STATUS_OBJECT_NAME_NOT_FOUND) { return STATUS_NOT_SUPPORTED; }
```

As a result, it can only open keys that already exist, and any program that
creates a key it did not previously find fails at that call.

This is not obvious against the shipped root, where `SOFTWARE` is a complete
hive and most lookups succeed. It becomes apparent under `NTUSER.DAT`, which is
only a stub, so writes to `HKCU\...\CurrentVersion\Run` fail.

`registry_manager` already provides `create_key()` and `can_create_key()`, both
of which write into the copy-on-write overlay, so creating a key does not
modify the backing hive files. Their only caller so far has been the `.reg`
importer. This change makes them available to the syscall path as well.

The handler now behaves as follows:

- if the key exists, it is opened, as before
- if the key is missing, it is created via `create_key()`, resolving
  `RootDirectory`-relative paths in the same manner as `NtOpenKey`
- if the path belongs to no loaded hive, `STATUS_OBJECT_PATH_NOT_FOUND` is
  returned, replacing the previous `STATUS_NOT_SUPPORTED`

The `disposition` parameter is also populated. It was previously unnamed and
never written, leaving callers unable to distinguish a newly created key from
an existing one.

`desired_access` and `create_options` remain unused, consistent with
`NtOpenKey`, so no access check is performed and `REG_OPTION_VOLATILE` is not
modelled.

`NtDeleteValueKey` has been left unchanged. Deleting values would require a
tombstone concept in the overlay, which is beyond the scope of this change.

### Tests

Three cases have been added to `RegistryFileTest`: creating a key absent from a
loaded hive and reading back a value, verifying that `create_key()` is
idempotent for an existing key, and confirming that a path outside any loaded
hive is rejected.
