### PR TITLE
fix(user): write the WoW64 userconnect reply in SHAREDINFO layout

### DIFF
--- a/docs/windows-ui-emulation.md
+++ b/docs/windows-ui-emulation.md
@@ -662,26 +662,25 @@ Dumping the live globals (guest `user32_base = fault_ip - 0x29378`; read `+0xccb
 reaches user32. With the limit at 0, only `DefWindowProc(WM_NULL=0)` reaches the read and `[0+0]`
 faults — and the load loop pumps `WM_NULL`, so it hits reliably.
 
-### Fix concept is validated; the clean location is NOT yet found
+### Resolved: the globals are `SHAREDINFO.DefWindowMsgs` / `DefWindowSpecMsgs`
+
+The four globals are `_gSharedInfo.DefWindowMsgs` (0x218) and `.DefWindowSpecMsgs` (0x228). The
+32-bit `user32!UserClientDllInitialize` raw-copies the 0x238-byte user-connect reply into
+`_gSharedInfo` and reads it with the same 8-byte-slotted `SHAREDINFO` layout as the 64-bit client
+(hence the 8-byte spacing of `…bc0/…bc8/…bd0/…bd8`). The WoW64 connect used to be written in a
+separate `WIN32K_USERCONNECT32` layout whose `wndmsg_count`/`wndmsg_table` fields landed in the
+wrong slots, so the message tables never reached user32. Both WoW64 writers (the CSRSS ApiPort
+reply in `ports/api_port.cpp` and `NtUserProcessConnect`) now go through the same
+`populate_user_shared_info` as the 64-bit path, and `WIN32K_USERCONNECT32` is gone.
+
+Reproduction: a 32-bit guest that creates a window and calls `DefWindowProcA(hwnd, WM_NULL, 0, 0)`
+faults inside user32 on a read of address 0 (the null bit-array pointer) before the fix and
+returns 0 after it.
 
 Seeding the four globals at runtime (targeted **execution hook** on `user32+0x29310`; write
-`DAT_100ccbc0=0x63F`, `DAT_100ccbc8`=client message-bits table addr, same for `…bd0/…bd8`)
-**eliminates the crash** — the dialog renders. So the diagnosis and the "what user32 needs" are
-correct.
-
-But the proper source is still unknown:
-- The WoW64 connect (`build_wow64_userconnect` → `WIN32K_USERCONNECT32` in `win32k_userconnect.cpp` /
-  `platform/user.hpp`) sets `wndmsg_count` (0x108) and an inline `wndmsg_table` (0x40), and has
-  unused pointer fields `wndmsg_bits` (0x110) / `ime_msg_bits` (0x120). Setting those pointers did
-  **not** move `DAT_100ccbc8` — and `DAT_100ccbc0` is 0 even though `wndmsg_count` is set — so user32
-  copies these four globals from a **different** connect/SHAREDINFO field than the struct assumes.
-- Ghidra finds **no write xref and no byte-immediate reference** to `0x100ccbc0`/`0x100ccbc8` in
-  user32 (its client init sets them via a copy/path the analyzer didn't resolve), so the source
-  offset can't be pinned statically. NEXT: instrument the emulator to watch the user32 client-init
-  write these globals (a GDB hardware watchpoint won't fire under WHP; and `hook_memory_read/write`
-  are **registered but not enforced** under WHP — only `hook_memory_execution` is, via int3/page
-  remap). The practical path is an execution-hook trace over user32 init, or a page-protect +
-  `memory_violation` hook on the globals' page.
+`DAT_100ccbc0=0x63F`, `DAT_100ccbc8`=client message-bits table addr, same for `…bd0/…bd8`) had
+already **eliminated the crash** — the dialog renders — which is what validated the diagnosis
+before the source field was found.
 
 ### Deeper wall: `NtUserMessageCall` server callback (`call to 0x2`)
 
@@ -693,9 +692,10 @@ tables — see "Ntdll/User32 Callback Findings" above). With the bit table **zer
 forwards: no crash, but the dialog's **buttons never get created** (controls need that server
 handling), so the dialog is non-operable.
 
-So a working dialog needs BOTH: (1) the message-table globals seeded from the right connect field,
-and (2) the `NtUserMessageCall` server-callback path through the WoW64 transition to resolve a valid
-client callback instead of `0x2`. (2) is the real blocker and is its own win32k-callback effort.
+So a working dialog needs BOTH: (1) the message-table globals seeded from the right connect field
+(done, see above), and (2) the `NtUserMessageCall` server-callback path through the WoW64 transition
+to resolve a valid client callback instead of `0x2`. (2) is the real blocker and is its own
+win32k-callback effort.
 
 ### Useful breadcrumbs
 
@@ -703,8 +703,9 @@ client callback instead of `0x2`. (2) is the real blocker and is its own win32k-
 - Globals: `user32+0xccbc0` (limit), `+0xccbc8` (bit-array ptr), `+0xccbd0`/`+0xccbd8` (2nd table).
 - Game wndproc: `iw4x.exe` `FUN_004731f0` (0x4731f0).
 - `NtUserMessageCall` crash: `ntdll+0xd6f1c`, `call to 0x2`, stack via `wow64cpu.dll` + `user32+0x3b880`.
-- `client_message_bits` table (44 client-callback message bits) lives in `user_handle_table.hpp`
-  (`get_client_message_bits()`); native `populate_user_shared_info` points `controlMessageBits`/
-  `staticMessageBits` at it — the WoW64 path has no working equivalent.
+- The per-message bit tables live in `user_handle_table.hpp` (`WND_MESSAGE_BITS`, read via
+  `get_awm_control_message`/`get_def_window_messages`/`get_def_window_spec_messages`);
+  `populate_user_shared_info` points `awmControl[]`/`DefWindowMsgs`/`DefWindowSpecMsgs` at them for
+  both the native and the WoW64 connect.
 - WHP debugging note: data watchpoints (GDB stub and `hook_memory_read/write`) do **not** fire under
   WHP; only `hook_memory_execution(address, …)` is enforced.

--- a/src/emulator-platform/platform/user.hpp
+++ b/src/emulator-platform/platform/user.hpp
@@ -128,41 +128,7 @@ namespace sogen
     static_assert(offsetof(USER_SHAREDINFO, awmControl) == 0x98);
     static_assert(offsetof(USER_SHAREDINFO, DefWindowMsgs) == 0x218);
     static_assert(offsetof(USER_SHAREDINFO, DefWindowSpecMsgs) == 0x228);
-
-    // user32 reads fields after copying 0x238 payload to _gSharedInfo
-    struct WIN32K_USERCONNECT32
-    {
-        uint32_t psi;
-        uint32_t reserved0;
-        uint32_t ahe_list;
-        uint32_t reserved1;
-        uint32_t he_entry_size;
-        uint32_t reserved2;
-        uint32_t disp_info_low;
-        uint32_t reserved3;
-        uint8_t reserved4[0x10];
-        uint32_t monitor_info_low;
-        uint32_t reserved5;
-        uint32_t shared_delta_low;
-        uint32_t shared_delta_high;
-        uint8_t wndmsg_table[0xC8];
-        uint32_t wndmsg_count;
-        uint32_t reserved6;
-        uint32_t wndmsg_bits;
-        uint32_t reserved7;
-        uint32_t ime_msg_count;
-        uint32_t reserved8;
-        uint32_t ime_msg_bits;
-        uint8_t reserved9[0x114];
-    };
-
-    static_assert(offsetof(WIN32K_USERCONNECT32, ahe_list) == 0x8);
-    static_assert(offsetof(WIN32K_USERCONNECT32, he_entry_size) == 0x10);
-    static_assert(offsetof(WIN32K_USERCONNECT32, disp_info_low) == 0x18);
-    static_assert(offsetof(WIN32K_USERCONNECT32, monitor_info_low) == 0x30);
-    static_assert(offsetof(WIN32K_USERCONNECT32, wndmsg_count) == 0x108);
-    static_assert(offsetof(WIN32K_USERCONNECT32, ime_msg_count) == 0x118);
-    static_assert(sizeof(WIN32K_USERCONNECT32) == 0x238);
+    static_assert(sizeof(USER_SHAREDINFO) == 0x238);
 
     // WoW64 (32-bit) raw-input structures, as the guest's user32/win32u marshal them.
     struct RAWINPUTDEVICE32

--- a/src/windows-emulator/ports/api_port.cpp
+++ b/src/windows-emulator/ports/api_port.cpp
@@ -69,8 +69,8 @@ namespace sogen
                 return false;
             }
 
-            if (payload.user_connect_length != sizeof(WIN32K_USERCONNECT32) &&
-                payload.user_connect_length != (sizeof(WIN32K_USERCONNECT32) + win32k_userconnect::k_wow64_userconnect_header_size))
+            if (payload.user_connect_length != sizeof(USER_SHAREDINFO) &&
+                payload.user_connect_length != (sizeof(USER_SHAREDINFO) + win32k_userconnect::k_wow64_userconnect_header_size))
             {
                 return false;
             }
@@ -94,14 +94,9 @@ namespace sogen
                 return destination_status;
             }
 
-            WIN32K_USERCONNECT32 connect{};
-            const auto connect_status = win32k_userconnect::build_wow64_userconnect(win_emu.process, connect);
-            if (connect_status != STATUS_SUCCESS)
-            {
-                return connect_status;
-            }
-
-            if (!win32k_userconnect::try_write_wow64_userconnect(win_emu.memory, destination, connect))
+            // user32's UserClientDllInitialize raw-copies this reply verbatim into _gSharedInfo, and
+            // the WoW64 client slots SHAREDINFO the same way the 64-bit one does.
+            if (!win32k_userconnect::try_write_user_shared_info(win_emu.memory, destination, win_emu.process))
             {
                 return STATUS_INVALID_PARAMETER;
             }

--- a/src/windows-emulator/syscalls/user.cpp
+++ b/src/windows-emulator/syscalls/user.cpp
@@ -1262,8 +1262,8 @@ namespace sogen
                 return STATUS_SUCCESS;
             }
 
-            user_shared_info_ptr = c.proc.base_allocator.reserve(sizeof(WIN32K_USERCONNECT32), alignof(WIN32K_USERCONNECT32));
-            std::array<std::byte, sizeof(WIN32K_USERCONNECT32)> zeros{};
+            user_shared_info_ptr = c.proc.base_allocator.reserve(sizeof(USER_SHAREDINFO), alignof(USER_SHAREDINFO));
+            std::array<std::byte, sizeof(USER_SHAREDINFO)> zeros{};
             c.emu.write_memory(user_shared_info_ptr, zeros.data(), zeros.size());
 
             uint32_t user_shared_info_ptr32{};
@@ -1697,14 +1697,7 @@ namespace sogen
                 return destination_status;
             }
 
-            WIN32K_USERCONNECT32 connect_info{};
-            const auto connect_status = win32k_userconnect::build_wow64_userconnect(c.proc, connect_info);
-            if (connect_status != STATUS_SUCCESS)
-            {
-                return connect_status;
-            }
-
-            if (!win32k_userconnect::try_write_wow64_userconnect(c.emu, connect_destination, connect_info))
+            if (!win32k_userconnect::try_write_user_shared_info(c.emu, connect_destination, c.proc))
             {
                 return STATUS_INVALID_PARAMETER;
             }
@@ -1718,7 +1711,7 @@ namespace sogen
 
             if (user_shared_info_ptr != 0)
             {
-                if (!win32k_userconnect::try_write_wow64_userconnect(c.emu, user_shared_info_ptr, connect_info))
+                if (!win32k_userconnect::try_write_user_shared_info(c.emu, user_shared_info_ptr, c.proc))
                 {
                     return STATUS_INVALID_PARAMETER;
                 }

--- a/src/windows-emulator/win32k_userconnect.cpp
+++ b/src/windows-emulator/win32k_userconnect.cpp
@@ -181,17 +181,17 @@ namespace sogen
                 return STATUS_INVALID_PARAMETER;
             }
 
-            if (user_connect_length < sizeof(WIN32K_USERCONNECT32))
+            if (user_connect_length < sizeof(USER_SHAREDINFO))
             {
                 return STATUS_BUFFER_TOO_SMALL;
             }
 
             uint64_t offset = 0;
-            if (user_connect_length == sizeof(WIN32K_USERCONNECT32))
+            if (user_connect_length == sizeof(USER_SHAREDINFO))
             {
                 offset = 0;
             }
-            else if (user_connect_length == (sizeof(WIN32K_USERCONNECT32) + k_wow64_userconnect_header_size))
+            else if (user_connect_length == (sizeof(USER_SHAREDINFO) + k_wow64_userconnect_header_size))
             {
                 offset = k_wow64_userconnect_header_size;
             }
@@ -207,65 +207,6 @@ namespace sogen
             }
 
             return narrow_wow64_address(destination64, destination);
-        }
-
-        NTSTATUS build_wow64_userconnect(const process_context& process, WIN32K_USERCONNECT32& connect)
-        {
-            connect = {};
-
-            uint32_t psi{};
-            uint32_t disp_info{};
-            uint32_t ahe_list{};
-            uint32_t monitor_info{};
-
-            auto status = narrow_wow64_address(process.user_handles.get_server_info().value(), psi);
-            if (status != STATUS_SUCCESS)
-            {
-                return status;
-            }
-
-            status = narrow_wow64_address(process.user_handles.get_display_info().value(), disp_info);
-            if (status != STATUS_SUCCESS)
-            {
-                return status;
-            }
-
-            status = narrow_wow64_address(process.user_handles.get_handle_table().value(), ahe_list);
-            if (status != STATUS_SUCCESS)
-            {
-                return status;
-            }
-
-            status = narrow_wow64_address(process.user_handles.get_display_info().value(), monitor_info);
-            if (status != STATUS_SUCCESS)
-            {
-                return status;
-            }
-
-            connect.psi = psi;
-            connect.ahe_list = ahe_list;
-            connect.he_entry_size = sizeof(USER_HANDLEENTRY);
-            connect.disp_info_low = disp_info;
-            connect.monitor_info_low = monitor_info;
-            std::ranges::fill(connect.wndmsg_table, uint8_t{0xFF});
-            connect.wndmsg_count = k_wow64_wndmsg_count;
-            connect.ime_msg_count = k_wow64_ime_msg_count;
-
-            return STATUS_SUCCESS;
-        }
-
-        bool try_write_wow64_userconnect(memory_interface& memory, const uint64_t destination, const WIN32K_USERCONNECT32& connect)
-        {
-            try
-            {
-                const emulator_object<WIN32K_USERCONNECT32> connect_obj{memory, destination};
-                connect_obj.write(connect);
-                return true;
-            }
-            catch (...)
-            {
-                return false;
-            }
         }
 
         void populate_user_shared_info(USER_SHAREDINFO& shared, const process_context& process)

--- a/src/windows-emulator/win32k_userconnect.hpp
+++ b/src/windows-emulator/win32k_userconnect.hpp
@@ -13,15 +13,11 @@ namespace sogen
     namespace win32k_userconnect
     {
         constexpr uint32_t k_user_server_dll_index = 3;
-        constexpr ULONG k_wow64_wndmsg_count = 0x63F;
-        constexpr ULONG k_wow64_ime_msg_count = 0x2000;
         constexpr ULONG k_wow64_userconnect_header_size = 0x8;
         constexpr ULONG k_wow64_userconnect_reply_shared_info_offset = sizeof(uint64_t);
 
         NTSTATUS narrow_wow64_address(uint64_t address, uint32_t& narrowed);
         NTSTATUS resolve_wow64_destination(uint64_t user_connect_ptr, uint64_t user_connect_length, uint32_t& destination);
-        NTSTATUS build_wow64_userconnect(const process_context& process, WIN32K_USERCONNECT32& connect);
-        bool try_write_wow64_userconnect(memory_interface& memory, uint64_t destination, const WIN32K_USERCONNECT32& connect);
         void populate_user_shared_info(USER_SHAREDINFO& shared, const process_context& process);
         bool try_write_user_shared_info(memory_interface& memory, uint64_t destination, const process_context& process);
         bool try_write_api_port_userconnect_reply(memory_interface& memory, uint64_t reply_base, const process_context& process);


### PR DESCRIPTION
## Problem

A 32-bit (WoW64) guest that creates a window and calls `DefWindowProcA(hwnd, WM_NULL, 0, 0)` faults inside user32 on the first call. Since a typical message loop pumps `WM_NULL`, this hits any 32-bit GUI app that gets as far as a window.

Root cause: the 32-bit `user32!UserClientDllInitialize` raw-copies the 0x238-byte user-connect reply verbatim into `_gSharedInfo` and reads it with the same 8-byte-slotted `SHAREDINFO` layout the 64-bit client uses. Sogen's two WoW64 writers of that reply — the CSRSS ApiPort user-connect reply in `ports/api_port.cpp` and `NtUserProcessConnect` in `syscalls/user.cpp` — both filled a separate, hand-built `WIN32K_USERCONNECT32` struct whose `wndmsg_count`/`wndmsg_table` fields sat in the wrong slots. `SHAREDINFO.DefWindowMsgs` (0x218) and `.DefWindowSpecMsgs` (0x228) therefore stayed null in the 32-bit client, and user32 dereferenced them on the first `DefWindowProc`.

## Fix

- Route both WoW64 writers through the existing `win32k_userconnect::try_write_user_shared_info` / `populate_user_shared_info`, i.e. the same code the native 64-bit connect already uses. WoW64 user32 expects the 64-bit-slotted struct, so no narrowing layer is needed.
- Delete `WIN32K_USERCONNECT32`, its `static_assert`s, `build_wow64_userconnect`, `try_write_wow64_userconnect`, and the now-unused `k_wow64_wndmsg_count` / `k_wow64_ime_msg_count` constants. The `NtUserProcessConnect` writer was a second, independently maintained copy of the same wrong layout; it now shares the one path.
- Add `static_assert(sizeof(USER_SHAREDINFO) == 0x238)` so the reply size user32 copies is pinned in the type itself (the length checks in `api_port.cpp` and `resolve_wow64_destination` now key off `sizeof(USER_SHAREDINFO)`).
- Update `docs/windows-ui-emulation.md`: the section "Fix concept is validated; the clean location is NOT yet found" described this exact investigation as open, with `WIN32K_USERCONNECT32` named as a suspect and a proposed watchpoint-based next step. It is rewritten as resolved (the four globals are `SHAREDINFO.DefWindowMsgs`/`DefWindowSpecMsgs`), and the breadcrumb about the WoW64 path having "no working equivalent" of the message-bit tables is corrected.

Net: +38 / -146 lines across 6 files. No behaviour change for 64-bit guests — `populate_user_shared_info` itself is untouched.

## Reproduction / verification

Minimal 32-bit repro (`i686-w64-mingw32-g++ -static`): `RegisterClassA` + `CreateWindowExA`, then `DefWindowProcA(hwnd, WM_NULL, 0, 0)`, print the result, exit 0 iff it returned 0. Run with `analyzer -s --backend unicorn -e <root> c:/wm-null-repro-x86.exe` (FEX has no WoW64 support, so unicorn is the only applicable backend here).

Before (this branch's five source files swapped to their `origin/main` versions, rebuilt):
```
calling DefWindowProcA(WM_NULL)
Null-pointer call to 0x0; caller return address 0x0 (?+0x0)
analyzer exit code 1.
```

After (this commit, `1e11a8da`):
```
calling DefWindowProcA(WM_NULL)
DefWindowProcA(WM_NULL) returned 0
analyzer exit code 0.
```

`windows-emulator-test` with `EMULATOR_ROOT` set: 50/50 pass on this commit (release preset, macOS arm64 host).