### PR TITLE
feat(dxgk): use a generic emulated adapter identity

### DIFF
--- a/src/windows-emulator/emulated_display_adapter.hpp
+++ b/src/windows-emulator/emulated_display_adapter.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+namespace sogen::emulated_display
+{
+    constexpr uint32_t vendor_id = 0x1414;
+    constexpr uint32_t device_id = 0x008C;
+    constexpr uint32_t revision_id = 0;
+    constexpr LUID adapter_luid = {0x1000, 0};
+    constexpr char16_t description[] = u"Microsoft Basic Render Driver";
+
+    // Documented Windows display-adapter interface class, not a device instance.
+    constexpr GUID interface_class = {0x5B45201D, 0xF2F2, 0x4F3B, {0x85, 0xBB, 0x30, 0xFF, 0x1F, 0x95, 0x35, 0x99}};
+
+    // Stable emulator-only unique adapter id. Sequential, not a host device.
+    constexpr GUID unique_id = {0x00000001, 0x0002, 0x0003, {0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}};
+
+    inline std::u16string from_narrow(const char* text)
+    {
+        return {text, text + std::strlen(text)};
+    }
+
+    inline std::u16string hardware_id()
+    {
+        char buf[80]{};
+        std::snprintf(buf, sizeof(buf), "PCI\\VEN_%04X&DEV_%04X&SUBSYS_00000000&REV_%02X", vendor_id, device_id, revision_id);
+        return from_narrow(buf);
+    }
+
+    inline std::u16string interface_path()
+    {
+        char buf[192]{};
+        std::snprintf(buf, sizeof(buf),
+                      "\\\\?\\PCI#VEN_%04X&DEV_%04X&SUBSYS_00000000&REV_%02X#4&1234567&0&0008#{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
+                      vendor_id, device_id, revision_id, interface_class.Data1, interface_class.Data2, interface_class.Data3,
+                      interface_class.Data4[0], interface_class.Data4[1], interface_class.Data4[2], interface_class.Data4[3],
+                      interface_class.Data4[4], interface_class.Data4[5], interface_class.Data4[6], interface_class.Data4[7]);
+        return from_narrow(buf);
+    }
+} // namespace sogen::emulated_display

--- a/src/windows-emulator/emulated_display_adapter.hpp
+++ b/src/windows-emulator/emulated_display_adapter.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <array>
 #include <cstdio>
 #include <cstring>
 #include <string>
+#include <string_view>
 
 namespace sogen::emulated_display
 {
@@ -10,7 +12,7 @@ namespace sogen::emulated_display
     constexpr uint32_t device_id = 0x008C;
     constexpr uint32_t revision_id = 0;
     constexpr LUID adapter_luid = {0x1000, 0};
-    constexpr char16_t description[] = u"Microsoft Basic Render Driver";
+    constexpr std::u16string_view description = u"Microsoft Basic Render Driver";
 
     // Documented Windows display-adapter interface class, not a device instance.
     constexpr GUID interface_class = {0x5B45201D, 0xF2F2, 0x4F3B, {0x85, 0xBB, 0x30, 0xFF, 0x1F, 0x95, 0x35, 0x99}};
@@ -25,19 +27,20 @@ namespace sogen::emulated_display
 
     inline std::u16string hardware_id()
     {
-        char buf[80]{};
-        std::snprintf(buf, sizeof(buf), "PCI\\VEN_%04X&DEV_%04X&SUBSYS_00000000&REV_%02X", vendor_id, device_id, revision_id);
-        return from_narrow(buf);
+        std::array<char, 80> buf{};
+        std::snprintf(buf.data(), buf.size(), "PCI\\VEN_%04X&DEV_%04X&SUBSYS_00000000&REV_%02X", vendor_id, device_id, revision_id);
+        return from_narrow(buf.data());
     }
 
     inline std::u16string interface_path()
     {
-        char buf[192]{};
-        std::snprintf(buf, sizeof(buf),
-                      "\\\\?\\PCI#VEN_%04X&DEV_%04X&SUBSYS_00000000&REV_%02X#4&1234567&0&0008#{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
-                      vendor_id, device_id, revision_id, interface_class.Data1, interface_class.Data2, interface_class.Data3,
-                      interface_class.Data4[0], interface_class.Data4[1], interface_class.Data4[2], interface_class.Data4[3],
-                      interface_class.Data4[4], interface_class.Data4[5], interface_class.Data4[6], interface_class.Data4[7]);
-        return from_narrow(buf);
+        std::array<char, 192> buf{};
+        std::snprintf(
+            buf.data(), buf.size(),
+            "\\\\?\\PCI#VEN_%04X&DEV_%04X&SUBSYS_00000000&REV_%02X#4&1234567&0&0008#{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
+            vendor_id, device_id, revision_id, interface_class.Data1, interface_class.Data2, interface_class.Data3,
+            interface_class.Data4[0], interface_class.Data4[1], interface_class.Data4[2], interface_class.Data4[3],
+            interface_class.Data4[4], interface_class.Data4[5], interface_class.Data4[6], interface_class.Data4[7]);
+        return from_narrow(buf.data());
     }
 } // namespace sogen::emulated_display

