### PR TITLE
fix(msvc): add iterator alias for MSVC 14.32 dependent name resolution

### DIFF
--- a/src/windows-emulator/handles.hpp
+++ b/src/windows-emulator/handles.hpp
@@ -188,6 +188,7 @@ namespace sogen
       public:
         using index_type = uint32_t;
         using value_map = std::map<index_type, T>;
+        using iterator = typename value_map::iterator;
 
         bool block_mutation(bool blocked)
         {
@@ -270,7 +271,7 @@ namespace sogen
             return h;
         }
 
-        std::pair<typename value_map::iterator, bool> erase(const value_map::iterator& entry)
+        std::pair<iterator, bool> erase(const iterator& entry)
         {
             if (this->block_mutation_)
             {
@@ -390,7 +391,7 @@ namespace sogen
             return this->store_.begin();
         }
 
-        value_map::iterator end()
+        iterator end()
         {
             return this->store_.end();
         }

--- a/src/windows-emulator/user_handle_table.hpp
+++ b/src/windows-emulator/user_handle_table.hpp
@@ -327,6 +327,7 @@ namespace sogen
       public:
         using index_type = uint32_t;
         using value_map = std::map<index_type, T>;
+        using iterator = typename value_map::iterator;
 
         explicit user_handle_store(user_handle_table& table)
             : table_(&table)
@@ -448,7 +449,7 @@ namespace sogen
             return h;
         }
 
-        std::pair<typename value_map::iterator, bool> erase(const value_map::iterator& entry)
+        std::pair<iterator, bool> erase(const iterator& entry)
         {
             if (this->block_mutation_)
             {
@@ -584,7 +585,7 @@ namespace sogen
             return this->store_.begin();
         }
 
-        value_map::iterator end()
+        iterator end()
         {
             return this->store_.end();
         }


### PR DESCRIPTION
Generic build fix, MSVC 14.32 fails to resolve typename value_map::iterator in dependent template signatures (C2061). Adds using iterator alias in handles.hpp and user_handle_table.hpp. No behavior change.