### PR TITLE
chore(create-root): collect displaycolormanagement.dll

### DIFF
--- a/src/tools/create-root.bat
+++ b/src/tools/create-root.bat
@@ -153,6 +153,7 @@ CALL :collect vcruntime140d.dll
 CALL :collect version.dll
 CALL :collect wer.dll
 CALL :collect win32u.dll
+CALL :collect windows.internal.graphics.display.displaycolormanagement.dll
 CALL :collect windows.storage.dll
 CALL :collect windowscodecs.dll
 CALL :collect winhttp.dll


### PR DESCRIPTION
## Summary

`src/tools/create-root.bat` (run by the `Create Emulation Root` job in `ci-reusable.yml`) stages `coloradapterclient.dll` and `msvcp_win.dll` but not `windows.internal.graphics.display.displaycolormanagement.dll`, which `coloradapterclient.dll` pulls in at runtime. This adds one `CALL :collect` line so the DLL is snapshotted from the same Windows install as everything else, for both `system32` and `syswow64`.

One line, `IF EXIST`-guarded like every other `:collect` entry, so a runner without the DLL is unaffected.

## Why the DLL is needed

`coloradapterclient.dll` does not import it statically. It calls `RoActivateInstance` on the runtime class `Windows.Internal.Graphics.Display.DisplayColorManagement.DisplayColorManagement` (the class name is in its string table, both x64 and x86 builds), and `combase.dll` resolves that class through the SOFTWARE hive's `ActivatableClassId` registration, whose `DllPath` is `C:\Windows\System32\Windows.Internal.Graphics.Display.DisplayColorManagement.dll` (and the `SysWOW64` equivalent). The registry hives `create-root.bat` captures already contain that registration, so the load is attempted on every root the script produces; only the file was missing.

`mscms.dll` (already collected) is the loader of `coloradapterclient.dll`, so any guest that touches the colour-management stack reaches this path.

## Reproduction

Observed with Call of Duty: Modern Warfare 2 (`iw4mp.exe`, 32-bit, WoW64 guest, FEX backend on Apple Silicon):

```
Emulation terminated with status: C0000139   (STATUS_ENTRYPOINT_NOT_FOUND)
Error Message: __std_atomic_notify_all_direct
```

fired when `windows.internal.graphics.display.displaycolormanagement.dll` was mapped, reproducing within ~3 minutes on two back-to-back runs. Root cause was not emulator logic: the guest `ntdll.dll` loader was correctly rejecting an import. The local root had a hand-copied `displaycolormanagement.dll` from a newer Windows build that imports `__std_atomic_notify_all_direct` from `msvcp_win.dll`, while the script-collected `msvcp_win.dll` predates that export. Because the script never collected the DLL, there was no way for a root to carry a version-consistent copy.

## Verification

- After adding the line, the fork's `Build Branch` CI (`Create Emulation Root` on both windows-2022 and windows-2025 runners) produced roots containing the DLL alongside the same-build `msvcp_win.dll`.
- With the CI-produced pair staged, the MW2 `C0000139` crash did not reproduce across a 13.3M-line run (previously hit within 3 minutes on both attempts); the analyzer smoke test (`analyzer.exe -s test-sample.exe`, 28/28) and `d3d9-triangle-test` (pixel-exact) were unaffected by the refreshed `msvcp_win.dll`.
- In the currently staged root (`10.0.26100.32995` `displaycolormanagement.dll` next to `10.0.26100.32860` `msvcp_win.dll`, same build line), all 19 of the DLL's `msvcp_win.dll` imports resolve against the staged export table (checked with `pefile`).
- `create-root.bat` remains all-CRLF (214/214 lines) with the new line matching its neighbours.

No compiled code changes; CMake does not consume this file.