### PR TITLE
fix(apiset): write zero-value namespace entries into the cloned map

### DIFF
--- a/src/windows-emulator-test/apiset_test.cpp
+++ b/src/windows-emulator-test/apiset_test.cpp
@@ -1,0 +1,115 @@
+#include "emulation_test_utils.hpp"
+
+#include <apiset/apiset.hpp>
+#include <memory_manager.hpp>
+#include <binary_writer.hpp>
+
+namespace sogen::test
+{
+    namespace
+    {
+        struct api_set_source_entry
+        {
+            std::u16string name{};
+            std::vector<std::u16string> values{};
+        };
+
+        apiset::container build_api_set_map(const std::vector<api_set_source_entry>& source_entries)
+        {
+            const auto count = static_cast<ULONG>(source_entries.size());
+
+            API_SET_NAMESPACE header{};
+            header.Version = 6;
+            header.Count = count;
+            header.EntryOffset = sizeof(API_SET_NAMESPACE);
+            header.HashOffset = header.EntryOffset + count * sizeof(API_SET_NAMESPACE_ENTRY);
+
+            std::vector<uint8_t> buffer{};
+            utils::aligned_binary_writer writer{buffer};
+            writer.pad(header.HashOffset + count * sizeof(API_SET_HASH_ENTRY));
+
+            for (ULONG i = 0; i < count; ++i)
+            {
+                const auto& source = source_entries[i];
+
+                API_SET_NAMESPACE_ENTRY entry{};
+                entry.NameOffset = static_cast<ULONG>(writer.offset());
+                entry.NameLength = static_cast<ULONG>(source.name.size() * sizeof(char16_t));
+                entry.HashedLength = entry.NameLength;
+                entry.ValueCount = static_cast<ULONG>(source.values.size());
+                writer.write(source.name.data(), entry.NameLength);
+
+                std::vector<API_SET_VALUE_ENTRY> values{};
+                for (const auto& host : source.values)
+                {
+                    API_SET_VALUE_ENTRY value{};
+                    value.ValueOffset = static_cast<ULONG>(writer.offset());
+                    value.ValueLength = static_cast<ULONG>(host.size() * sizeof(char16_t));
+                    writer.write(host.data(), value.ValueLength);
+                    values.push_back(value);
+                }
+
+                writer.align_to(alignof(API_SET_VALUE_ENTRY));
+                entry.ValueOffset = static_cast<ULONG>(writer.offset());
+                for (const auto& value : values)
+                {
+                    writer.write(value);
+                }
+
+                const API_SET_HASH_ENTRY hash{.Hash = (i + 1) * 0x1000, .Index = i};
+
+                writer.write_at(header.EntryOffset + i * sizeof(API_SET_NAMESPACE_ENTRY), entry);
+                writer.write_at(header.HashOffset + i * sizeof(API_SET_HASH_ENTRY), hash);
+            }
+
+            header.Size = static_cast<ULONG>(writer.offset());
+            writer.write_at(0, header);
+
+            const auto* begin = reinterpret_cast<const std::byte*>(buffer.data());
+            return {.data = {begin, begin + buffer.size()}};
+        }
+    }
+
+    TEST(ApiSetTest, CloneWritesEntriesWithoutValues)
+    {
+        const auto source = build_api_set_map({
+            {.name = u"api-ms-win-core-first-l1-1-0", .values = {u"first.dll"}},
+            {.name = u"api-ms-win-core-empty-l1-1-0", .values = {}},
+            {.name = u"api-ms-win-core-last-l1-1-0", .values = {u"last.dll"}},
+        });
+
+        const auto emu = create_x86_64_emulator_from_environment();
+        memory_manager memory{*emu};
+
+        constexpr size_t region_size = 0x10000;
+        const auto region = memory.allocate_memory(region_size, memory_permission::read_write);
+        ASSERT_NE(region, 0u);
+
+        emulator_allocator allocator{memory, region, region_size};
+        const auto clone = apiset::clone(*emu, allocator, source);
+        const auto header = clone.read();
+        ASSERT_EQ(header.Count, 3u);
+
+        const emulator_object<API_SET_NAMESPACE_ENTRY> entries{memory, clone.value() + header.EntryOffset};
+        const emulator_object<API_SET_HASH_ENTRY> hashes{memory, clone.value() + header.HashOffset};
+
+        const auto empty_entry = entries.read(1);
+        EXPECT_EQ(empty_entry.ValueCount, 0u);
+        EXPECT_EQ(empty_entry.ValueOffset, 0u);
+        EXPECT_EQ(read_string<char16_t>(memory, clone.value() + empty_entry.NameOffset, empty_entry.NameLength / sizeof(char16_t)),
+                  u"api-ms-win-core-empty-l1-1-0");
+
+        const auto empty_hash = hashes.read(1);
+        EXPECT_EQ(empty_hash.Hash, 0x2000u);
+        EXPECT_EQ(empty_hash.Index, 1u);
+
+        const auto cloned_data = memory.read_memory(clone.value(), static_cast<size_t>(region + region_size - clone.value()));
+        const auto table = apiset::get_namespace_table(reinterpret_cast<const API_SET_NAMESPACE*>(cloned_data.data()));
+
+        const apiset_map expected_table{
+            {u"api-ms-win-core-first-l1-1-0.dll", u"first.dll"},
+            {u"api-ms-win-core-last-l1-1-0.dll", u"last.dll"},
+        };
+        EXPECT_EQ(table, expected_table);
+    }
+} // namespace sogen::test

--- a/src/windows-emulator/apiset/apiset.cpp
+++ b/src/windows-emulator/apiset/apiset.cpp
@@ -147,30 +147,32 @@ namespace sogen
                 ns_entry.NameOffset = copy_string_as_relative(emu, allocator, api_set_map_obj.value(), &orig_api_set_map,
                                                               ns_entry.NameOffset, ns_entry.NameLength);
 
