### PR TITLE
feat(registry): stub NtCreateRegistryTransaction and NtOpenRegistryTransaction

### DIFF
--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -20,6 +20,7 @@
 #include <intrin.h>
 
 #include <windows.h>
+#include <winternl.h>
 #include <timeapi.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -611,6 +612,41 @@ namespace
         }
 
         return true;
+    }
+
+    bool test_registry_transaction()
+    {
+        using nt_create_registry_transaction = NTSTATUS(NTAPI*)(PHANDLE, ACCESS_MASK, POBJECT_ATTRIBUTES, ULONG);
+        using nt_open_registry_transaction = NTSTATUS(NTAPI*)(PHANDLE, ACCESS_MASK, POBJECT_ATTRIBUTES);
+
+        auto* const ntdll = GetModuleHandleW(L"ntdll.dll");
+        const auto create_transaction =
+            reinterpret_cast<nt_create_registry_transaction>(reinterpret_cast<void*>(GetProcAddress(ntdll, "NtCreateRegistryTransaction")));
+        const auto open_transaction =
+            reinterpret_cast<nt_open_registry_transaction>(reinterpret_cast<void*>(GetProcAddress(ntdll, "NtOpenRegistryTransaction")));
+        if (!create_transaction || !open_transaction)
+        {
+            return false;
+        }
+
+        constexpr auto status_not_supported = static_cast<NTSTATUS>(0xC00000BB);
+
+        OBJECT_ATTRIBUTES attributes{};
+        InitializeObjectAttributes(&attributes, nullptr, 0, nullptr, nullptr);
+
+        HANDLE transaction{};
+        const auto create_status = create_transaction(&transaction, TRANSACTION_ALL_ACCESS, &attributes, 0);
+        if (create_status >= 0)
+        {
+            CloseHandle(transaction);
+        }
+        else if (create_status != status_not_supported)
+        {
+            return false;
+        }
+
+        const auto open_status = open_transaction(&transaction, TRANSACTION_ALL_ACCESS, &attributes);
+        return open_status < 0;
     }
 
     bool test_system_info()
@@ -1916,6 +1952,7 @@ int main(const int argc, const char* argv[])
     RUN_TEST(test_working_directory, "Working Directory")
 #endif
     RUN_TEST(test_registry, "Registry")
+    RUN_TEST(test_registry_transaction, "Registry Transaction")
     RUN_TEST(test_system_info, "System Info")
     RUN_TEST(test_monitor_info, "Monitor Info")
     RUN_TEST(test_time_zone, "Time Zone")

--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -311,6 +311,13 @@ namespace sogen
         NTSTATUS handle_NtDeleteValueKey(const syscall_context& c, handle key_handle,
                                          emulator_object<UNICODE_STRING<EmulatorTraits<Emu64>>> value_name);
         NTSTATUS handle_NtNotifyChangeKey();
