### PR TITLE
feat(dxgk): stub GPU/CPU sync and UnBindCompositionSurface

### DIFF
--- a/src/windows-emulator/syscalls.cpp
+++ b/src/windows-emulator/syscalls.cpp
@@ -858,6 +858,13 @@ namespace sogen
         NTSTATUS handle_NtGdiDdDDIOpenAdapterFromLuid(const syscall_context& c,
                                                       emulator_object<EMU_D3DKMT_OPENADAPTERFROMLUID> open_adapter);
         NTSTATUS handle_NtGdiDdDDIOpenAdapterFromHdc(const syscall_context& c, emulator_object<EMU_D3DKMT_OPENADAPTERFROMHDC> open_adapter);
+        NTSTATUS handle_NtGdiDdDDIWaitForSynchronizationObjectFromGpu();
+        NTSTATUS handle_NtGdiDdDDIWaitForSynchronizationObjectFromCpu();
+        NTSTATUS handle_NtGdiDdDDISignalSynchronizationObjectFromGpu();
+        NTSTATUS handle_NtGdiDdDDISignalSynchronizationObjectFromCpu();
+
+        // syscalls/composition.cpp:
+        NTSTATUS handle_NtUnBindCompositionSurface();
 
         // syscalls/trace.cpp:
         NTSTATUS handle_NtTraceControl(const syscall_context& c, ULONG function_code, uint64_t input_buffer, ULONG input_buffer_length,
@@ -1689,6 +1696,11 @@ namespace sogen
         add_handler(NtGdiOpenDCW);
         add_handler(NtGdiDdDDIOpenAdapterFromLuid);
         add_handler(NtGdiDdDDIOpenAdapterFromHdc);
+        add_handler(NtGdiDdDDIWaitForSynchronizationObjectFromGpu);
+        add_handler(NtGdiDdDDIWaitForSynchronizationObjectFromCpu);
+        add_handler(NtGdiDdDDISignalSynchronizationObjectFromGpu);
+        add_handler(NtGdiDdDDISignalSynchronizationObjectFromCpu);
+        add_handler(NtUnBindCompositionSurface);
         add_handler(NtGdiSelectFont);
         add_handler(NtUserInitThreadCoreMessagingIocp2);
         add_handler(NtUserDrainThreadCoreMessagingCompletions2);

--- a/src/windows-emulator/syscalls/composition.cpp
+++ b/src/windows-emulator/syscalls/composition.cpp
@@ -1,0 +1,16 @@
+#include "../std_include.hpp"
+#include "../emulator_utils.hpp"
+#include "../syscall_utils.hpp"
+
+namespace sogen
+{
+
+    namespace syscalls
+    {
+        NTSTATUS handle_NtUnBindCompositionSurface()
+        {
+            return STATUS_SUCCESS;
+        }
+    }
+
+} // namespace sogen

--- a/src/windows-emulator/syscalls/gdi.cpp
+++ b/src/windows-emulator/syscalls/gdi.cpp
@@ -5029,6 +5029,26 @@ namespace sogen
             return STATUS_SUCCESS;
         }
 
+        NTSTATUS handle_NtGdiDdDDIWaitForSynchronizationObjectFromGpu()
+        {
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiDdDDIWaitForSynchronizationObjectFromCpu()
+        {
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiDdDDISignalSynchronizationObjectFromGpu()
+        {
+            return STATUS_SUCCESS;
+        }
+
+        NTSTATUS handle_NtGdiDdDDISignalSynchronizationObjectFromCpu()
+        {
+            return STATUS_SUCCESS;
+        }
+
         COLORREF handle_NtGdiSetPixel(const syscall_context& c, const hdc dc, const int x, const int y, const COLORREF color)
         {
             constexpr uint64_t clr_invalid = 0xFFFFFFFF;


### PR DESCRIPTION
## Summary
- Wait/SignalSynchronizationObjectFromGpu and FromCpu are unimplemented and abort guests that wait on GPU work.
- NtUnBindCompositionSurface is similarly unimplemented.
- Stub all five as STATUS_SUCCESS.

Fixes #1342

## Test plan
- [ ] Guest that calls WaitForSynchronizationObjectFromGpu after Render is not aborted
- [ ] Guest that unbinds a composition surface is not aborted
