### PR TITLE
fix(module): bound the wow64cpu.dll base search below 4GB

### DIFF
--- a/src/windows-emulator-test/host_allocation_test.cpp
+++ b/src/windows-emulator-test/host_allocation_test.cpp
@@ -184,6 +184,22 @@ namespace sogen::test
         ASSERT_EQ(mm.find_free_allocation_base(0x1000, base + ALLOCATION_GRANULARITY), base + reserved_size);
     }
 
+    // The contract the wow64cpu.dll pre-search in map_module_from_data relies on: the start address is
+    // only a hint, so a pick for a 32-bit-reachable module must carry the ceiling explicitly.
+    TEST(HostAllocationTest, FindFreeHostBaseWithBelow4GbCeilingReturnsZeroWhenLowArenaIsFull)
+    {
+        fake_host_memory host{};
+        memory_manager mm{host};
+
+        constexpr uint64_t four_gb = 0x100000000ULL;
+        constexpr size_t size = 0x9000;
+        ASSERT_TRUE(mm.allocate_memory(MIN_ALLOCATION_ADDRESS, static_cast<size_t>(four_gb - MIN_ALLOCATION_ADDRESS),
+                                       nt_memory_permission{memory_permission::read_write}, true));
+
+        ASSERT_EQ(mm.find_free_allocation_base(size, DEFAULT_ALLOCATION_ADDRESS_32BIT), four_gb);
+        ASSERT_EQ(mm.find_free_host_allocation_base(size, DEFAULT_ALLOCATION_ADDRESS_32BIT, four_gb - 1), 0u);
+    }
+
     TEST(HostAllocationTest, AllocateHostMemoryUsesSourceAddressWhenBackendRequiresIdentity)
     {
         fake_host_memory host{};

--- a/src/windows-emulator/module/module_mapping.cpp
+++ b/src/windows-emulator/module/module_mapping.cpp
@@ -530,11 +530,12 @@ namespace sogen
         binary.size_of_image = page_align_up(optional_header.SizeOfImage); // TODO: Sanitize
 
         const bool force_wow64cpu_32bit_va = must_map_module_below_4gb(binary.name, nt_headers.FileHeader.Machine, binary.image_base);
+        constexpr uint64_t below_4gb_ceiling = 0xFFFFFFFFULL;
 
         if (force_wow64cpu_32bit_va)
         {
-            binary.image_base =
-                memory.find_free_allocation_base(static_cast<size_t>(binary.size_of_image), DEFAULT_ALLOCATION_ADDRESS_32BIT);
+            binary.image_base = memory.find_free_host_allocation_base(static_cast<size_t>(binary.size_of_image),
+                                                                      DEFAULT_ALLOCATION_ADDRESS_32BIT, below_4gb_ceiling);
         }
 
         // Store PE header fields
@@ -563,7 +564,6 @@ namespace sogen
             // bits, aliasing the module onto whatever unrelated allocation sits at the truncated address.
             const bool needs_below_4gb = force_wow64cpu_32bit_va || is_32bit;
             const uint64_t fallback_start = needs_below_4gb ? DEFAULT_ALLOCATION_ADDRESS_32BIT : DEFAULT_ALLOCATION_ADDRESS_64BIT;
-            constexpr uint64_t below_4gb_ceiling = 0xFFFFFFFFULL;
             const uint64_t highest_address = needs_below_4gb ? below_4gb_ceiling : MAX_ALLOCATION_ADDRESS;
             const auto image_size = static_cast<size_t>(binary.size_of_image);
 


### PR DESCRIPTION
## Summary

`map_module_from_data` forces `wow64cpu.dll` below 4GB when its preferred `ImageBase` is above 4GB (`must_map_module_below_4gb`), but the pick it makes for that case is not actually bounded. It calls the two-argument `memory_manager::find_free_allocation_base(size, DEFAULT_ALLOCATION_ADDRESS_32BIT)`, whose `start` is only a search hint and whose ceiling is `MAX_ALLOCATION_END_EXCL - 1`. Once the low arena is occupied the search walks straight past 4GB and returns a base that WOW64 pointer marshaling later truncates to 32 bits, aliasing the module onto whatever sits at the truncated address.

The relocation fallback a few lines further down in the same function already does this correctly: it calls `find_free_host_allocation_base(size, start, highest_address)` with an explicit `0xFFFFFFFF` ceiling for 32-bit and forced-wow64cpu modules. This change routes the forced pre-search through that same ceilinged helper and hoists the `below_4gb_ceiling` constant so both call sites share it.

On exhaustion the ceilinged helper returns 0, which the existing `if (!binary.image_base || !try_map_module_at_current_base(...))` branch already handles by falling into the ceilinged relocation loop, so no new failure path is introduced. Net production change is three lines in `src/windows-emulator/module/module_mapping.cpp`; it is backend-agnostic (pure `memory_manager` bookkeeping, no backend hooks involved).

## Trigger conditions

Both must hold, so most roots never hit it:

1. The root's `wow64cpu.dll` has a preferred `ImageBase` above 4GB (the `must_map_module_below_4gb` gate; a `0x1800...`-style high-entropy base from a newer Windows build).
2. Enough of the sub-4GB arena is already reserved that the first free slot at or above `0x10000` is above 4GB.

## Test

Added `HostAllocationTest.FindFreeHostBaseWithBelow4GbCeilingReturnsZeroWhenLowArenaIsFull` in `src/windows-emulator-test/host_allocation_test.cpp`. It reserves `[MIN_ALLOCATION_ADDRESS, 4GB)` in a `memory_manager` over the existing `fake_host_memory`, then asks for a `0x9000`-byte base (the real `SizeOfImage` of the `wow64cpu.dll` in my root) starting at `DEFAULT_ALLOCATION_ADDRESS_32BIT`:

- the old call, `find_free_allocation_base(size, DEFAULT_ALLOCATION_ADDRESS_32BIT)`, returns exactly `0x100000000` -- the first address past the ceiling, i.e. the bug;
- the new call, `find_free_host_allocation_base(size, DEFAULT_ALLOCATION_ADDRESS_32BIT, 0xFFFFFFFF)`, returns `0`.

The test pins both so the contract the pre-search now relies on cannot regress silently.

## Verification (macOS arm64, Apple Clang, `--preset=release`, default backend)

- `windows-emulator-test`: 51/51 pass with `EMULATOR_ROOT` set (14/14 in `HostAllocationTest.*`).
- `analyzer -s -e root c:\test-sample.exe` (x64): all tests report `Success`.
- `analyzer -s -e root c:\wow64-test-sample.exe` (x86 / WOW64): `wow64-test-sample: ok` (module churn 5x50 cycles, VirtualAlloc/VirtualFree 200 cycles, file roundtrip all ok).

To be explicit about coverage: the `wow64cpu.dll` in my root has a preferred `ImageBase` of `0x6b100000`, so `must_map_module_below_4gb` returns false for it and the WOW64 smoke run exercises the unchanged preferred-base path -- it is regression evidence that the hoisted constant and the shared helper did not disturb the normal case, not a live reproduction of the forced-pick bug. The forced-pick behaviour itself is covered by the new unit test at the `memory_manager` level, where the wrong answer (`0x100000000`) is observed directly.