### PR TITLE
Avoid quadratic memory allocation search

### DIFF
--- a/src/windows-emulator-test/host_allocation_test.cpp
+++ b/src/windows-emulator-test/host_allocation_test.cpp
@@ -154,6 +154,36 @@ namespace sogen::test
         ASSERT_EQ(mm.find_free_host_allocation_base(size, start), mm.find_free_allocation_base(size, start));
     }
 
+    TEST(HostAllocationTest, FindFreeBaseSkipsDenseReservedRegions)
+    {
+        fake_host_memory host{};
+        memory_manager mm{host};
+
+        constexpr uint64_t start = DEFAULT_ALLOCATION_ADDRESS_32BIT;
+        constexpr size_t region_count = 800;
+        constexpr size_t size = 0x1000;
+
+        for (size_t i = 0; i < region_count; ++i)
+        {
+            const auto address = start + i * ALLOCATION_GRANULARITY;
+            ASSERT_TRUE(mm.allocate_memory(address, size, nt_memory_permission{memory_permission::read_write}, true));
+        }
+
+        ASSERT_EQ(mm.find_free_allocation_base(size, start), start + region_count * ALLOCATION_GRANULARITY);
+    }
+
+    TEST(HostAllocationTest, FindFreeBaseMovesPastRegionContainingStart)
+    {
+        fake_host_memory host{};
+        memory_manager mm{host};
+
+        constexpr uint64_t base = 0x40000000;
+        constexpr size_t reserved_size = 2 * ALLOCATION_GRANULARITY;
+        ASSERT_TRUE(mm.allocate_memory(base, reserved_size, nt_memory_permission{memory_permission::read_write}, true));
+
+        ASSERT_EQ(mm.find_free_allocation_base(0x1000, base + ALLOCATION_GRANULARITY), base + reserved_size);
+    }
+
     TEST(HostAllocationTest, AllocateHostMemoryUsesSourceAddressWhenBackendRequiresIdentity)
     {
         fake_host_memory host{};

--- a/src/windows-emulator/memory_manager.cpp
+++ b/src/windows-emulator/memory_manager.cpp
@@ -1014,8 +1014,14 @@ namespace sogen
 
         uint64_t start_address = *aligned_start;
 
-        // Since reserved_regions_ is a sorted map, we can iterate through it
-        // and find gaps between regions
+        // Since reserved_regions_ is a sorted map, start at the region immediately
+        // before or containing start_address and advance through it only once.
+        auto region = this->reserved_regions_.upper_bound(start_address);
+        if (region != this->reserved_regions_.begin())
+        {
+            --region;
+        }
+
         while (start_address <= highest_address)
         {
             const auto end_address = start_address + size;
@@ -1024,32 +1030,31 @@ namespace sogen
                 return 0;
             }
 
-            bool conflict = false;
-
-            // Check if the proposed range [start_address, start_address+size) conflicts with any existing region
-            for (const auto& region : this->reserved_regions_)
+            while (region != this->reserved_regions_.end())
             {
-                const auto region_end = region.first + region.second.length;
-                if (region_end < region.first)
+                const auto region_end = region->first + region->second.length;
+                if (region_end < region->first)
                 {
                     return 0;
                 }
 
-                // If this region ends before our start, skip it
+                // This region ends before our candidate, so it can never conflict
+                // with this or any later candidate.
                 if (region_end <= start_address)
                 {
+                    ++region;
                     continue;
                 }
 
-                // If this region starts after our end, we're done checking (map is sorted)
-                if (region.first >= end_address)
+                // The next reserved region starts after our candidate range, so
+                // the entire range [start_address, end_address) is free.
+                if (region->first >= end_address)
                 {
-                    break;
+                    return start_address;
                 }
 
-                // Otherwise, we have a conflict
-                conflict = true;
-                // Move start_address past this conflicting region
+                // Otherwise the candidate overlaps this region. Move the candidate
+                // past it and continue scanning from the following region.
                 aligned_start = checked_align_up(region_end, alignment);
                 if (!aligned_start.has_value())
                 {
@@ -1057,12 +1062,21 @@ namespace sogen
                 }
 
                 start_address = *aligned_start;
+                ++region;
                 break;
             }
 
-            // If no conflict was found, we have our address
-            if (!conflict)
+            // No reserved regions remain, so only the address-range bounds need
+            // to be checked for the candidate we may have just advanced to.
+            if (region == this->reserved_regions_.end())
             {
+                const auto final_end_address = start_address + size;
+                if (final_end_address < start_address || final_end_address > MAX_ALLOCATION_END_EXCL ||
+                    final_end_address - 1 > highest_address)
+                {
+                    return 0;
+                }
+
                 return start_address;
             }
         }


### PR DESCRIPTION
This PR optimizes `find_free_allocation_base` to avoid quadratic complexity, using a new linear-time algorithm. In one profiler sample, this reduced the time spent in `find_free_allocation_base` from 50% down to 5% of total profile time.