### PR TITLE
fix(handles): make handle values 4-aligned like real Windows

### DIFF
--- a/src/samples/test-sample/test.cpp
+++ b/src/samples/test-sample/test.cpp
@@ -1858,6 +1858,58 @@ namespace
         return true;
     }
 
+    bool test_handle_tag_bits()
+    {
+        using nt_close_t = LONG(NTAPI*)(HANDLE);
+        const auto nt_close =
+            reinterpret_cast<nt_close_t>(reinterpret_cast<void*>(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtClose")));
+        if (!nt_close)
+        {
+            puts("ntdll!NtClose not found");
+            return false;
+        }
+
+        const auto open_file = [](const char* path) {
+            return CreateFileA(path, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+        };
+
+        const auto is_open = [](const HANDLE file) {
+            char byte{};
+            DWORD read{};
+            return ReadFile(file, &byte, sizeof(byte), &read, nullptr) != FALSE;
+        };
+
+        bool valid = true;
+
+        for (uint32_t tag = 0; tag < 4; ++tag)
+        {
+            const HANDLE before = open_file(R"(C:\Windows\System32\ntdll.dll)");
+            const HANDLE target = open_file(R"(C:\Windows\System32\kernel32.dll)");
+            const HANDLE after = open_file(R"(C:\Windows\System32\kernelbase.dll)");
+
+            if (before == INVALID_HANDLE_VALUE || target == INVALID_HANDLE_VALUE || after == INVALID_HANDLE_VALUE)
+            {
+                puts("Failed to open the probe files");
+                return false;
+            }
+
+            auto* const tagged = reinterpret_cast<HANDLE>((reinterpret_cast<ULONG_PTR>(target) & ~ULONG_PTR{3}) | tag);
+            const auto status = nt_close(tagged);
+
+            if (status != 0 || !is_open(before) || is_open(target) || !is_open(after))
+            {
+                printf("NtClose(%p) with tag %u did not close exactly %p (status 0x%08lX)\n", tagged, tag, target, status);
+                valid = false;
+                CloseHandle(target);
+            }
+
+            CloseHandle(before);
+            CloseHandle(after);
+        }
+
+        return valid;
+    }
+
     bool test_gdi()
     {
         const wchar_t* cursor_path = L"C:\\Windows\\Cursors\\aero_arrow.cur";
@@ -1941,6 +1993,7 @@ int main(const int argc, const char* argv[])
     RUN_TEST(test_paint_message_queue, "Message Queue (Paint)")
     RUN_TEST(test_settimer, "User Timer")
     RUN_TEST(test_private_namespace, "Private Namespace")
+    RUN_TEST(test_handle_tag_bits, "Handle Tag Bits")
     RUN_TEST(test_actctx, "Activation Context")
     RUN_TEST(test_mmio, "MMIO")
     RUN_TEST(test_gdi, "GDI")

--- a/src/windows-emulator/handles.hpp
+++ b/src/windows-emulator/handles.hpp
@@ -46,7 +46,10 @@ namespace sogen
 
     struct handle_value
     {
-        uint64_t id : 23;
+        // NT handles are multiples of 4: the kernel ignores the low 2 bits and user mode tags them
+        // (rpcrt4 keeps private flags there), so an id starting at bit 0 would alias a neighbouring handle.
+        uint64_t reserved : 2;
+        uint64_t id : 21;
         uint64_t type : 7;
         uint64_t is_system : 1;
         uint64_t is_pseudo : 1;
@@ -181,7 +184,7 @@ namespace sogen
         virtual std::optional<handle> duplicate(handle h) = 0;
     };
 
-    template <handle_types::type Type, typename T, uint32_t IndexShift = 0>
+    template <handle_types::type Type, typename T>
         requires(utils::Serializable<T> && std::is_base_of_v<ref_counted_object, T>)
     class handle_store : public generic_handle_store
     {
@@ -219,7 +222,7 @@ namespace sogen
             h.bits = 0;
             h.value.is_pseudo = false;
             h.value.type = Type;
-            h.value.id = index << IndexShift;
+            h.value.id = index;
 
             return h;
         }
@@ -408,7 +411,7 @@ namespace sogen
                 return this->store_.end();
             }
 
-            return this->store_.find(static_cast<uint32_t>(h.id) >> IndexShift);
+            return this->store_.find(static_cast<uint32_t>(h.id));
         }
 
         uint32_t find_free_index()

--- a/src/windows-emulator/process_context.hpp
+++ b/src/windows-emulator/process_context.hpp
@@ -531,7 +531,7 @@ namespace sogen
         handle_store<handle_types::event, event> events{};
         handle_store<handle_types::file, file> files{};
         utils::insensitive_u16string_map<file_lock_ranges> file_locks{};
-        handle_store<handle_types::section, section, 2> sections{};
+        handle_store<handle_types::section, section> sections{};
         handle_store<handle_types::device, io_device_container> devices{};
         handle console_handle{};
         handle_store<handle_types::semaphore, semaphore> semaphores{};
@@ -547,7 +547,7 @@ namespace sogen
         user_handle_store<handle_types::type::menu, menu> menus{user_handles};
         handle_store<handle_types::timer, timer> timers{};
         user_handle_store<handle_types::accelerator_table, accelerator_table> accelerator_tables{user_handles};
-        handle_store<handle_types::registry, registry_key, 2> registry_keys{};
+        handle_store<handle_types::registry, registry_key> registry_keys{};
         std::map<uint32_t, handle> thread_handles_by_id{};
         std::map<uint16_t, atom_entry> atoms{};
         utils::insensitive_u16string_map<class_entry> classes{};

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -339,12 +339,12 @@ namespace sogen
             }
 
             const auto index = static_cast<uint32_t>(h.value.id);
-            if (index == 0 || index >= user_handle_table::MAX_HANDLES)
+            if (index == 0 || index >= user_handle_table::MAX_HANDLE_INDICES)
             {
                 return;
             }
 
-            c.proc.user_handles.get_handle_table().access([&](USER_HANDLEENTRY& entry) { entry.pOwner = owner; }, index);
+            c.proc.user_handles.set_owner(index, owner);
         }
 
         void invalidate_window(const syscall_context& c, window& win, const std::optional<RECT>& update_rect, bool erase);