--- a/src/windows-emulator/emulated_display_adapter.hpp
+++ b/src/windows-emulator/emulated_display_adapter.hpp
@@ -1,46 +1,17 @@
 #pragma once
 
-#include <array>
-#include <cstdio>
-#include <cstring>
-#include <string>
+#include <cstdint>
 #include <string_view>
 
 namespace sogen::emulated_display
 {
+    // In-box Microsoft Basic Render Driver (WARP). Not a host GPU.
     constexpr uint32_t vendor_id = 0x1414;
     constexpr uint32_t device_id = 0x008C;
     constexpr uint32_t revision_id = 0;
-    constexpr LUID adapter_luid = {0x1000, 0};
+
     constexpr std::u16string_view description = u"Microsoft Basic Render Driver";
-
-    // Documented Windows display-adapter interface class, not a device instance.
-    constexpr GUID interface_class = {0x5B45201D, 0xF2F2, 0x4F3B, {0x85, 0xBB, 0x30, 0xFF, 0x1F, 0x95, 0x35, 0x99}};
-
-    // Stable emulator-only unique adapter id. Sequential, not a host device.
-    constexpr GUID unique_id = {0x00000001, 0x0002, 0x0003, {0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}};
-
-    inline std::u16string from_narrow(const char* text)
-    {
-        return {text, text + std::strlen(text)};
-    }
-
-    inline std::u16string hardware_id()
-    {
-        std::array<char, 80> buf{};
-        std::snprintf(buf.data(), buf.size(), "PCI\\VEN_%04X&DEV_%04X&SUBSYS_00000000&REV_%02X", vendor_id, device_id, revision_id);
-        return from_narrow(buf.data());
-    }
-
-    inline std::u16string interface_path()
-    {
-        std::array<char, 192> buf{};
-        std::snprintf(
-            buf.data(), buf.size(),
-            "\\\\?\\PCI#VEN_%04X&DEV_%04X&SUBSYS_00000000&REV_%02X#4&1234567&0&0008#{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
-            vendor_id, device_id, revision_id, interface_class.Data1, interface_class.Data2, interface_class.Data3,
-            interface_class.Data4[0], interface_class.Data4[1], interface_class.Data4[2], interface_class.Data4[3],
-            interface_class.Data4[4], interface_class.Data4[5], interface_class.Data4[6], interface_class.Data4[7]);
-        return from_narrow(buf.data());
-    }
+    constexpr std::u16string_view hardware_id = u"PCI\\VEN_1414&DEV_008C&SUBSYS_00000000&REV_00";
+    constexpr std::u16string_view interface_path =
+        u"\\\\?\\PCI#VEN_1414&DEV_008C&SUBSYS_00000000&REV_00#4&1234567&0&0008#{5b45201d-f2f2-4f3b-85bb-30ff1f953599}";
 } // namespace sogen::emulated_display

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -198,7 +198,9 @@ namespace sogen
             constexpr uint32_t k_dxgk_device_handle = 0x5000;
             constexpr uint32_t k_dxgk_context_handle = 0x6000;
             constexpr uint32_t k_dxgk_shared_primary_handle = 0x7000;
