### PR TITLE
Implement NtSetInformationObject for ObjectHandleFlagInformation

### DIFF
--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -211,7 +211,8 @@ namespace sogen
                                               emulator_object<LARGE_INTEGER> timeout);
         NTSTATUS handle_NtSignalAndWaitForSingleObject(const syscall_context& c, handle signal_handle, handle wait_handle,
                                                        BOOLEAN alertable, emulator_object<LARGE_INTEGER> timeout);
-        NTSTATUS handle_NtSetInformationObject();
+        NTSTATUS handle_NtSetInformationObject(const syscall_context& c, handle handle, OBJECT_INFORMATION_CLASS object_information_class,
+                                               emulator_pointer object_information, ULONG object_information_length);
         NTSTATUS handle_NtQuerySecurityObject(const syscall_context& c, handle /*h*/, SECURITY_INFORMATION /*security_information*/,
                                               emulator_pointer security_descriptor, ULONG length, emulator_object<ULONG> length_needed);
         NTSTATUS handle_NtSetSecurityObject();

--- a/src/windows-emulator/syscalls/object.cpp
+++ b/src/windows-emulator/syscalls/object.cpp
@@ -790,9 +790,35 @@ namespace sogen
             return handle_NtWaitForSingleObject(c, wait_handle, alertable, timeout);
         }
 
-        NTSTATUS handle_NtSetInformationObject()
+        NTSTATUS handle_NtSetInformationObject(const syscall_context& c, const handle handle,
+                                               const OBJECT_INFORMATION_CLASS object_information_class,
+                                               const emulator_pointer object_information, const ULONG object_information_length)
         {
-            return STATUS_NOT_SUPPORTED;
+            if (object_information_class != ObjectHandleFlagInformation)
+            {
+                c.win_emu.log.error("Unsupported object info class: %X\n", object_information_class);
+                return STATUS_NOT_SUPPORTED;
+            }
+
+            if (object_information_length < sizeof(OBJECT_HANDLE_FLAG_INFORMATION))
+            {
+                return STATUS_INFO_LENGTH_MISMATCH;
+            }
+
+            const auto effective_handle = c.proc.resolve_object_pseudo_handle(handle, c.vcpu.active_thread);
+            if (!c.proc.get_handle_store(effective_handle))
+            {
+                return STATUS_INVALID_HANDLE;
+            }
+
+            // Validate the buffer, then drop the flags: NtQueryObject reports both
+            // as 0 because neither is tracked per handle. Failing instead breaks
+            // callers that only set them defensively -- winhttp aborts session
+            // creation with ERROR_NOT_SUPPORTED and returns a NULL session.
+            const emulator_object<OBJECT_HANDLE_FLAG_INFORMATION> info{c.emu, object_information};
+            (void)info.read();
+
+            return STATUS_SUCCESS;
         }
 
         NTSTATUS handle_NtQuerySecurityObject(const syscall_context& c, const handle /*h*/, const SECURITY_INFORMATION security_information,


### PR DESCRIPTION
`handle_NtSetInformationObject` took no parameters and returned
`STATUS_NOT_SUPPORTED` unconditionally:

```cpp
NTSTATUS handle_NtSetInformationObject()
{
    return STATUS_NOT_SUPPORTED;
}
```

That is enough to disable WinHTTP entirely. `WinHttpOpen` sets handle flags
while creating a session, converts the failure into `ERROR_NOT_SUPPORTED`, and
returns a NULL session handle, so every subsequent `WinHttp*` call is
unreachable. The failure is silent from the caller's perspective — nothing is
logged, the session pointer is simply null.

This change accepts `ObjectHandleFlagInformation` after validating the handle
and the buffer length. The flags are then discarded: neither `Inherit` nor
`ProtectFromClose` is tracked per handle, and `NtQueryObject` already reports
both as 0, so storing them would create state nothing reads. Every other
information class still returns `STATUS_NOT_SUPPORTED`, and the unsupported
class is logged the way `NtQueryObject` logs its own.

`desired_access` is not checked, consistent with the surrounding object
handlers.

### Verification

Against a sample that calls `WinHttpOpen`/`Connect`/`OpenRequest`/`SendRequest`
and reports its own progress: before this change it fails at `WinHttpOpen`;
after it proceeds through connect and request creation, so the session, target
host, port, verb and path all become observable.

Two further gaps remain before a request is actually sent, both outside this
change: `webio.dll` is absent from the emulation root, and AFD IOCTL
`AFD_ADDRESS_LIST_QUERY` (function 44) is unimplemented in `afd_endpoint.cpp`.