@@ -4358,14 +4358,14 @@ namespace sogen
                 return desktop->mapped_object;
             }
 
-            const auto index = handle.value.id;
+            const auto index = static_cast<uint32_t>(handle.value.id);
 
-            if (index == 0 || index >= user_handle_table::MAX_HANDLES)
+            if (index == 0 || index >= user_handle_table::MAX_HANDLE_INDICES)
             {
                 return 0;
             }
 
-            const auto handle_entry = c.proc.user_handles.get_handle_table().read(static_cast<size_t>(index));
+            const auto handle_entry = c.proc.user_handles.get_handle_table().read(user_handle_table::handle_index_to_ahe_slot(index));
             return handle_entry.pHead;
         }
 

--- a/src/windows-emulator/user_handle_table.hpp
+++ b/src/windows-emulator/user_handle_table.hpp
@@ -11,6 +11,7 @@ namespace sogen
     {
       public:
         static constexpr uint32_t MAX_HANDLES = 0xFFFF;
+        static constexpr uint32_t MAX_HANDLE_INDICES = MAX_HANDLES >> 2;
         static constexpr size_t CLIENT_MESSAGE_BITS_SIZE = 0xC8;
         static constexpr size_t WND_MESSAGE_BITS_COUNT = FNID_ARRAY_SIZE + 2;
         static constexpr size_t DEF_WINDOW_MSGS_INDEX = FNID_ARRAY_SIZE;
@@ -25,7 +26,7 @@ namespace sogen
         {
             this->is_wow64_process_ = is_wow64_process;
 
-            used_indices_.resize(MAX_HANDLES, false);
+            used_indices_.resize(MAX_HANDLE_INDICES, false);
             next_free_index_ = 1;
 
             const auto server_info_size = static_cast<size_t>(page_align_up(sizeof(USER_SERVERINFO)));
@@ -92,6 +93,13 @@ namespace sogen
             return {*memory_, handle_table_addr_};
         }
 
+        // user32 indexes the shared aheList by the HANDLE's low 16 bits, not by our internal id.
+        // Handles are 4-aligned, so the id sits at bit 2 and the slot the guest computes is id << 2.
+        static constexpr uint32_t handle_index_to_ahe_slot(const uint32_t index)
+        {
+            return index << 2;
+        }
+
         emulator_object<USER_DISPINFO> get_display_info() const
         {
             return {*memory_, display_info_addr_};
@@ -128,7 +136,7 @@ namespace sogen
                     entry.bType = get_native_type(type);
                     entry.wUniq = static_cast<uint16_t>(type << 7);
                 },
-                index);
+                handle_index_to_ahe_slot(index));
 
             used_indices_.at(index) = true;
 
@@ -141,7 +149,7 @@ namespace sogen
         void set_owner(const uint32_t index, const uint64_t owner)
         {
             const emulator_object<USER_HANDLEENTRY> handle_table_obj(*memory_, handle_table_addr_);
-            handle_table_obj.access([&](USER_HANDLEENTRY& entry) { entry.pOwner = owner; }, index);
+            handle_table_obj.access([&](USER_HANDLEENTRY& entry) { entry.pOwner = owner; }, handle_index_to_ahe_slot(index));
         }
 
         void free_index(uint32_t index)
@@ -159,7 +167,7 @@ namespace sogen
                     memory_->release_memory(entry.pHead, 0);
                     entry = {};
                 },
-                index);
+                handle_index_to_ahe_slot(index));
         }
 
         void serialize(utils::buffer_serializer& buffer) const
