### PR TITLE
Add AttributeList to process parameters

### DIFF
--- a/src/emulator-platform/platform/kernel_mapped.hpp
+++ b/src/emulator-platform/platform/kernel_mapped.hpp
@@ -389,9 +389,10 @@ namespace sogen
         ULONG DefaultThreadpoolCpuSetMaskCount;
         ULONG DefaultThreadpoolThreadMaximum;
         ULONG HeapMemoryTypeMask; // WIN11
+        std::uint64_t AttributeList;
     } RTL_USER_PROCESS_PARAMETERS64, *PRTL_USER_PROCESS_PARAMETERS64;
 
-    static_assert(sizeof(RTL_USER_PROCESS_PARAMETERS64) == 0x448);
+    static_assert(sizeof(RTL_USER_PROCESS_PARAMETERS64) == 0x450);
 
     union PEB_CROSS_PROCESS_FLAGS_UNION
     {
@@ -552,9 +553,10 @@ namespace sogen
         ULONG DefaultThreadpoolCpuSetMaskCount;
         ULONG DefaultThreadpoolThreadMaximum;
         ULONG HeapMemoryTypeMask; // WIN11
+        std::uint32_t AttributeList;
     } RTL_USER_PROCESS_PARAMETERS32, *PRTL_USER_PROCESS_PARAMETERS32;
 
-    static_assert(sizeof(RTL_USER_PROCESS_PARAMETERS32) == 708);
+    static_assert(sizeof(RTL_USER_PROCESS_PARAMETERS32) == 0x2C8);
 
     typedef struct _PEB64
     {


### PR DESCRIPTION
Before this, emulating any PE file with sogen on the latest windows version crashes during very early startup at "LdrpHandleUserCopyAttributeList". Simply extending both `RTL_USER_PROCESS_PARAMETERS64` and `RTL_USER_PROCESS_PARAMETERS32` with the field `AttributeList` fixes this issue since this function checks if it is NULL or not, and execution continues normally.