### PR TITLE
fix(module): collect ordinal-only exports in both collect_exports overloads

### DIFF
--- a/src/windows-emulator-test/module_exports_test.cpp
+++ b/src/windows-emulator-test/module_exports_test.cpp
@@ -1,0 +1,91 @@
+#include "emulation_test_utils.hpp"
+#include "module/module_mapping.hpp"
+
+namespace sogen::test
+{
+    namespace
+    {
+        // profapi.dll exports every function by ordinal only.
+        constexpr auto ordinal_only_module = R"(C:\Windows\System32\profapi.dll)";
+
+        mapped_module& map_ordinal_only_module(windows_emulator& emu)
+        {
+            auto* mod = emu.mod_manager.map_module(ordinal_only_module, emu.log);
+            if (!mod)
+            {
+                throw std::runtime_error("Failed to map profapi.dll");
+            }
+
+            return *mod;
+        }
+
+        IMAGE_EXPORT_DIRECTORY read_export_directory(const memory_manager& memory, const mapped_module& mod)
+        {
+            const auto dos_header = memory.read_memory<PEDosHeader_t>(mod.image_base);
+            const auto nt_headers = memory.read_memory<PENTHeaders_t<uint64_t>>(mod.image_base + dos_header.e_lfanew);
+            const auto& entry = nt_headers.OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT];
+            return memory.read_memory<IMAGE_EXPORT_DIRECTORY>(mod.image_base + entry.VirtualAddress);
+        }
+
+        size_t count_used_export_slots(const memory_manager& memory, const mapped_module& mod, const IMAGE_EXPORT_DIRECTORY& directory)
+        {
+            size_t used_slots = 0;
+            for (DWORD slot = 0; slot < directory.NumberOfFunctions; ++slot)
+            {
+                const auto rva = memory.read_memory<DWORD>(mod.image_base + directory.AddressOfFunctions + slot * sizeof(DWORD));
+                if (rva != 0)
+                {
+                    ++used_slots;
+                }
+            }
+
+            return used_slots;
+        }
+    }
+
+    TEST(ModuleExportsTest, OrdinalOnlyExportsAreCollected)
+    {
+        auto emu = create_empty_emulator();
+        const auto& mod = map_ordinal_only_module(emu);
+
+        const auto directory = read_export_directory(emu.memory, mod);
+        ASSERT_EQ(directory.NumberOfNames, 0u);
+        ASSERT_GT(directory.NumberOfFunctions, 0u);
+
+        ASSERT_EQ(mod.exports.size(), count_used_export_slots(emu.memory, mod, directory));
+
+        for (const auto& symbol : mod.exports)
+        {
+            EXPECT_EQ(symbol.name, "#" + std::to_string(symbol.ordinal));
+            EXPECT_GE(symbol.ordinal, directory.Base);
+            EXPECT_LT(symbol.ordinal, directory.Base + directory.NumberOfFunctions);
+            EXPECT_EQ(symbol.address, mod.image_base + symbol.rva);
+            EXPECT_EQ(mod.find_export(symbol.name), symbol.address);
+            EXPECT_TRUE(mod.address_names.contains(symbol.address));
+        }
+    }
+
+    TEST(ModuleExportsTest, MemoryMappedModuleCollectsSameExportsAsFileMappedModule)
+    {
+        auto emu = create_empty_emulator();
+        const auto& file_mapped = map_ordinal_only_module(emu);
+        ASSERT_FALSE(file_mapped.exports.empty());
+
+        const auto memory_mapped =
+            map_module_from_memory<uint64_t>(emu.memory, file_mapped.image_base, file_mapped.size_of_image, file_mapped.module_path);
+
+        ASSERT_EQ(memory_mapped.exports.size(), file_mapped.exports.size());
+
+        for (size_t i = 0; i < file_mapped.exports.size(); ++i)
+        {
+            const auto& expected = file_mapped.exports[i];
+            const auto& actual = memory_mapped.exports[i];
+            EXPECT_EQ(actual.name, expected.name);
+            EXPECT_EQ(actual.ordinal, expected.ordinal);
+            EXPECT_EQ(actual.rva, expected.rva);
+            EXPECT_EQ(actual.address, expected.address);
+        }
+
+        EXPECT_EQ(memory_mapped.address_names, file_mapped.address_names);
+    }
+} // namespace sogen::test

--- a/src/windows-emulator/module/module_mapping.cpp
+++ b/src/windows-emulator/module/module_mapping.cpp
@@ -56,23 +56,45 @@ namespace sogen
             const auto export_directory = buffer.as<IMAGE_EXPORT_DIRECTORY>(export_directory_entry.VirtualAddress).get();
 
             const auto names_count = export_directory.NumberOfNames;
