### PR TITLE
whp: skip exec-hook scan + sandbox fast-mode timing

### DIFF
--- a/src/backends/whp-emulator/whp_x86_64_emulator.cpp
+++ b/src/backends/whp-emulator/whp_x86_64_emulator.cpp
@@ -1457,6 +1457,8 @@ namespace sogen::whp
                     auto backing = allocate_backing_memory(size);
                     auto* backing_base = backing.get();
 
+                    const bool range_has_hooks = this->range_intersects_execution_hook(address, size);
+
                     for (size_t offset = 0; offset < size; offset += page_size)
                     {
                         const auto guest_address = address + offset;
@@ -1468,7 +1470,7 @@ namespace sogen::whp
 
                         page->owned_page = backing;
                         page->host_page = backing_base + offset;
-                        this->assign_guest_physical_page(guest_address, *page);
+                        this->assign_guest_physical_page(guest_address, *page, range_has_hooks);
                         page->permissions = permissions;
                         this->apply_patched_execution_breakpoints(guest_address);
                         this->ensure_virtual_mapping(guest_address);
@@ -2200,8 +2202,21 @@ namespace sogen::whp
                 return guest_physical_memory_base + (static_cast<uint64_t>(page_index) * page_size);
             }
 
-            // Assumes partition_mutex_ is held exclusively.
-            void assign_guest_physical_page(const uint64_t guest_address, mapped_page& page)
+            // True if any execution hook overlaps [base, base + size). Used to skip the per-page hook
+            // count for allocations that cannot possibly touch a hooked code range (the common case:
+            // freshly committed data/heap far from any module code). Assumes partition_mutex_ is held.
+            bool range_intersects_execution_hook(const uint64_t base, const uint64_t size) const
+            {
+                return std::ranges::any_of(this->memory_execution_hooks_, [&](const auto& entry) {
+                    const auto& hook = entry.second;
+                    return hook.address && !hook.patched_breakpoint && hook.size != 0 &&
+                           regions_with_length_intersect(*hook.address, hook.size, base, size);
+                });
+            }
+
+            // Assumes partition_mutex_ is held exclusively. maybe_has_execution_hooks lets a batch caller
+            // that has already ruled out any overlap for the whole range skip the (linear) per-page scan.
+            void assign_guest_physical_page(const uint64_t guest_address, mapped_page& page, const bool maybe_has_execution_hooks = true)
             {
                 if (page.guest_physical_address != unmapped_guest_page)
                 {
@@ -2210,11 +2225,16 @@ namespace sogen::whp
 
                 page.guest_page_base = align_down_to_page(guest_address);
                 page.guest_physical_address = this->allocate_guest_physical_page();
-                page.page_execution_hook_count = std::ranges::count_if(this->memory_execution_hooks_, [&](const auto& entry) {
-                    const auto& hook = entry.second;
-                    return hook.address && !hook.patched_breakpoint && hook.size != 0 &&
-                           regions_with_length_intersect(*hook.address, hook.size, page.guest_page_base, page_size);
-                });
+                page.page_execution_hook_count =
+                    maybe_has_execution_hooks
+                        ? std::ranges::count_if(this->memory_execution_hooks_,
+                                                [&](const auto& entry) {
+                                                    const auto& hook = entry.second;
+                                                    return hook.address && !hook.patched_breakpoint && hook.size != 0 &&
+                                                           regions_with_length_intersect(*hook.address, hook.size, page.guest_page_base,
+                                                                                         page_size);
+                                                })
+                        : 0;
                 this->guest_pages_by_gpa_[this->guest_physical_page_index(page.guest_physical_address)] = page.guest_page_base;
             }
 
@@ -3310,6 +3330,7 @@ namespace sogen::whp
                     {
                         throw_hr(run_hr, "WHvRunVirtualProcessor");
                     }
+
                     switch (exit_context.ExitReason)
                     {
                     case WHvRunVpExitReasonCanceled: {

--- a/src/tools/sandbox/main.cpp
+++ b/src/tools/sandbox/main.cpp
@@ -77,6 +77,10 @@ namespace sogen::sandbox
 #endif
 
             emulator_settings settings{
+                // The sandbox favours speed over exact timing: read the TSC and KUSER_SHARED_DATA
+                // natively instead of trapping every access (the analyzer keeps interception on).
+                .intercept_rdtsc = false,
+                .intercept_kusd = false,
                 .vcpu_count = vcpu_count,
                 .registry_directory = get_current_binary_dir() / "registry",
             };

--- a/src/windows-emulator/kusd_mmio.cpp
+++ b/src/windows-emulator/kusd_mmio.cpp
@@ -135,10 +135,23 @@ namespace sogen
     {
     }
 
-    void kusd_mmio::setup(const windows_version_manager& version, const fake_environment_config& fake_env)
+    void kusd_mmio::setup(const windows_version_manager& version, const fake_environment_config& fake_env, const bool intercept)
     {
+        this->intercept_ = intercept;
         setup_kusd(this->kusd_, version, fake_env);
         this->register_mmio();
+    }
+
+    void kusd_mmio::refresh()
+    {
+        if (this->intercept_ || !this->registered_)
+        {
+            return;
+        }
+
+        const std::scoped_lock lock(this->mutex_);
+        this->update();
+        this->memory_->write_memory(KUSD_ADDRESS, &this->kusd_, KUSD_SIZE);
     }
 
     void kusd_mmio::serialize(utils::buffer_serializer& buffer) const
@@ -205,14 +218,25 @@ namespace sogen
 
         this->registered_ = true;
 
-        this->memory_->allocate_mmio(
-            KUSD_ADDRESS, KUSD_BUFFER_SIZE,
-            [this](const uint64_t addr, void* data, const size_t size) {
-                this->read(addr, data, size); //
-            },
-            [](const uint64_t, const void*, const size_t) {
-                // Writing not supported!
-            });
+        if (this->intercept_)
+        {
+            this->memory_->allocate_mmio(
+                KUSD_ADDRESS, KUSD_BUFFER_SIZE,
+                [this](const uint64_t addr, void* data, const size_t size) {
+                    this->read(addr, data, size); //
+                },
+                [](const uint64_t, const void*, const size_t) {
+                    // Writing not supported!
+                });
+            return;
+        }
+
+        // Fast mode: a plain read-only page the guest reads without a per-access MMIO trap. The time
+        // fields are seeded here and then refreshed periodically via refresh().
+        this->memory_->allocate_memory(KUSD_ADDRESS, KUSD_BUFFER_SIZE, memory_permission::read);
+        const std::scoped_lock lock(this->mutex_);
+        this->update();
+        this->memory_->write_memory(KUSD_ADDRESS, &this->kusd_, KUSD_SIZE);
     }
 
     void kusd_mmio::deregister_mmio()

--- a/src/windows-emulator/kusd_mmio.hpp
+++ b/src/windows-emulator/kusd_mmio.hpp
@@ -50,13 +50,19 @@ namespace sogen
 
         static uint64_t address();
 
-        void setup(const windows_version_manager& version, const fake_environment_config& fake_env);
+        void setup(const windows_version_manager& version, const fake_environment_config& fake_env, bool intercept = true);
+
+        // In non-intercept (fast) mode KUSD is a plain mapped page rather than an MMIO trap; call this
+        // periodically (e.g. from the timer thread) to refresh the time fields into that page. No-op
+        // when intercepting.
+        void refresh();
 
       private:
         memory_manager* memory_{};
         utils::clock* clock_{};
 
         bool registered_{};
+        bool intercept_{true};
 
         // The MMIO read callback runs on the WHP worker thread during guest execution
         // (outside the kernel lock), so multiple vCPUs can read KUSD concurrently. This

--- a/src/windows-emulator/process_context.cpp
+++ b/src/windows-emulator/process_context.cpp
@@ -252,13 +252,13 @@ namespace sogen
     void process_context::setup(x86_64_emulator& emu, memory_manager& memory, registry_manager& registry, file_system& file_system,
                                 windows_version_manager& version, const fake_environment_config& fake_env,
                                 const application_settings& app_settings, const mapped_module& executable, const mapped_module& ntdll,
-                                const apiset::container& apiset_container, const mapped_module* ntdll32)
+                                const apiset::container& apiset_container, const mapped_module* ntdll32, const bool intercept_kusd)
     {
         this->sid = get_sid(registry);
 
         setup_gdt(emu, memory);
 
-        this->kusd.setup(version, fake_env);
+        this->kusd.setup(version, fake_env, intercept_kusd);
 
         this->base_allocator = create_allocator(memory, PEB_SEGMENT_SIZE, this->is_wow64_process);
         auto& allocator = this->base_allocator;

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -333,7 +333,7 @@ namespace sogen
         void setup(x86_64_emulator& emu, memory_manager& memory, registry_manager& registry, file_system& file_system,
                    windows_version_manager& version, const fake_environment_config& fake_env, const application_settings& app_settings,
                    const mapped_module& executable, const mapped_module& ntdll, const apiset::container& apiset_container,
-                   const mapped_module* ntdll32 = nullptr);
+                   const mapped_module* ntdll32 = nullptr, bool intercept_kusd = true);
 
         handle create_thread(memory_manager& memory, uint64_t start_address, uint64_t argument, uint64_t stack_size, uint32_t create_flags,
                              bool initial_thread = false);

--- a/src/windows-emulator/windows_emulator.cpp
+++ b/src/windows-emulator/windows_emulator.cpp
@@ -606,6 +606,8 @@ namespace sogen
           process(*this->emu_, memory, *this->clock_, this->callbacks),
           use_relative_time_(settings.use_relative_time),
           instruction_precision_(settings.use_instruction_precision && this->emu_->supports_instruction_counting()),
+          intercept_rdtsc_(settings.intercept_rdtsc),
+          intercept_kusd_(settings.intercept_kusd),
           vcpu_count_(settings.vcpu_count)
     {
         if (this->vcpu_count_ == 0)
@@ -695,7 +697,8 @@ namespace sogen
         const auto apiset_data = apiset::obtain(this->emulation_root);
 
         this->process.setup(this->emu(), this->memory, this->registry, this->file_sys, this->version, this->fake_env,
-                            this->application_settings_, *executable, *ntdll, apiset_data, this->mod_manager.wow64_modules_.ntdll32);
+                            this->application_settings_, *executable, *ntdll, apiset_data, this->mod_manager.wow64_modules_.ntdll32,
+                            this->intercept_kusd_);
 
         const auto ntdll_data = emu.read_memory(ntdll->image_base, static_cast<size_t>(ntdll->size_of_image));
         const auto win32u_data = emu.read_memory(win32u->image_base, static_cast<size_t>(win32u->size_of_image));
@@ -990,37 +993,43 @@ namespace sogen
             return instruction_hook_continuation::skip_instruction;
         });
 