-            constexpr LUID k_dxgk_adapter_luid = emulated_display::adapter_luid;
+            constexpr LUID k_dxgk_adapter_luid = {0x1000, 0};
+            // Stable emulator-only unique adapter id. Sequential, not a host device.
+            constexpr GUID k_dxgk_adapter_unique_id = {0x00000001, 0x0002, 0x0003, {0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}};
             constexpr uint32_t k_dxgk_adapter_source_count = 1;
             constexpr uint32_t k_dxgk_command_buffer_size = 0x1000;
             constexpr uint32_t k_dxgk_allocation_list_entry_size = 8;
@@ -4126,7 +4128,7 @@ namespace sogen
             }
 
             case KMTQAITYPE::KMTQAITYPE_ADAPTERGUID: {
-                GUID adapter_guid = emulated_display::unique_id;
+                GUID adapter_guid = k_dxgk_adapter_unique_id;
                 return write_query_adapter_info(c, query, adapter_guid);
             }
 
@@ -4214,7 +4216,7 @@ namespace sogen
             }
 
             case KMTQAITYPE::KMTQAITYPE_QUERY_ADAPTER_UNIQUE_GUID: {
-                GUID unique_guid = emulated_display::unique_id;
+                GUID unique_guid = k_dxgk_adapter_unique_id;
                 return write_query_adapter_info(c, query, unique_guid);
             }
 

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -1,5 +1,6 @@
 #include "../std_include.hpp"
 #include "../debug_font.hpp"
+#include "../emulated_display_adapter.hpp"
 #include "../emulator_utils.hpp"
 #include "../syscall_utils.hpp"
 
@@ -197,7 +198,7 @@ namespace sogen
             constexpr uint32_t k_dxgk_device_handle = 0x5000;
             constexpr uint32_t k_dxgk_context_handle = 0x6000;
             constexpr uint32_t k_dxgk_shared_primary_handle = 0x7000;
-            constexpr LUID k_dxgk_adapter_luid = {0x1000, 0};
+            constexpr LUID k_dxgk_adapter_luid = emulated_display::adapter_luid;
             constexpr uint32_t k_dxgk_adapter_source_count = 1;
             constexpr uint32_t k_dxgk_command_buffer_size = 0x1000;
             constexpr uint32_t k_dxgk_allocation_list_entry_size = 8;
@@ -212,15 +213,11 @@ namespace sogen
             constexpr uint32_t k_dxgk_max_list_count = 0x10000;            // 64k entries (<= 1.5 MiB of list bytes)
             constexpr uint64_t k_dxgk_dedicated_video_memory_size = 4ull * 1024 * 1024 * 1024;
             constexpr uint64_t k_dxgk_shared_system_memory_size = 8ull * 1024 * 1024 * 1024;
-            constexpr uint32_t k_dxgk_fake_vendor_id = 0x10DE;
-            constexpr uint32_t k_dxgk_fake_device_id = 0x1C03;
-            constexpr uint32_t k_dxgk_fake_revision_id = 0xA1;
             constexpr uint32_t k_dxgk_open_resource_resource_private_size = 0x18;
             constexpr uint32_t k_dxgk_open_resource_allocation_private_size = 0x18;
             constexpr uint32_t k_dxgk_open_resource_descriptor_size = 0x80;
             constexpr uint32_t k_dxgk_open_resource_total_private_size =
                 k_dxgk_open_resource_allocation_private_size + k_dxgk_open_resource_descriptor_size;
