### PR TITLE
gdb-stub: use range execution hook for exec breakpoints

### DIFF
--- a/src/linux-gdb-stub/x64_gdb_stub_handler.hpp
+++ b/src/linux-gdb-stub/x64_gdb_stub_handler.hpp
@@ -187,10 +187,7 @@ namespace sogen
             try
             {
                 return this->hooks_.access<bool>([&](hook_map& hooks) {
-                    auto hook_vector = this->create_hook(type, addr, size);
-
-                    hooks[{addr, size, type}] = scoped_hook(*this->emu_, std::move(hook_vector));
-
+                    hooks[{addr, size, type}] = this->create_hook(type, addr, size);
                     return true;
                 });
             }
@@ -254,34 +251,28 @@ namespace sogen
         using hook_map = std::unordered_map<breakpoint_key, scoped_hook>;
         utils::concurrency::container<hook_map> hooks_{};
 
-        std::vector<emulator_hook*> create_execute_hook(const uint64_t addr, const size_t size)
+        emulator_hook* create_execute_hook(const uint64_t addr, const size_t size)
         {
-            auto* hook = this->emu_->hook_memory_range_execution(addr, size, [this](cpu_interface&, const uint64_t) {
+            return this->emu_->hook_memory_range_execution(addr, size, [this](cpu_interface&, const uint64_t) {
                 this->on_interrupt(); //
             });
-
-            return {hook};
         }
 
-        std::vector<emulator_hook*> create_read_hook(const uint64_t addr, const size_t size)
+        emulator_hook* create_read_hook(const uint64_t addr, const size_t size)
         {
-            auto* hook = this->emu_->hook_memory_read(addr, size, [this](cpu_interface&, const uint64_t, const void*, const size_t) {
+            return this->emu_->hook_memory_read(addr, size, [this](cpu_interface&, const uint64_t, const void*, const size_t) {
                 this->on_interrupt(); //
             });
-
-            return {hook};
         }
 
-        std::vector<emulator_hook*> create_write_hook(const uint64_t addr, const size_t size)
+        emulator_hook* create_write_hook(const uint64_t addr, const size_t size)
         {
-            auto* hook = this->emu_->hook_memory_write(addr, size, [this](cpu_interface&, const uint64_t, const void*, const size_t) {
+            return this->emu_->hook_memory_write(addr, size, [this](cpu_interface&, const uint64_t, const void*, const size_t) {
                 this->on_interrupt(); //
             });
-
-            return {hook};
         }
 
-        std::vector<emulator_hook*> create_hook(const gdb_stub::breakpoint_type type, const uint64_t addr, const size_t size)
+        scoped_hook create_hook(const gdb_stub::breakpoint_type type, const uint64_t addr, const size_t size)
         {
             using enum gdb_stub::breakpoint_type;
 
@@ -289,17 +280,13 @@ namespace sogen
             {
             case software:
             case hardware_exec:
-                return this->create_execute_hook(addr, size);
+                return {*this->emu_, this->create_execute_hook(addr, size)};
             case hardware_read:
-                return this->create_read_hook(addr, size);
+                return {*this->emu_, this->create_read_hook(addr, size)};
             case hardware_write:
-                return this->create_write_hook(addr, size);
-            case hardware_read_write: {
-                auto hooks1 = this->create_hook(hardware_read, addr, size);
-                auto hooks2 = this->create_hook(hardware_write, addr, size);
-                hooks1.insert(hooks1.end(), hooks2.begin(), hooks2.end());
-                return hooks1;
-            }
+                return {*this->emu_, this->create_write_hook(addr, size)};
+            case hardware_read_write:
+                return {*this->emu_, {this->create_read_hook(addr, size), this->create_write_hook(addr, size)}};
             default:
                 throw std::runtime_error("Bad bp type");
             }

--- a/src/linux-gdb-stub/x64_gdb_stub_handler.hpp
+++ b/src/linux-gdb-stub/x64_gdb_stub_handler.hpp
@@ -256,19 +256,11 @@ namespace sogen
 
         std::vector<emulator_hook*> create_execute_hook(const uint64_t addr, const size_t size)
         {
-            std::vector<emulator_hook*> hooks{};
-            hooks.reserve(size);
+            auto* hook = this->emu_->hook_memory_range_execution(addr, size, [this](cpu_interface&, const uint64_t) {
+                this->on_interrupt(); //
+            });
 
-            for (size_t i = 0; i < size; ++i)
-            {
-                auto* hook = this->emu_->hook_memory_execution(addr + i, [this](cpu_interface&, const uint64_t) {
-                    this->on_interrupt(); //
-                });
-
-                hooks.push_back(hook);
-            }
-
-            return hooks;
+            return {hook};
         }
 
         std::vector<emulator_hook*> create_read_hook(const uint64_t addr, const size_t size)

--- a/src/windows-gdb-stub/x86_64_gdb_stub_handler.hpp
+++ b/src/windows-gdb-stub/x86_64_gdb_stub_handler.hpp
@@ -192,10 +192,7 @@ namespace sogen
             try
             {
                 return this->hooks_.access<bool>([&](hook_map& hooks) {
-                    auto hook_vector = this->create_hook(type, addr, size);
-
-                    hooks[{addr, size, type}] = scoped_hook(*this->emu_, std::move(hook_vector));
-
+                    hooks[{addr, size, type}] = this->create_hook(type, addr, size);
                     return true;
                 });
             }
@@ -293,34 +290,28 @@ namespace sogen
         using hook_map = std::unordered_map<breakpoint_key, scoped_hook>;
         utils::concurrency::container<hook_map> hooks_{};
 
-        std::vector<emulator_hook*> create_execute_hook(const uint64_t addr, const size_t size)
+        emulator_hook* create_execute_hook(const uint64_t addr, const size_t size)
         {
-            auto* hook = this->emu_->hook_memory_range_execution(addr, size, [this](cpu_interface&, const uint64_t) {
+            return this->emu_->hook_memory_range_execution(addr, size, [this](cpu_interface&, const uint64_t) {
                 this->on_interrupt(); //
             });
-
-            return {hook};
         }
 
-        std::vector<emulator_hook*> create_read_hook(const uint64_t addr, const size_t size)
+        emulator_hook* create_read_hook(const uint64_t addr, const size_t size)
         {
-            auto* hook = this->emu_->hook_memory_read(addr, size, [this](cpu_interface&, const uint64_t, const void*, const size_t) {
+            return this->emu_->hook_memory_read(addr, size, [this](cpu_interface&, const uint64_t, const void*, const size_t) {
                 this->on_interrupt(); //
             });
-
-            return {hook};
         }
 
-        std::vector<emulator_hook*> create_write_hook(const uint64_t addr, const size_t size)
+        emulator_hook* create_write_hook(const uint64_t addr, const size_t size)
         {
-            auto* hook = this->emu_->hook_memory_write(addr, size, [this](cpu_interface&, const uint64_t, const void*, const size_t) {
+            return this->emu_->hook_memory_write(addr, size, [this](cpu_interface&, const uint64_t, const void*, const size_t) {
                 this->on_interrupt(); //
             });
-
-            return {hook};
         }
 
-        std::vector<emulator_hook*> create_hook(const gdb_stub::breakpoint_type type, const uint64_t addr, const size_t size)
+        scoped_hook create_hook(const gdb_stub::breakpoint_type type, const uint64_t addr, const size_t size)
         {
             using enum gdb_stub::breakpoint_type;
 
@@ -328,17 +319,13 @@ namespace sogen
             {
             case software:
             case hardware_exec:
-                return this->create_execute_hook(addr, size);
+                return {*this->emu_, this->create_execute_hook(addr, size)};
             case hardware_read:
-                return this->create_read_hook(addr, size);
+                return {*this->emu_, this->create_read_hook(addr, size)};
             case hardware_write:
-                return this->create_write_hook(addr, size);
-            case hardware_read_write: {
-                auto hooks1 = this->create_hook(hardware_read, addr, size);
-                auto hooks2 = this->create_hook(hardware_write, addr, size);
-                hooks1.insert(hooks1.end(), hooks2.begin(), hooks2.end());
-                return hooks1;
-            }
+                return {*this->emu_, this->create_write_hook(addr, size)};
+            case hardware_read_write:
+                return {*this->emu_, {this->create_read_hook(addr, size), this->create_write_hook(addr, size)}};
             default:
                 throw std::runtime_error("Bad bp type");
             }

--- a/src/windows-gdb-stub/x86_64_gdb_stub_handler.hpp
+++ b/src/windows-gdb-stub/x86_64_gdb_stub_handler.hpp
@@ -295,19 +295,11 @@ namespace sogen
 
         std::vector<emulator_hook*> create_execute_hook(const uint64_t addr, const size_t size)
         {
-            std::vector<emulator_hook*> hooks{};
-            hooks.reserve(size);
+            auto* hook = this->emu_->hook_memory_range_execution(addr, size, [this](cpu_interface&, const uint64_t) {
+                this->on_interrupt(); //
+            });
 
-            for (size_t i = 0; i < size; ++i)
-            {
-                auto* hook = this->emu_->hook_memory_execution(addr + i, [this](cpu_interface&, const uint64_t) {
-                    this->on_interrupt(); //
-                });
-
-                hooks.push_back(hook);
-            }
-
-            return hooks;
+            return {hook};
         }
 
         std::vector<emulator_hook*> create_read_hook(const uint64_t addr, const size_t size)


### PR DESCRIPTION
To support an unpacking project, I'd like to be able to set hardware execution breakpoints on a range (actually, a full section). Seems like there's a lot of overhead today (per-instruction): one hashmap entry for icicle (O(n)), one list entry for Unicorn (O(n**2)).

It seems this handling can be simplified to use the `hook_memory_range_execution` API, which I *believe* was implemented after the GDB handler.

Of course, I'm not yet very intimate with this project, so don't hesitate to push back if this change doesn't make sense to you.

---

Claude told me:

The per-byte hook loop dates from April 2025 when the simplified hook interface only offered single-address execution hooks.  The range API was re-added in May 2026 (3f28e5ef) for WHP section tracking but the GDB stub was never updated.  Replace the O(N) individual hooks with a single hook_memory_range_execution call, matching what the read/write watchpoint paths already do.