-            // const auto function_count = export_directory.NumberOfFunctions;
+            const auto function_count = export_directory.NumberOfFunctions;
 
             const auto names = buffer.as<DWORD>(export_directory.AddressOfNames);
             const auto ordinals = buffer.as<WORD>(export_directory.AddressOfNameOrdinals);
             const auto functions = buffer.as<DWORD>(export_directory.AddressOfFunctions);
 
-            binary.exports.reserve(names_count);
+            binary.exports.reserve(function_count);
 
+            std::unordered_map<WORD, DWORD> name_index_by_ordinal{};
+            name_index_by_ordinal.reserve(names_count);
             for (DWORD i = 0; i < names_count; i++)
             {
-                const auto ordinal = ordinals.get(i);
+                name_index_by_ordinal[ordinals.get(i)] = i;
+            }
+
+            // AddressOfNames covers only part of AddressOfFunctions: exports without a name-table entry
+            // are still real exports and need a symbol.
+            for (DWORD ordinal = 0; ordinal < function_count; ordinal++)
+            {
+                const auto rva = functions.get(ordinal);
+                if (rva == 0)
+                {
+                    continue; // Unused ordinal slot.
+                }
 
                 exported_symbol symbol{};
                 symbol.ordinal = export_directory.Base + ordinal;
-                symbol.rva = functions.get(ordinal);
+                symbol.rva = rva;
                 symbol.address = binary.image_base + symbol.rva;
-                symbol.name = buffer.as_string(names.get(i));
+
+                const auto name_index = name_index_by_ordinal.find(static_cast<WORD>(ordinal));
+                if (name_index != name_index_by_ordinal.end())
+                {
+                    symbol.name = buffer.as_string(names.get(name_index->second));
+                }
+                else
+                {
+                    symbol.name = "#" + std::to_string(symbol.ordinal);
+                }
 
                 binary.exports.push_back(std::move(symbol));
             }
@@ -198,22 +220,43 @@ namespace sogen
                 read_mapped_object<IMAGE_EXPORT_DIRECTORY>(memory, binary.image_base + export_directory_entry.VirtualAddress);
 
             const auto names_count = export_directory.NumberOfNames;
-            binary.exports.reserve(names_count);
+            const auto function_count = export_directory.NumberOfFunctions;
+            binary.exports.reserve(function_count);
 
+            std::unordered_map<WORD, DWORD> name_index_by_ordinal{};
+            name_index_by_ordinal.reserve(names_count);
             for (DWORD i = 0; i < names_count; i++)
             {
                 const auto ordinal =
                     read_mapped_object<WORD>(memory, binary.image_base + export_directory.AddressOfNameOrdinals + i * sizeof(WORD));
+                name_index_by_ordinal[ordinal] = i;
+            }
+
+            for (DWORD ordinal = 0; ordinal < function_count; ordinal++)
+            {
                 const auto function_rva =
                     read_mapped_object<DWORD>(memory, binary.image_base + export_directory.AddressOfFunctions + ordinal * sizeof(DWORD));
-                const auto name_rva =
-                    read_mapped_object<DWORD>(memory, binary.image_base + export_directory.AddressOfNames + i * sizeof(DWORD));
+                if (function_rva == 0)
+                {
+                    continue; // Unused ordinal slot.
+                }
 
                 exported_symbol symbol{};
                 symbol.ordinal = export_directory.Base + ordinal;
                 symbol.rva = function_rva;
                 symbol.address = binary.image_base + symbol.rva;
-                symbol.name = read_mapped_string(memory, binary.image_base + name_rva);
+
+                const auto name_index = name_index_by_ordinal.find(static_cast<WORD>(ordinal));
+                if (name_index != name_index_by_ordinal.end())
+                {
+                    const auto name_rva = read_mapped_object<DWORD>(memory, binary.image_base + export_directory.AddressOfNames +
+                                                                                name_index->second * sizeof(DWORD));
+                    symbol.name = read_mapped_string(memory, binary.image_base + name_rva);
+                }
+                else
+                {
+                    symbol.name = "#" + std::to_string(symbol.ordinal);
+                }
 
                 binary.exports.push_back(std::move(symbol));
             }


### PR DESCRIPTION
## Problem