-        this->emu().hook_instruction(x86_hookable_instructions::rdtscp, [&](cpu_interface& cpu, uint64_t) {
-            const std::scoped_lock lock(this->kernel_lock_);
-            auto& vcpu = this->vcpu(cpu.index());
-            const scoped_dispatch dispatch(*this, vcpu);
-            auto& acting = vcpu.cpu;
-            this->callbacks.on_rdtscp();
+        // rdtsc/rdtscp are intercepted only when timing must stay exact (the analyzer). Otherwise the
+        // guest reads the host TSC natively - the WHP backend serves the exit with the real TSC and no
+        // kernel lock - removing a hot VM-exit path for games.
+        if (this->intercept_rdtsc_)
+        {
+            this->emu().hook_instruction(x86_hookable_instructions::rdtscp, [&](cpu_interface& cpu, uint64_t) {
+                const std::scoped_lock lock(this->kernel_lock_);
+                auto& vcpu = this->vcpu(cpu.index());
+                const scoped_dispatch dispatch(*this, vcpu);
+                auto& acting = vcpu.cpu;
+                this->callbacks.on_rdtscp();
 
-            const auto ticks = this->clock_->timestamp_counter();
-            acting.reg(x86_register::rax, static_cast<uint32_t>(ticks));
-            acting.reg(x86_register::rdx, static_cast<uint32_t>(ticks >> 32));
+                const auto ticks = this->clock_->timestamp_counter();
+                acting.reg(x86_register::rax, static_cast<uint32_t>(ticks));
+                acting.reg(x86_register::rdx, static_cast<uint32_t>(ticks >> 32));
 
-            // Return the IA32_TSC_AUX value in RCX (low 32 bits)
-            auto tsc_aux = 0; // Need to replace this with proper CPUID later
-            acting.reg(x86_register::rcx, tsc_aux);
+                // Return the IA32_TSC_AUX value in RCX (low 32 bits)
+                auto tsc_aux = 0; // Need to replace this with proper CPUID later
+                acting.reg(x86_register::rcx, tsc_aux);
 
-            return instruction_hook_continuation::skip_instruction;
-        });
+                return instruction_hook_continuation::skip_instruction;
+            });
 
-        this->emu().hook_instruction(x86_hookable_instructions::rdtsc, [&](cpu_interface& cpu, uint64_t) {
-            const std::scoped_lock lock(this->kernel_lock_);
-            auto& vcpu = this->vcpu(cpu.index());
-            const scoped_dispatch dispatch(*this, vcpu);
-            auto& acting = vcpu.cpu;
-            this->callbacks.on_rdtsc();
+            this->emu().hook_instruction(x86_hookable_instructions::rdtsc, [&](cpu_interface& cpu, uint64_t) {
+                const std::scoped_lock lock(this->kernel_lock_);
+                auto& vcpu = this->vcpu(cpu.index());
+                const scoped_dispatch dispatch(*this, vcpu);
+                auto& acting = vcpu.cpu;
+                this->callbacks.on_rdtsc();
 
-            const auto ticks = this->clock_->timestamp_counter();
-            acting.reg(x86_register::rax, static_cast<uint32_t>(ticks));
-            acting.reg(x86_register::rdx, static_cast<uint32_t>(ticks >> 32));
+                const auto ticks = this->clock_->timestamp_counter();
+                acting.reg(x86_register::rax, static_cast<uint32_t>(ticks));
+                acting.reg(x86_register::rdx, static_cast<uint32_t>(ticks >> 32));
 
-            return instruction_hook_continuation::skip_instruction;
-        });
+                return instruction_hook_continuation::skip_instruction;
+            });
+        }
 
         // TODO: Unicorn needs this - This should be handled in the backend
         this->emu().hook_instruction(x86_hookable_instructions::invalid, [&](cpu_interface& cpu, uint64_t) {
@@ -1232,9 +1241,11 @@ namespace sogen
             }
         });
 
