### PR TITLE
fix(wow64): register the synthetic heaven-gate module instead of skipping it

### DIFF
--- a/src/windows-emulator/module/module_manager.cpp
+++ b/src/windows-emulator/module/module_manager.cpp
@@ -421,7 +421,7 @@ namespace sogen
                 code_initialized = true;
             }
 
-            if (code_initialized && this->modules_.contains(kCodeBase))
+            if (code_initialized && !this->modules_.contains(kCodeBase))
             {
                 mapped_module module{};
                 module.name = "wow64_heaven_gate";


### PR DESCRIPTION
## Summary

`module_manager::install_wow64_heaven_gate` (`src/windows-emulator/module/module_manager.cpp`) builds a synthetic `wow64_heaven_gate` module for the trampoline page at `0xFF300000`, but guards the insertion with `this->modules_.contains(kCodeBase)` instead of `!contains`. On the first (and only) install the key is absent, so the block is skipped and the module is never registered. This flips the condition.

One-line change, no other files touched.

## Impact

The gate page is entered from exactly one place: `exception_dispatch.cpp` sets `rip = kCodeBase` when an exception is dispatched to a thread running in 32-bit compat mode, so the trampoline can switch to the 64-bit `KiUserExceptionDispatcher`. Because the module was never registered, every `find_by_address` / `find_name` lookup on that page failed and the transition was attributed to `<N/A>`.

## Reproduction

32-bit console binary that deliberately raises an unhandled access violation (`c:/av32.exe`, PE32 i386, staged in the emulation root), default backend, macOS host:

```
./analyzer -e root -r root/registry c:/av32.exe
```

Before (origin/main `e8824779`):

```
Executing function: KiUserExceptionDispatcher (ntdll.dll) (0x1800a4330) via 0xff300011 (<N/A>)
Emulation terminated with status: C0000005
```

After:

```
Executing entry point: wow64_heaven_gate (0xff300000)
Executing function: KiUserExceptionDispatcher (ntdll.dll) (0x1800a4330) via 0xff300011 (wow64_heaven_gate)
Emulation terminated with status: C0000005
```

(`C0000005` is the AV the sample raises on purpose; that is unchanged.)

With `-v`, the before/after logs (45,270 vs 45,271 lines) differ in exactly that one line becoming those two; nothing else in the trace changes. A 32-bit sample that raises no exception (`heaven-gate-probe-x86.exe`, 862-line trace) produces identical output before and after, as expected since the gate is never executed.

## Verification

- `cmake --build --preset=release` (analyzer + windows-emulator-test) on the squashed commit: green.
- `windows-emulator-test` with `EMULATOR_ROOT` pointed at the real root: 50/50 passed, before and after squash.
- Baseline numbers above were produced by reverting the single line on the same tree and rebuilding, so the comparison is apples-to-apples.

## Notes

No unit test is added: `windows-emulator-test` only carries a 64-bit `test-sample`, and exercising this path needs a 32-bit PE that raises an exception, which the suite has no way to build today.