### PR TITLE
fix(vulkan): run against a portability driver (MoltenVK) on macOS hosts

### DIFF
--- a/docs/gpu-paravirtualization.md
+++ b/docs/gpu-paravirtualization.md
@@ -304,6 +304,28 @@ plus the surrounding calls needed to actually use them:
     (the `vkCreateDevice`/features paths are on their path too). Full DXVK rendering (swapchain +
     DXVK's large runtime device-function set) is still ahead; DXVK remains otherwise deprioritized.
 
+- **macOS / MoltenVK host bring-up (portability driver).** The host had only ever been run against
+  native ICDs (Linux) or SwiftShader; on an Apple-Silicon Mac the host `vulkan-1.dll`/`libvulkan.dylib`
+  resolves to the **MoltenVK** portability driver (Vulkan-over-Metal), which the Khronos loader refuses
+  to use unless the caller opts in. Two portability requirements were added to `vulkan_host`:
+  - `create_instance` now enables `VK_KHR_portability_enumeration` and sets
+    `VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` when the loader advertises that instance
+    extension; without it `vkCreateInstance` returns `VK_ERROR_INCOMPATIBLE_DRIVER` and no physical
+    device is ever enumerated. The extension is implemented by the loader, not the driver, so it can
+    appear on Linux loaders too — but enabling it is harmless everywhere: it only un-hides
+    non-conformant devices from enumeration, it never misreports a device's capabilities.
+  - `create_device` now appends `VK_KHR_portability_subset` when the physical device advertises it
+    (Vulkan requires enabling it whenever the device does); the guest never asks for it. Whether a
+    device advertises it is checked once and cached per physical device.
+  Verified end-to-end on macOS against a real GPU: the guest `vulkan-shim-test` enumerates the host
+  **Apple M5 Pro** through MoltenVK and its `fill+readback` (`0xDEADBEEF`) and `clear+readback`
+  (`0xFF0000FF`) checks both pass — the GPU produces the pixels and the guest reads them back exactly.
+  This ran under the Unicorn CPU backend (the bridge is CPU-backend-agnostic) with the direct-alias
+  `vkMapMemory` path actually taken (host allocations are page-rounded and MoltenVK returns
+  page-aligned mapped pointers, so the whole `VkDeviceMemory` aliases straight into guest VA). Run it
+  with the homebrew loader + MoltenVK ICD on the environment:
+  `DYLD_LIBRARY_PATH=/opt/homebrew/lib VK_ICD_FILENAMES=/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json`.
+
 ## Remoted Vulkan entry points so far
 
 Instance/device: `vkCreateInstance`, `vkDestroyInstance`, `vkEnumeratePhysicalDevices`,

--- a/src/windows-emulator/devices/vulkan_host.cpp
+++ b/src/windows-emulator/devices/vulkan_host.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstring>
+#include <optional>
 #include <string_view>
 #include <unordered_map>
 #include <vector>
@@ -225,7 +226,45 @@ namespace sogen
         {
             VkPhysicalDevice handle{};
             uint64_t instance_id{};
+            std::optional<bool> portability{};
         };
+
+        static bool has_device_extension(const instance_data& instance, VkPhysicalDevice device, const std::string_view name)
+        {
+            if (!instance.enumerate_device_extension_properties)
+            {
+                return false;
+            }
+
+            uint32_t count = 0;
+            if (instance.enumerate_device_extension_properties(device, nullptr, &count, nullptr) != VK_SUCCESS)
+            {
+                return false;
+            }
+
+            std::vector<VkExtensionProperties> extensions(count);
+            if (count > 0 && instance.enumerate_device_extension_properties(device, nullptr, &count, extensions.data()) != VK_SUCCESS)
+            {
+                return false;
+            }
+
+            return std::ranges::any_of(extensions, [&](const VkExtensionProperties& extension) {
+                return std::string_view{static_cast<const char*>(extension.extensionName)} == name;
+            });
+        }
+
+        // VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME lives in vulkan_beta.h behind VK_ENABLE_BETA_EXTENSIONS.
+        static constexpr std::string_view portability_subset_extension_name = "VK_KHR_portability_subset";
+
+        static bool is_portability_device(const instance_data& instance, physical_device_data& device)
+        {
+            if (!device.portability)
+            {
+                device.portability = has_device_extension(instance, device.handle, portability_subset_extension_name);
+            }
+
+            return *device.portability;
+        }
 
         struct device_data
         {
@@ -1084,6 +1123,39 @@ namespace sogen
         create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
         create_info.pApplicationInfo = &app_info;
 
+        // With a portability driver installed (MoltenVK on macOS) the loader fails vkCreateInstance with
+        // VK_ERROR_INCOMPATIBLE_DRIVER unless the caller enables VK_KHR_portability_enumeration and sets
+        // VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR.
+        std::vector<const char*> instance_extensions;
+        if (const auto enumerate_instance_extensions = reinterpret_cast<PFN_vkEnumerateInstanceExtensionProperties>(
+                this->impl_->get_instance_proc_addr(nullptr, "vkEnumerateInstanceExtensionProperties")))
+        {
+            uint32_t ext_count = 0;
+            std::vector<VkExtensionProperties> available;
+            if (enumerate_instance_extensions(nullptr, &ext_count, nullptr) == VK_SUCCESS && ext_count > 0)
+            {
+                available.resize(ext_count);
+                if (enumerate_instance_extensions(nullptr, &ext_count, available.data()) != VK_SUCCESS)
+                {
+                    available.clear();
+                }
+            }
+
+            const bool has_portability_enumeration = std::ranges::any_of(available, [](const VkExtensionProperties& ext) {
+                return std::string_view{static_cast<const char*>(ext.extensionName)} == VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME;
+            });
+            if (has_portability_enumeration)
+            {
+                instance_extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+                create_info.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+            }
+        }
+        if (!instance_extensions.empty())
+        {
+            create_info.enabledExtensionCount = static_cast<uint32_t>(instance_extensions.size());
+            create_info.ppEnabledExtensionNames = instance_extensions.data();
+        }
+
         VkInstance instance{};
         const VkResult result = this->impl_->create_instance(&create_info, nullptr, &instance);
         if (result != VK_SUCCESS)
@@ -1888,6 +1960,15 @@ namespace sogen
                 }
                 cursor = terminator + 1;
             }