-                if (!ns_entry.ValueCount)
+                if (ns_entry.ValueCount)
                 {
-                    continue;
-                }
+                    const auto values_obj = allocator.reserve<API_SET_VALUE_ENTRY>(ns_entry.ValueCount);
+                    const auto* orig_values = offset_pointer<API_SET_VALUE_ENTRY>(&orig_api_set_map, ns_entry.ValueOffset);
 
-                const auto values_obj = allocator.reserve<API_SET_VALUE_ENTRY>(ns_entry.ValueCount);
-                const auto* orig_values = offset_pointer<API_SET_VALUE_ENTRY>(&orig_api_set_map, ns_entry.ValueOffset);
+                    ns_entry.ValueOffset = static_cast<ULONG>(values_obj.value() - api_set_map_obj.value());
 
-                ns_entry.ValueOffset = static_cast<ULONG>(values_obj.value() - api_set_map_obj.value());
-
-                for (ULONG j = 0; j < ns_entry.ValueCount; ++j)
-                {
-                    auto value = orig_values[j];
-
-                    value.ValueOffset = copy_string_as_relative(emu, allocator, api_set_map_obj.value(), &orig_api_set_map,
-                                                                value.ValueOffset, value.ValueLength);
-
-                    if (value.NameLength)
+                    for (ULONG j = 0; j < ns_entry.ValueCount; ++j)
                     {
-                        value.NameOffset = copy_string_as_relative(emu, allocator, api_set_map_obj.value(), &orig_api_set_map,
-                                                                   value.NameOffset, value.NameLength);
-                    }
+                        auto value = orig_values[j];
 
-                    values_obj.write(value, j);
+                        value.ValueOffset = copy_string_as_relative(emu, allocator, api_set_map_obj.value(), &orig_api_set_map,
+                                                                    value.ValueOffset, value.ValueLength);
+
+                        if (value.NameLength)
+                        {
+                            value.NameOffset = copy_string_as_relative(emu, allocator, api_set_map_obj.value(), &orig_api_set_map,
+                                                                       value.NameOffset, value.NameLength);
+                        }
+
+                        values_obj.write(value, j);
+                    }
+                }
+                else
+                {
+                    ns_entry.ValueOffset = 0;
                 }
 
                 ns_entries_obj.write(ns_entry, i);


### PR DESCRIPTION
## Summary

`apiset::clone` (`src/windows-emulator/apiset/apiset.cpp`) `continue`d out of the per-entry loop as soon as it saw a namespace entry with `ValueCount == 0`. That skipped not only the value copying but also the two writes at the end of the loop body, so the guest copy of the map was left with a zero-filled `API_SET_NAMESPACE_ENTRY` slot *and* a zero-filled `API_SET_HASH_ENTRY` slot for that index.

The hash-table slot is the damaging one: ntdll resolves api sets by binary-searching the hash table by `Hash`, so a stray `{Hash = 0, Index = 0}` in the middle of the table breaks the sort invariant and makes the search miss entries that have nothing to do with the empty one. The visible symptom is the loader failing to resolve an unrelated `api-ms-win-*` DLL with `STATUS_DLL_NOT_FOUND`.

## Change

- Restructure the loop so the value copying is conditional on `ValueCount != 0`, while the namespace-entry and hash-entry writes run for every entry.
- For entries without values, set `ValueOffset = 0` instead of carrying the source map's offset into the relocated copy, where it points at nothing meaningful.
- Add `ApiSetTest.CloneWritesEntriesWithoutValues` (`src/windows-emulator-test/apiset_test.cpp`), which builds a synthetic v6 map with three entries (the middle one has no values), clones it into a fresh `memory_manager` region, and checks the middle entry's name/`ValueCount`/`ValueOffset`, its hash slot (`Hash = 0x2000`, `Index = 1`), and that `apiset::get_namespace_table` on the cloned bytes yields the expected two resolvable entries.

The test uses a synthetic map on purpose: I parsed the zstd-compressed `api-set.bin` in the staged root (version 6, 936 entries) and it contains zero entries with `ValueCount == 0` and a correctly sorted hash table, so the shipped map cannot exercise this path. The bug only bites with a map that has such entries (real Windows api-set maps can carry them for retired/unhosted contracts).

## Verification

Host: macOS arm64, `--preset=release` (RelWithDebInfo), Unicorn backend (the test helper's default with no `EMULATOR_*` overrides), `EMULATOR_ROOT` pointing at the staged root; the test runs on the x86-64 emulator and exercises the clone path shared by the 64- and 32-bit loaders.

- **Red on `origin/main`**: swapped in `origin/main`'s `apiset.cpp`, rebuilt `windows-emulator-test`, ran `--gtest_filter=ApiSetTest.*`: 1 test **FAILED** with 3 assertion failures, at `apiset_test.cpp:100` (cloned name reads back as `u""`), `:103` (hash `0` vs expected `8192`/`0x2000`) and `:104` (index `0` vs expected `1`). This is exactly the unwritten namespace-entry slot plus unwritten hash slot.
- **Green on this branch**: same test **passes**.
- **Full suite on this branch**: `gtest_parallel.py ./windows-emulator-test` -> 51/51 passed, exit code 0.

## Notes

- Two files touched: `src/windows-emulator/apiset/apiset.cpp` and the new `src/windows-emulator-test/apiset_test.cpp` (picked up by the existing `GLOB_RECURSE` in the test `CMakeLists.txt`).
- No behavioural change for maps without zero-value entries: the value-copy branch is byte-for-byte the previous logic, only re-indented under the new condition.