Both `collect_exports` overloads in `src/windows-emulator/module/module_mapping.cpp` (the file-buffer walker and the `map_module_from_memory` walker) iterate `AddressOfNames` for `NumberOfNames` entries and reach the function slot through `AddressOfNameOrdinals`. The PE export directory does not require every function slot to have a name-table entry, so:

- A module whose exports are ordinal-only (`NumberOfNames == 0`) produces an **empty** `exports` vector and an empty `address_names` map.
- A mixed module silently drops every export that has no name entry.

Because `mapped_module::address_names` is what `windows-analyzer/analysis.cpp` uses to emit `function_execution_event` / `foreign_code_transition_event`, calls into an ordinal-only DLL are never logged at all, and calls into an unnamed ordinal of a mixed DLL are attributed via `upper_bound` to the nearest *named* export with a wrong offset. `find_export` cannot resolve them either, and the export count reported by `minidump_loader.cpp` is wrong.

## Fix

Walk `AddressOfFunctions` for `NumberOfFunctions` slots, skip zero (unused) slots, and attach the name through a reverse ordinal -> name-index map built from `AddressOfNameOrdinals`. Exports with no name entry get the conventional `#<ordinal>` name so `find_export("#N")` and `address_names` resolve them. Both overloads get the same change so file-mapped and memory-mapped modules produce identical export lists.

## Reproduction

`C:\Windows\System32\profapi.dll` (x64, from the emulation root) has `NumberOfNames == 0` and 17 non-zero slots in `AddressOfFunctions`. The new test `src/windows-emulator-test/module_exports_test.cpp` maps it through `module_manager::map_module` and compares `mod.exports.size()` against an independent walk of the export directory read back from guest memory.

Against `origin/main`'s `module_mapping.cpp` (swapped in, rebuilt, run, then restored):

```
module_exports_test.cpp:55: Failure
Expected equality of these values:
  mod.exports.size()
    Which is: 0
  count_used_export_slots(emu.memory, mod, directory)
    Which is: 17
[  FAILED  ] ModuleExportsTest.OrdinalOnlyExportsAreCollected
[  FAILED  ] ModuleExportsTest.MemoryMappedModuleCollectsSameExportsAsFileMappedModule
```

With this branch:

```
[       OK ] ModuleExportsTest.OrdinalOnlyExportsAreCollected (7 ms)
[       OK ] ModuleExportsTest.MemoryMappedModuleCollectsSameExportsAsFileMappedModule (3 ms)
```

## How widespread this is

Independent survey (a standalone PE parser, not sogen) of the DLLs in the emulation root that carry an export directory:

- `system32` (x64): 158 DLLs. 2 are ordinal-only and previously mapped with **zero** exports (`profapi.dll` 17, `ntasn1.dll` 60). 37 mixed DLLs previously dropped **2,268** unnamed exports in total, e.g. `dxcore.dll` names=1 used=224 (+223), `combase.dll` 461/598 (+137), `comctl32.dll` 119/181 (+62), `dwmapi.dll` 44/101 (+57), `dcomp.dll` 12/32 (+20), `d3d9.dll` 17/23 (+6).
- `syswow64` (x86): 2,339 DLLs. 38 ordinal-only (including every MFC runtime, `mfc140u.dll` alone has 14,482 exports, all unnamed; `edgeIso.dll` 232, `shunimpl.dll` 453). 134 mixed DLLs previously dropped **27,725** unnamed exports.

## Tests

- New `ModuleExportsTest.OrdinalOnlyExportsAreCollected`: asserts `NumberOfNames == 0`, `exports.size()` equals the number of non-zero function slots, every symbol is named `#<ordinal>`, ordinal is within `[Base, Base + NumberOfFunctions)`, `address == image_base + rva`, `find_export(name)` resolves, and `address_names` contains the address.
- New `ModuleExportsTest.MemoryMappedModuleCollectsSameExportsAsFileMappedModule`: `map_module_from_memory<uint64_t>` over the already-mapped image yields the same `exports` (name/ordinal/rva/address, in order) and an equal `address_names` map as the file-mapped module.
- Full `windows-emulator-test` suite via `gtest_parallel.py` with `EMULATOR_ROOT=root`: 52/52 pass, exit code 0 (macOS arm64, `--preset=release`).

## Notes

- No behavioural change for exports that already had a name: named symbols still get their string name; only previously-missing slots are added. `exports.reserve` now uses `NumberOfFunctions` instead of `NumberOfNames`.
- The `#<ordinal>` naming matches the existing `u"#"` convention already used for ordinal-based class/resource lookups elsewhere in the emulator (`process_context.cpp`, `syscalls/user.cpp`).