-            constexpr GUID k_dxgk_adapter_guid = {0x5b45201d, 0xf2f2, 0x4f3b, {0x85, 0xbb, 0x30, 0xff, 0x1f, 0x95, 0x35, 0x99}};
 
             uint64_t ensure_gdi_shared_table(const syscall_context& c)
             {
@@ -4129,7 +4126,7 @@ namespace sogen
             }
 
             case KMTQAITYPE::KMTQAITYPE_ADAPTERGUID: {
-                GUID adapter_guid = k_dxgk_adapter_guid;
+                GUID adapter_guid = emulated_display::unique_id;
                 return write_query_adapter_info(c, query, adapter_guid);
             }
 
@@ -4201,10 +4198,10 @@ namespace sogen
                     UINT32 FunctionNumber;
                 } ids{};
 
-                ids.VendorID = k_dxgk_fake_vendor_id;
-                ids.DeviceID = k_dxgk_fake_device_id;
+                ids.VendorID = emulated_display::vendor_id;
+                ids.DeviceID = emulated_display::device_id;
                 ids.SubSystemID = 0;
-                ids.RevisionID = k_dxgk_fake_revision_id;
+                ids.RevisionID = emulated_display::revision_id;
                 ids.BusNumber = 0;
                 ids.DeviceNumber = 0;
                 ids.FunctionNumber = 0;
@@ -4217,7 +4214,7 @@ namespace sogen
             }
 
             case KMTQAITYPE::KMTQAITYPE_QUERY_ADAPTER_UNIQUE_GUID: {
-                GUID unique_guid = k_dxgk_adapter_guid;
+                GUID unique_guid = emulated_display::unique_id;
                 return write_query_adapter_info(c, query, unique_guid);
             }
 

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1,4 +1,5 @@
 #include "../std_include.hpp"
+#include "../emulated_display_adapter.hpp"
 #include "../emulator_utils.hpp"
 #include "../syscall_utils.hpp"
 #include "../win32k_userconnect.hpp"
@@ -4146,8 +4147,8 @@ namespace sogen
                 display_device.access([&](EMU_DISPLAY_DEVICEW& dev) {
                     dev.StateFlags = 0x5; // DISPLAY_DEVICE_PRIMARY_DEVICE | DISPLAY_DEVICE_ATTACHED_TO_DESKTOP
                     utils::string::copy(dev.DeviceName, u"\\\\.\\DISPLAY1");
-                    utils::string::copy(dev.DeviceString, u"Emulated Virtual Adapter");
-                    utils::string::copy(dev.DeviceID, u"PCI\\VEN_10DE&DEV_0000&SUBSYS_00000000&REV_A1");
+                    utils::string::copy(dev.DeviceString, emulated_display::description);
+                    utils::string::copy(dev.DeviceID, emulated_display::hardware_id().c_str());
                     utils::string::copy(dev.DeviceKey, u"\\Registry\\Machine\\System\\CurrentControlSet\\Control\\Video\\{00000001-"
                                                        u"0002-0003-0004-000000000005}\\0000");
                 });
@@ -5224,9 +5225,7 @@ namespace sogen
 
                 adapter_name.access([&](EMU_DISPLAYCONFIG_ADAPTER_NAME& adapterName) {
                     adapterName.header = header;
-                    utils::string::copy(
-                        adapterName.adapterDevicePath,
-                        u"\\\\?\\PCI#VEN_10DE&DEV_1C03&SUBSYS_00000000&REV_A1#4&1234567&0&0008#{5b45201d-f2f2-4f3b-85bb-30ff1f953599}");
+                    utils::string::copy(adapterName.adapterDevicePath, emulated_display::interface_path().c_str());
                 });
 
                 return STATUS_SUCCESS;