+        NTSTATUS handle_NtCreateRegistryTransaction(const syscall_context& c, emulator_object<handle> transaction_handle,
+                                                    ACCESS_MASK desired_access,
+                                                    emulator_object<OBJECT_ATTRIBUTES<EmulatorTraits<Emu64>>> object_attributes,
+                                                    ULONG create_options);
+        NTSTATUS handle_NtOpenRegistryTransaction(const syscall_context& c, emulator_object<handle> transaction_handle,
+                                                  ACCESS_MASK desired_access,
+                                                  emulator_object<OBJECT_ATTRIBUTES<EmulatorTraits<Emu64>>> object_attributes);
         NTSTATUS handle_NtSetInformationKey(const syscall_context& c, handle key_handle, KEY_SET_INFORMATION_CLASS key_information_class,
                                             uint64_t key_information, ULONG length);
         NTSTATUS handle_NtEnumerateKey(const syscall_context& c, handle key_handle, ULONG index,
@@ -1459,6 +1466,8 @@ namespace sogen
         add_handler(NtSetValueKey);
         add_handler(NtDeleteValueKey);
         add_handler(NtNotifyChangeKey);
+        add_handler(NtCreateRegistryTransaction);
+        add_handler(NtOpenRegistryTransaction);
         add_handler(NtGetCurrentProcessorNumberEx);
         add_handler(NtGetCurrentProcessorNumber);
         add_handler(NtQueryObject);

--- a/src/windows-emulator/syscalls/registry.cpp
+++ b/src/windows-emulator/syscalls/registry.cpp
@@ -495,6 +495,21 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
+        NTSTATUS handle_NtCreateRegistryTransaction(const syscall_context&, const emulator_object<handle> /*transaction_handle*/,
+                                                    const ACCESS_MASK /*desired_access*/,
+                                                    const emulator_object<OBJECT_ATTRIBUTES<EmulatorTraits<Emu64>>> /*object_attributes*/,
+                                                    const ULONG /*create_options*/)
+        {
+            return STATUS_NOT_SUPPORTED;
+        }
+
+        NTSTATUS handle_NtOpenRegistryTransaction(const syscall_context&, const emulator_object<handle> /*transaction_handle*/,
+                                                  const ACCESS_MASK /*desired_access*/,
+                                                  const emulator_object<OBJECT_ATTRIBUTES<EmulatorTraits<Emu64>>> /*object_attributes*/)
+        {
+            return STATUS_NOT_SUPPORTED;
+        }
+
         NTSTATUS handle_NtSetInformationKey(const syscall_context& c, const handle key_handle,
                                             const KEY_SET_INFORMATION_CLASS key_information_class, const uint64_t key_information,
                                             const ULONG length)


### PR DESCRIPTION
## Summary

Register `NtCreateRegistryTransaction` and `NtOpenRegistryTransaction` (both exported by the Windows 10+ `ntdll.dll` in the emulation root, syscall ids `0xC0` / `0x12F`) as handlers that return `STATUS_NOT_SUPPORTED` (`0xC00000BB`). Sogen's registry is a plain hive with no Kernel Transaction Manager (TxR) support, and `STATUS_NOT_SUPPORTED` is what a Windows system without transacted-registry support returns, so callers take their ordinary non-transacted fallback path. The output handle is left untouched on the failure path, as NT does.

Before this change, the first call aborts the whole emulation through the unimplemented-syscall path.

## Reproduction

Any x64 guest that calls either export. The new `test-sample` section is the minimal one: resolve both from `ntdll.dll` via `GetProcAddress`, call `NtCreateRegistryTransaction(&h, TRANSACTION_ALL_ACCESS, &oa, 0)` and `NtOpenRegistryTransaction(&h, TRANSACTION_ALL_ACCESS, &oa)`.

Without the handlers registered (the two `add_handler` lines removed, everything else identical), `test-sample.exe` (x64, cross-built with the repo's `cmake/toolchain/mingw-w64.cmake`) under `--backend unicorn`:

```
Executing syscall: NtCreateRegistryTransaction (0xC0) at 0x1800a1bf2 via 0x1400e162d (test-sample.exe)
Unimplemented syscall: NtCreateRegistryTransaction - 0xC0 (raw: 0xC0)
Emulation failed at: 0x1800a1bf4 - Emulation terminated without status
```

The analyzer exits with status 1 and guest stdout stops at `Running test 'Registry Transaction': ` with no result; every test after it never runs.

## Verification

Same `test-sample.exe`, this branch:

- `--backend unicorn`: both syscalls dispatched (`NtCreateRegistryTransaction (0xC0)`, `NtOpenRegistryTransaction (0x12F)`), `Emulation terminated with status: 0`, guest stdout shows `Running test 'Registry Transaction': Success`, 30 `Success` / 0 `Fail` across the whole sample.
- `--backend fex`: identical result (both syscalls dispatched, status 0, 30/0).
- `windows-emulator-test` with `EMULATOR_ROOT` pointing at a root containing the rebuilt sample: `50 tests from 11 test suites ran ... [  PASSED  ] 50 tests.` The `EmulationTest.*` cases run the sample end to end, so the new section is exercised on every CI run that rebuilds `test-sample.exe`.
- Host: macOS arm64, `cmake --build --preset=release`.

Note the sample check accepts either `STATUS_NOT_SUPPORTED` or success from the create call (so a future real TxR implementation does not have to touch the test), and only requires the open call to fail, since no transaction object exists to open.

## Files

- `src/windows-emulator/syscalls/registry.cpp` — the two handlers
- `src/windows-emulator/syscalls.cpp` — declarations + `add_handler` registrations
- `src/samples/test-sample/test.cpp` — `test_registry_transaction` + `RUN_TEST` entry, `<winternl.h>` include