### PR TITLE
fix(exception): propagate ExceptionCode into process exit status

### DIFF
--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -1903,6 +1903,13 @@ int main(const int argc, const char* argv[])
         return 0;
     }
 
+    if (argc == 2 && argv[1] == "-fail-fast"sv)
+    {
+        EXCEPTION_RECORD record{};
+        record.ExceptionCode = 0xE0001234;
+        RaiseFailFastException(&record, nullptr, 0);
+    }
+
     bool valid = true;
 
 #ifdef _WIN64

--- a/src/windows-emulator-test/emulation_test_utils.hpp
+++ b/src/windows-emulator-test/emulation_test_utils.hpp
@@ -50,6 +50,7 @@ namespace sogen::test
     struct sample_configuration
     {
         bool print_time{false};
+        bool fail_fast{false};
     };
 
     namespace
@@ -106,6 +107,11 @@ namespace sogen::test
         if (config.print_time)
         {
             settings.arguments.emplace_back(u"-time");
+        }
+
+        if (config.fail_fast)
+        {
+            settings.arguments.emplace_back(u"-fail-fast");
         }
 
         return settings;

--- a/src/windows-emulator-test/exception_test.cpp
+++ b/src/windows-emulator-test/exception_test.cpp
@@ -1,0 +1,14 @@
+#include "emulation_test_utils.hpp"
+
+namespace sogen::test
+{
+    TEST(ExceptionTest, SecondChanceExceptionCodeBecomesExitStatus)
+    {
+        constexpr NTSTATUS sample_fail_fast_code = 0xE0001234;
+
+        auto emu = create_sample_emulator({.fail_fast = true});
+        emu.start();
+
+        ASSERT_TERMINATED_WITH_STATUS(emu, sample_fail_fast_code);
+    }
+} // namespace sogen::test

--- a/src/windows-emulator/syscalls/exception.cpp
+++ b/src/windows-emulator/syscalls/exception.cpp
@@ -44,7 +44,7 @@ namespace sogen
         }
 
         NTSTATUS handle_NtRaiseException(const syscall_context& c,
-                                         const emulator_object<EMU_EXCEPTION_RECORD<EmulatorTraits<Emu64>>> /*exception_record*/,
+                                         const emulator_object<EMU_EXCEPTION_RECORD<EmulatorTraits<Emu64>>> exception_record,
                                          const emulator_object<CONTEXT64> /*thread_context*/, const BOOLEAN handle_exception)
         {
             if (handle_exception)
@@ -54,6 +54,7 @@ namespace sogen
                 return STATUS_NOT_SUPPORTED;
             }
 
+            c.proc.exit_status = exception_record.read().ExceptionCode;
             c.win_emu.callbacks.on_exception();
             c.emu.stop();
 


### PR DESCRIPTION
## Problem

When a guest raises a second-chance exception, `handle_NtRaiseException` (`HandleException == FALSE`) calls `on_exception()` and `emu.stop()` but never touches `process.exit_status`. The analyzer then lands in its `!exit_status.has_value()` branch and reports the generic

```
Emulation failed at: 0x1800a3194 - Emulation terminated without status
```

with no indication of *which* exception ended the run. The two sibling termination paths already record a code: `NtRaiseHardError` stores its `error_status`, and the `int 0x29` `__fastfail` path in `windows_emulator.cpp` stores `STATUS_FAIL_FAST_EXCEPTION`. `NtRaiseException` was the only one that dropped it.

## Change

- `src/windows-emulator/syscalls/exception.cpp`: read the guest `EXCEPTION_RECORD` and store its `ExceptionCode` in `c.proc.exit_status` before `on_exception()` / `stop()`. The previously unused `exception_record` parameter is now named and used. Nothing else in the handler changes.
- `src/samples/test-sample/test.cpp`: new `-fail-fast` argument that fills an `EXCEPTION_RECORD` with code `0xE0001234` and calls `RaiseFailFastException(&record, nullptr, 0)`. kernelbase forwards that to `NtRaiseException` with `HandleException = FALSE`, i.e. exactly the path being fixed. The code is deliberately not `STATUS_FAIL_FAST_EXCEPTION` (`0xC0000409`) so the test proves the record's code is propagated rather than the unrelated `int 0x29` path being hit.
- `src/windows-emulator-test/exception_test.cpp` (new) + `emulation_test_utils.hpp`: `ExceptionTest.SecondChanceExceptionCodeBecomesExitStatus` runs the sample with `sample_configuration{.fail_fast = true}` and asserts `ASSERT_TERMINATED_WITH_STATUS(emu, 0xE0001234)`.

Note on scope: the emulator stopping on a second-chance exception is pre-existing behaviour and is untouched here (the `stop()` call is unchanged, on every backend). This PR only makes the reason for that stop visible through `exit_status`, so a run that previously ended as "terminated without status" now ends as "terminated with status: <ExceptionCode>", which is a non-success status as it should be.

## Reproduction and verification

Host: macOS arm64, Apple Clang, `--preset=release`, default backend (unicorn, no `EMULATOR_*` env overrides). Guest: 64-bit `test-sample.exe` cross-built from this branch's `test.cpp` with mingw-w64 (GCC 16.1), run in an emulation root containing that binary as `C:\test-sample.exe`.

Before (identical tree with `origin/main`'s `exception.cpp` swapped back in):

```
$ analyzer -e <root> --very-concise 'C:\test-sample.exe' -fail-fast
Executing function: RaiseFailFastException (kernelbase.dll) (0x104177500) via 0x1400e0b60 (test-sample.exe)
Emulation failed at: 0x1800a3194 - Emulation terminated without status
```

```
[ RUN      ] ExceptionTest.SecondChanceExceptionCodeBecomesExitStatus
exception_test.cpp:12: Failure
Value of: (emu).process.exit_status.has_value()
  Actual: false
Expected: true
[  FAILED  ] ExceptionTest.SecondChanceExceptionCodeBecomesExitStatus (697 ms)
```

After (this branch):

```
$ analyzer -e <root> --very-concise 'C:\test-sample.exe' -fail-fast
Executing function: RaiseFailFastException (kernelbase.dll) (0x104177500) via 0x1400e0b60 (test-sample.exe)
Emulation terminated with status: E0001234
```

```
[ RUN      ] ExceptionTest.SecondChanceExceptionCodeBecomesExitStatus
[       OK ] ExceptionTest.SecondChanceExceptionCodeBecomesExitStatus (610 ms)
```

Full `windows-emulator-test` against the rebuilt sample: 51/51 passed (20.4 s). Against the previous prebuilt `test-sample.exe` (no `-fail-fast` support) the other 50 tests still pass; only the new test fails, with `exit_status == 0` vs `0xE0001234`, because a stale sample ignores the argument and exits normally. So the new test needs `test-sample.exe` rebuilt from this branch, which the sample build in CI does.