+        }
+
+        // Vulkan requires VK_KHR_portability_subset to be enabled whenever the device advertises it, and
+        // the guest never asks for it.
+        const bool requests_portability_subset = std::ranges::any_of(
+            extensions, [](const char* name) { return std::string_view{name} == impl::portability_subset_extension_name; });
+        if (!requests_portability_subset && impl::is_portability_device(instance->second, pd->second))
+        {
+            extensions.push_back(impl::portability_subset_extension_name.data());
         }
 
         // Rebuild the pNext feature chain to enable (same record format as get_physical_device_features2);


### PR DESCRIPTION
## Summary

`vulkan_host` could not create a Vulkan instance on a macOS host. The host library there is MoltenVK, a *portability* driver that the Khronos loader deliberately hides from enumeration unless the application opts in, so `vkCreateInstance` failed with `VK_ERROR_INCOMPATIBLE_DRIVER` (-9) and the guest never saw a physical device.

Two changes in `src/windows-emulator/devices/vulkan_host.cpp` (+81 lines), plus a doc paragraph in `docs/gpu-paravirtualization.md`:

- `create_instance`: if the loader advertises `VK_KHR_portability_enumeration`, enable it and set `VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR`. The extension is checked via `vkEnumerateInstanceExtensionProperties`, so on loaders that don't offer it (older Linux loaders, SwiftShader setups) nothing changes. On loaders that do offer it, enabling it only un-hides non-conformant devices; it never alters a device's reported capabilities.
- `create_device`: if the physical device advertises `VK_KHR_portability_subset`, append it to the enabled device extensions unless the guest already asked for it. The spec requires this extension to be enabled whenever the device exposes it, and a Windows guest never requests it. The per-device check is done once and cached in `physical_device_data` (`std::optional<bool> portability`). `VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME` lives in `vulkan_beta.h` behind `VK_ENABLE_BETA_EXTENSIONS`, so the name is spelled out as a `string_view` constant instead.

No wire-protocol change; the guest shim is untouched.

## Reproduction / verification

Host: Apple M5 Pro, macOS 26.5 (Darwin 25.6.0), Homebrew `vulkan-loader` 1.4.350.1 + `molten-vk` 1.4.1. Guest binaries: `vulkan-shim-test` and the `vulkan-shim` DLL from this tree, cross-compiled with mingw-w64 (i686 and x86_64), staged in the emulation root.

```
DYLD_LIBRARY_PATH=/opt/homebrew/lib \
VK_ICD_FILENAMES=/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json \
./analyzer -e root --backend unicorn -s 'C:\vulkan-shim-test-x86.exe' 'C:\vulkan-shim.dll'
```

Before (origin/main `e8824779`, same host, same guest binaries):

```
[shim-test] vkCreateInstance -> -9, instance=00000000
```

After (this commit):

```
[shim-test] vkCreateInstance -> 0, instance=00000001
[shim-test] vkEnumeratePhysicalDevices -> 0, count=1
[shim-test] device[0]: 'Apple M5 Pro' type=1 api=1.3.334
[shim-test] queue families=4, graphics family=0, timestamp family=0
[shim-test] vkCreateDevice -> 0, device=00000003
[shim-test] empty submit -> 0, fence wait -> 0 -> PASS
[shim-test] fill+readback (0xDEADBEEF x64) -> PASS
[shim-test] clear+readback (16x16 -> 0xFF0000FF) wait=0 -> PASS
[shim-test] pipeline cache round trip -> PASS
[shim-test] ok
```

Same result for the x86 guest under `--backend unicorn` (WoW64) and for the x64 guest under both `--backend unicorn` and `--backend fex`: instance + device creation succeed, the GPU fills a buffer and clears a 16x16 image, and the guest reads the expected bytes back through the direct `vkMapMemory` alias.

`windows-emulator-test`: 50/50 passing on this commit (`EMULATOR_ROOT` set). `clang-format --dry-run --Werror` clean on the changed source file.