### PR TITLE
fix(ksecdd): parse the algorithm name from short BCrypt provider requests

### DIFF
--- a/src/samples/test-sample/CMakeLists.txt
+++ b/src/samples/test-sample/CMakeLists.txt
@@ -9,7 +9,7 @@ list(SORT SRC_FILES)
 add_executable(test-sample ${SRC_FILES})
 
 if(WIN)
-  target_link_libraries(test-sample PRIVATE dnsapi ws2_32 winmm)
+  target_link_libraries(test-sample PRIVATE bcrypt dnsapi ws2_32 winmm)
 endif()
 
 sogen_assign_source_group(${SRC_FILES})

--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -28,6 +28,7 @@
 #include <combaseapi.h>
 #include <knownfolders.h>
 #include <sddl.h>
+#include <bcrypt.h>
 
 using namespace std::literals;
 
@@ -1885,6 +1886,49 @@ namespace
         DestroyCursor(cursor);
         return true;
     }
+
+    bool test_bcrypt_hash()
+    {
+        struct hash_vector
+        {
+            const wchar_t* algorithm;
+            std::vector<UCHAR> digest;
+        };
+
+        const std::array<hash_vector, 2> vectors{{
+            {.algorithm = BCRYPT_MD5_ALGORITHM,
+             .digest = {0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0, 0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72}},
+            {.algorithm = BCRYPT_SHA256_ALGORITHM,
+             .digest = {0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
+                        0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c, 0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad}},
+        }};
+
+        std::array<UCHAR, 3> input{'a', 'b', 'c'};
+
+        for (const auto& vector : vectors)
+        {
+            BCRYPT_ALG_HANDLE algorithm{};
+            const auto open_status = BCryptOpenAlgorithmProvider(&algorithm, vector.algorithm, nullptr, 0);
+            if (!BCRYPT_SUCCESS(open_status))
+            {
+                printf("BCryptOpenAlgorithmProvider(%ls) failed: 0x%08lX\n", vector.algorithm, open_status);
+                return false;
+            }
+
+            const auto close_algorithm = sogen::utils::finally([&] { BCryptCloseAlgorithmProvider(algorithm, 0); });
+
+            std::vector<UCHAR> digest(vector.digest.size());
+            const auto hash_status = BCryptHash(algorithm, nullptr, 0, input.data(), static_cast<ULONG>(input.size()), digest.data(),
+                                                static_cast<ULONG>(digest.size()));
+            if (!BCRYPT_SUCCESS(hash_status) || digest != vector.digest)
+            {
+                printf("BCryptHash(%ls) failed: 0x%08lX\n", vector.algorithm, hash_status);
+                return false;
+            }
+        }
+
+        return true;
+    }
 }
 
 #define RUN_TEST(func, name)                 \
@@ -1944,6 +1988,7 @@ int main(const int argc, const char* argv[])
     RUN_TEST(test_actctx, "Activation Context")
     RUN_TEST(test_mmio, "MMIO")
     RUN_TEST(test_gdi, "GDI")
+    RUN_TEST(test_bcrypt_hash, "BCrypt Hash")
 
     return valid ? 0 : 1;
 }

--- a/src/windows-emulator/devices/security_support_provider.cpp
+++ b/src/windows-emulator/devices/security_support_provider.cpp
@@ -149,13 +149,9 @@ namespace sogen
                     return STATUS_SUCCESS;
                 }
 
-                std::u16string_view algorithm_name{};
-
-                if (c.input_buffer_length >= sizeof(ksec_algorithm_request))
-                {
-                    // The field is guest-controlled and may not be NUL-terminated.
-                    algorithm_name = utils::string::to_string_view<char16_t>(request.algorithm_name);
-                }
+                // bcrypt sizes the request to the name it carries (0x38 bytes for "MD5"), so it can be shorter than
+                // the struct. The field is guest-controlled and may not be NUL-terminated.
+                const auto algorithm_name = utils::string::to_string_view<char16_t>(request.algorithm_name);
 
                 const auto write_response = [&](const auto& output_data) -> NTSTATUS {
                     if (!c.output_buffer || c.output_buffer_length < sizeof(output_data))


### PR DESCRIPTION
## Problem

`BCryptOpenAlgorithmProvider` fails with `STATUS_NOT_SUPPORTED` (`0xC00000BB`) for every algorithm whose name is three characters long (`MD5`, `MD4`, `MD2`), while `SHA1`/`SHA256` work.

bcrypt.dll sizes the KsecDD `0x390400` provider-lookup request to the name it carries. Measured on the emulated x64 bcrypt.dll by temporarily logging `c.input_buffer_length` in `security_support_provider.cpp`:

| Algorithm | request length |
|---|---|
| `MD5`, `MD4` | `0x38` |
| `SHA1`, `SHA256` | `0x40` |

`ksec_algorithm_request` is `0x40` bytes, and the handler only parsed `algorithm_name` when `input_buffer_length >= sizeof(ksec_algorithm_request)`. Every `0x38`-byte request therefore ended up with an empty name, missed the hash-algorithm table, and fell through to the RNG-provider response, which bcrypt then rejected.

## Fix

`src/windows-emulator/devices/security_support_provider.cpp`: drop the full-struct-size gate and always parse `algorithm_name`. The read already goes through `read_memory<T>(address, size)`, which copies `min(size, sizeof(T))` bytes into a zero-initialised struct, so a short request never reads out of bounds; the guard was only discarding data that had already been read safely. The existing `ksec_algorithm_request_min_size` (`0x30`, the offset of the name) check still rejects requests too short to contain any name at all.

## Test

`src/samples/test-sample/test.cpp` + `CMakeLists.txt`: new `BCrypt Hash` test-sample case (links `bcrypt`) that opens `MD5` (short request) and `SHA256` (full request), hashes `"abc"` via `BCryptHash`, and compares against the known digests, so both request shapes stay covered.

## Verification

All runs: macOS host, x64 `analyzer` from `cmake --build --preset=release`. "main-equivalent" below is this branch's tree with only `security_support_provider.cpp` reverted to `origin/main` (`e8824779`), rebuilt.

**test-sample.exe (x64, built from this branch with mingw-w64), `--backend unicorn`:**
- main-equivalent: 29/30, `Running test 'BCrypt Hash': BCryptOpenAlgorithmProvider(MD5) failed: 0xC00000BB` -> `Fail`, exit 1
- this branch: 30/30, exit 0
- this branch, `--backend fex`: 30/30, exit 0

**Standalone probe (`BCryptOpenAlgorithmProvider` + `BCryptHash("abc")` for MD5/MD4/SHA1/SHA256), before -> after:**
- x64 unicorn: MD5/MD4 `0xC00000BB` -> `0x00000000` with digests `900150983cd24fb0d6963f7d28e17f72` / `a448017aaf21d8525fc10ae87aa6729d`; SHA1/SHA256 unchanged (`0x00000000`, correct digests) in both builds
- x86 (WoW64) unicorn: same before/after result as x64
- x64 fex: same before/after result as x64
- x86 fex: not runnable, backend reports "FEX backend does not support WoW64 (32-bit) processes yet" (pre-existing, unrelated)

**Regression:** `EMULATOR_ROOT=<root> ./windows-emulator-test` on this branch: 50/50 passed. `clang-format --dry-run --Werror` clean on the changed files.