@@ -5275,17 +5274,15 @@ namespace sogen
 
                     const auto fill_block = [](EMU_DISPLAY_INFO_DEVICE_BLOCK& block) {
                         block.Valid = 1;
-                        block.VendorID = 0x10DE;
-                        block.DeviceID = 0x1C03;
-                        block.SubSystemVendorID = 0x10DE;
+                        block.VendorID = emulated_display::vendor_id;
+                        block.DeviceID = emulated_display::device_id;
+                        block.SubSystemVendorID = emulated_display::vendor_id;
                         block.SubSystemID = 0;
-                        block.RevisionID = 0xA1;
+                        block.RevisionID = emulated_display::revision_id;
                         block.WddmVersion = 3200;
 
-                        utils::string::copy(block.AdapterDesc, u"NVIDIA GeForce GTX 1060 6GB");
-                        utils::string::copy(
-                            block.AdapterDevicePath,
-                            u"\\\\?\\PCI#VEN_10DE&DEV_1C03&SUBSYS_00000000&REV_A1#4&1234567&0&0008#{5b45201d-f2f2-4f3b-85bb-30ff1f953599}");
+                        utils::string::copy(block.AdapterDesc, emulated_display::description);
+                        utils::string::copy(block.AdapterDevicePath, emulated_display::interface_path().c_str());
                     };
 
                     fill_block(info.DisplayAdapter);
@@ -5315,14 +5312,14 @@ namespace sogen
                         return;
                     }
 
-                    info.VendorID = 0x10DE;
-                    info.DeviceID = 0x1C03;
+                    info.VendorID = emulated_display::vendor_id;
+                    info.DeviceID = emulated_display::device_id;
                     info.SubSysID0 = 0;
                     info.SubSysID1 = 0;
-                    info.RevisionID = 0xA1;
+                    info.RevisionID = emulated_display::revision_id;
                     info.WddmVersion = 2700;
 
-                    utils::string::copy(info.AdapterDesc, u"NVIDIA GeForce GTX 1060 6GB");
+                    utils::string::copy(info.AdapterDesc, emulated_display::description);
 
                     info.DisplayLeft = 0;
                     info.DisplayTop = 0;

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -4148,7 +4148,7 @@ namespace sogen
                     dev.StateFlags = 0x5; // DISPLAY_DEVICE_PRIMARY_DEVICE | DISPLAY_DEVICE_ATTACHED_TO_DESKTOP
                     utils::string::copy(dev.DeviceName, u"\\\\.\\DISPLAY1");
                     utils::string::copy(dev.DeviceString, emulated_display::description);
-                    utils::string::copy(dev.DeviceID, emulated_display::hardware_id().c_str());
+                    utils::string::copy(dev.DeviceID, emulated_display::hardware_id);
                     utils::string::copy(dev.DeviceKey, u"\\Registry\\Machine\\System\\CurrentControlSet\\Control\\Video\\{00000001-"
                                                        u"0002-0003-0004-000000000005}\\0000");
                 });
@@ -5225,7 +5225,7 @@ namespace sogen
 
                 adapter_name.access([&](EMU_DISPLAYCONFIG_ADAPTER_NAME& adapterName) {
                     adapterName.header = header;
-                    utils::string::copy(adapterName.adapterDevicePath, emulated_display::interface_path().c_str());
+                    utils::string::copy(adapterName.adapterDevicePath, emulated_display::interface_path);
                 });
 
                 return STATUS_SUCCESS;
@@ -5282,7 +5282,7 @@ namespace sogen
                         block.WddmVersion = 3200;
 
                         utils::string::copy(block.AdapterDesc, emulated_display::description);
-                        utils::string::copy(block.AdapterDevicePath, emulated_display::interface_path().c_str());
+                        utils::string::copy(block.AdapterDevicePath, emulated_display::interface_path);
                     };
 
                     fill_block(info.DisplayAdapter);


### PR DESCRIPTION
## Summary
- DXGK and DisplayConfig currently advertise a discrete-GPU product identity.
- Centralize a generic emulated adapter identity: in-box software-adapter IDs, the documented display-adapter interface class, and a sequential unique GUID.
- EnumDisplayDevices, DisplayConfig, and QueryAdapterInfo now share that identity. Description string is Microsoft Basic Render Driver.

Fixes #1343

## Test plan
- [ ] EnumDisplayDevices reports the generic software-adapter description
- [ ] QueryAdapterInfo adapter GUID / unique GUID / physical device IDs match the shared identity
- [ ] DisplayConfig adapter name and GET_DISPLAY_INFO use the same identity