@@ -284,10 +292,10 @@ namespace sogen
 
         uint32_t find_free_index()
         {
-            for (uint32_t attempts = 0; attempts < MAX_HANDLES - 1; ++attempts)
+            for (uint32_t attempts = 0; attempts < MAX_HANDLE_INDICES - 1; ++attempts)
             {
                 const auto index = next_free_index_;
-                next_free_index_ = next_free_index_ + 1 < MAX_HANDLES ? next_free_index_ + 1 : 1;
+                next_free_index_ = next_free_index_ + 1 < MAX_HANDLE_INDICES ? next_free_index_ + 1 : 1;
 
                 if (!used_indices_.at(index))
                 {


### PR DESCRIPTION
## Problem

Sogen hands out kernel handle values with the object id starting at bit 0, so consecutive handles are `0x800002, 0x800003, 0x800004, ...`. Real NT handles are always multiples of 4: the kernel ignores the low two bits, and user-mode code is allowed to (and does) store private tag bits there.

The consequence is not cosmetic. When guest code tags a handle and later passes it to `NtClose`, the emulator resolves the *tagged* value as a different id and closes whichever neighbouring handle happens to live there. Concretely, on current `main` (x64 guest, unicorn backend), with `before=0x800001`, `target=0x800002`, `after=0x800003` all open:

```
NtClose(0x800003)   // target | 3
  -> STATUS_SUCCESS, `target` still open, `after` closed
NtClose(0x800001)   // target | 1
  -> STATUS_SUCCESS, none of the three probe handles closed (some other live handle was)
NtClose(0x800000)   // target & ~3
  -> STATUS_INVALID_HANDLE (0xC0000008)
```

The same happens for a 32-bit guest (`NtClose(0x800005)` with tag 1 closes `after` instead of `target`; tags 2 and 3 fail with `STATUS_INVALID_HANDLE`).

## Fix

- `handles.hpp`: `handle_value` reserves the low 2 bits (`reserved : 2`, `id : 21` instead of `id : 23`). Every `handle_store` therefore hands out 4-aligned values and lookups ignore the tag bits. The per-store `IndexShift` template parameter becomes redundant and is removed.
- `process_context.hpp`: drops the now-nonexistent `IndexShift = 2` argument from `sections` and `registry_keys`. Those two stores previously got 4-alignment by shifting their own index; every store now gets it from the layout.
- `user_handle_table.hpp` / `syscalls/user.cpp`: user32 indexes the shared `aheList` by the HANDLE's low 16 bits, not by our internal id. With the id now at bit 2, the slot the guest computes is `id << 2`, so `allocate`, `set_owner`, `free_index` and `NtUserMapDesktopObject` go through `handle_index_to_ahe_slot()`. The allocator is bounded by `MAX_HANDLE_INDICES = MAX_HANDLES >> 2` (the ids that still have a slot inside the 0xFFFF-entry table); `used_indices_` and the bound checks in `user.cpp` use the same constant.
- `test-sample/test.cpp`: new `Handle Tag Bits` case. It opens three files, calls `ntdll!NtClose` on the middle one with each low-2-bit pattern (0..3), and asserts `STATUS_SUCCESS`, the target closed, and both neighbours still readable.

## Verification

Host: macOS arm64 (Apple Clang), `--preset=release`. Guest binaries cross-built with mingw-w64 14.0.0 from this branch's `test.cpp` (x64) plus a standalone copy of the new test body for x86 (`test.cpp` itself only builds with MSVC on 32-bit).

`test-sample.exe` (x64), full run, this branch vs. a build with `origin/main`'s `handles.hpp`, `process_context.hpp`, `user.cpp`, `user_handle_table.hpp` swapped in (same test binary):

| backend | main-equivalent | this branch |
|---|---|---|
| unicorn | `Handle Tag Bits`: **Fail**, exit 1 (28 other tests pass) | 30/30 pass, exit 0 |
| FEX | `Handle Tag Bits`: **Fail**, exit 1 | 30/30 pass, exit 0 |
| icicle | `Handle Tag Bits`: **Fail**, exit 1 (27 other pass; Interrupts self-skips) | 29/29 pass, exit 0 |

Standalone probe (same logic as the new test), unicorn:

| guest | main-equivalent | this branch |
|---|---|---|
| x64 | FAIL (handles `0x800002/03/04`; tag 3 closes `after`, tag 1 closes an unrelated handle, tag 0 -> `0xC0000008`) | PASS (handles `0x800008/0c/10`; all 4 tags close exactly `target`) |
| x86 (WoW64) | FAIL (handles `0x800003/04/05`; tag 1 closes `after`, tags 2-3 -> `0xC0000008`) | PASS (handles `0x80000c/10/14`; all 4 tags close exactly `target`) |

`windows-emulator-test` on this branch: 50/50 passed (29s).