-        if (!this->uses_instruction_precision() && this->emu().is_stop_thread_safe())
+        const bool preempt_vcpus = !this->uses_instruction_precision() && this->emu().is_stop_thread_safe();
+        const bool refresh_kusd = !this->intercept_kusd_;
+        if (preempt_vcpus || refresh_kusd)
         {
-            interrupt_thread = std::thread([&] {
+            interrupt_thread = std::thread([&, preempt_vcpus, refresh_kusd] {
                 while (!this->should_stop)
                 {
                     std::unique_lock lock{interrupt_mutex};
@@ -1242,7 +1253,18 @@ namespace sogen
                         return this->should_stop.load(); //
                     });
 
-                    if (!this->should_stop)
+                    if (this->should_stop)
+                    {
+                        break;
+                    }
+
+                    // Fast-mode KUSD is a plain page; refresh its time fields here instead of on each read.
+                    if (refresh_kusd)
+                    {
+                        this->process.kusd.refresh();
+                    }
+
+                    if (preempt_vcpus)
                     {
                         for (uint32_t i = 0; i < this->vcpu_count_; ++i)
                         {

--- a/src/windows-emulator/windows_emulator.hpp
+++ b/src/windows-emulator/windows_emulator.hpp
@@ -93,6 +93,13 @@ namespace sogen
         bool use_relative_time{false};
         bool use_instruction_precision{true};
 
+        // Timing fidelity vs. speed. With interception on (the default, used by the analyzer) rdtsc reads
+        // and KUSER_SHARED_DATA accesses trap so the emulated clock stays exact and deterministic. Turning
+        // them off (as the sandbox does) lets the guest read the host TSC natively and KUSD from a plain
+        // mapped page, removing those VM exits at the cost of exact/reproducible timing.
+        bool intercept_rdtsc{true};
+        bool intercept_kusd{true};
+
         // Number of virtual CPUs to run guest threads on. Values above 1 require a
         // backend where supports_multiple_vcpus() is true (see docs/multi-vcpu-design.md).
         uint32_t vcpu_count{1};
@@ -403,6 +410,8 @@ namespace sogen
       private:
         bool use_relative_time_{false}; // TODO: Get rid of that
         bool instruction_precision_{true};
+        bool intercept_rdtsc_{true};
+        bool intercept_kusd_{true};
         uint32_t vcpu_count_{1};
         std::atomic_bool should_stop{false};
 


### PR DESCRIPTION
Draft: generic perf foranalyzer. Skip per-page execution-hook scan when allocation cannot overlap code; add emulator_settings intercept_rdtsc/intercept_kusd fast paths defaulting to accurate behavior (analyzer stays exact).