### PR TITLE
feat(win32k): implement NtUserIsTopLevelWindow

### DIFF
--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -626,6 +626,7 @@ namespace sogen
                                                       BOOL Ansi);
         uint32_t handle_NtUserSetWindowLong(const syscall_context& c, handle hWnd, int nIndex, uint32_t dwNewLong, BOOL Ansi);
         uint64_t handle_NtUserGetAncestor(const syscall_context& c, hwnd child_hwnd, UINT flags);
+        BOOL handle_NtUserIsTopLevelWindow(const syscall_context& c, hwnd window);
         BOOL handle_NtUserRedrawWindow(const syscall_context& c, hwnd hwnd, emulator_object<RECT> update_rect, uint64_t update_rgn,
                                        UINT flags);
         NTSTATUS handle_NtUserGetCPD();
@@ -1636,6 +1637,7 @@ namespace sogen
         add_handler(NtUserSetClassLongPtr);
         add_handler(NtUserSetWindowLong);
         add_handler(NtUserGetAncestor);
+        add_handler(NtUserIsTopLevelWindow);
         add_handler(NtUserPostMessage);
         add_handler(NtUserPostThreadMessage);
         add_handler(NtUserRedrawWindow);

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -4859,6 +4859,18 @@ namespace sogen
             }
         }
 
+        BOOL handle_NtUserIsTopLevelWindow(const syscall_context& c, const hwnd window)
+        {
+            const auto* win = c.proc.windows.get(window);
+            if (!win)
+            {
+                return FALSE;
+            }
+
+            // Owned popups still parent to the desktop; do not consult owner_handle.
+            return win->parent_handle == c.proc.default_desktop_window_handle.bits ? TRUE : FALSE;
+        }
+
         BOOL handle_NtUserRedrawWindow(const syscall_context& c, const hwnd hwnd, const emulator_object<RECT> update_rect,
                                        const uint64_t /*update_rgn*/, const UINT flags)
         {


### PR DESCRIPTION
Fixes #1337

## Problem

GUI guests that call `DwmExtendFrameIntoClientArea` abort because win32k `NtUserIsTopLevelWindow` is named (e.g. `0x146F`) but has no handler:

```
Executing syscall: NtUserIsTopLevelWindow (0x146F) via dwmapi.dll
Unimplemented syscall: NtUserIsTopLevelWindow - 0x146F
```

## Fix

`handle_NtUserIsTopLevelWindow` matches ReactOS `IntIsTopLevelWindow` / win32k: TRUE iff the window exists and its parent is the desktop. Owned popups still parent to the desktop, so they are top-level; children, HWND_MESSAGE windows, the desktop itself, and invalid HWNDs are not. `owner_handle` is not consulted.

## Test

No unit test: `windows-emulator-test` has no window-tree fixture, and putting `CreateWindowEx` / `IsTopLevelWindow` into `test-sample` would pull the GUI stack into the console smoke suite.

Verified by rebuilding `analyzer` (`vs2022` RelWithDebInfo, Unicorn) and re-running a DWM-framed guest that previously died on this syscall. After this change the call succeeds and the next stop is `NtConnectPort` on `\\Windows\\DwmApiPort` (separate DWM LPC work, not this PR).

## Notes

Backend-agnostic: syscall handler only, no CPU-backend hooks.